### PR TITLE
feat: 최소 녹음 시간 미달 시 자동 업로드 스킵

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -387,11 +387,16 @@ async function processAutoMode(audioPath, recordingTitle) {
   }, 5000);
 }
 
-async function handleRecordingStopped(audioPath) {
+async function handleRecordingStopped(audioPath, skipAutoUpload = false) {
   resetRecordingUI();
   const recordingTitle = meetingTitle.value.trim() || 'Untitled_Meeting';
   meetingTitle.value = '';
   await refreshRecordingsList();
+  if (skipAutoUpload) {
+    showToast('Recording too short — auto-upload skipped');
+    console.log('Skipping auto-upload: recording below minimum duration');
+    return;
+  }
   await processAutoMode(audioPath, recordingTitle);
 }
 
@@ -399,7 +404,7 @@ async function stopRecording() {
   try {
     const result = await window.electronAPI.stopRecording();
     if (result.success) {
-      await handleRecordingStopped(result.filePath);
+      await handleRecordingStopped(result.filePath, result.skipAutoUpload);
     }
   } catch (error) {
     alert('Failed to stop recording: ' + error.message);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ function usage(): never {
   process.exit(1);
 }
 
-const KNOWN_CONFIG_KEYS = ['geminiApiKey', 'geminiModel', 'geminiFlashModel', 'notionApiKey', 'notionDatabaseId', 'autoMode', 'globalShortcut'] as const;
+const KNOWN_CONFIG_KEYS = ['geminiApiKey', 'geminiModel', 'geminiFlashModel', 'notionApiKey', 'notionDatabaseId', 'autoMode', 'globalShortcut', 'minRecordingSeconds'] as const;
 type ConfigKey = typeof KNOWN_CONFIG_KEYS[number];
 
 function maskValue(key: string, value: string | undefined): string {
@@ -110,6 +110,14 @@ function handleConfig(subArgs: string[]): void {
         config.setAutoMode(v === 'true');
       },
       globalShortcut: (v) => config.setGlobalShortcut(v),
+      minRecordingSeconds: (v) => {
+        const n = parseInt(v, 10);
+        if (isNaN(n) || n < 0) {
+          process.stderr.write('Error: minRecordingSeconds must be a non-negative integer\n');
+          process.exit(1);
+        }
+        config.setMinRecordingSeconds(n);
+      },
     };
     setters[key](value);
     process.stderr.write(`Set ${key}\n`);

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -15,6 +15,7 @@ export interface AppConfig {
   summaryPrompt?: string;
   maxRecordingMinutes?: number;
   recordingReminderMinutes?: number;
+  minRecordingSeconds?: number;
 }
 
 export const DEFAULT_SUMMARY_PROMPT = `Based on this meeting transcript, provide:
@@ -193,6 +194,15 @@ export class ConfigService {
     this.saveConfig();
   }
 
+  getMinRecordingSeconds(): number {
+    return this.config.minRecordingSeconds ?? 60;
+  }
+
+  setMinRecordingSeconds(seconds: number): void {
+    this.config.minRecordingSeconds = Math.max(0, Math.floor(seconds));
+    this.saveConfig();
+  }
+
   getSummaryPrompt(): string {
     return this.config.summaryPrompt || DEFAULT_SUMMARY_PROMPT;
   }
@@ -225,7 +235,8 @@ export class ConfigService {
       knownWords: this.getKnownWords(),
       summaryPrompt: this.getSummaryPrompt(),
       maxRecordingMinutes: this.getMaxRecordingMinutes(),
-      recordingReminderMinutes: this.getRecordingReminderMinutes()
+      recordingReminderMinutes: this.getRecordingReminderMinutes(),
+      minRecordingSeconds: this.getMinRecordingSeconds()
     };
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ const fileHandlerService = new FileHandlerService();
 const meetingDetector = new MeetingDetectorService();
 const displayDetector = new DisplayDetectorService();
 let meetingAutoStartedRecording = false;
+let recordingStartedAt: number | null = null;
 let geminiService: GeminiService | null = null;
 let notionService: NotionService | null = null;
 let recordingMaxTimer: NodeJS.Timeout | null = null;
@@ -389,6 +390,7 @@ ipcMain.handle('start-recording', async (_, meetingTitle: string) => {
     const result = await audioRecorder.startRecording(meetingTitle);
     // Update menu bar icon state
     if (result.success) {
+      recordingStartedAt = Date.now();
       menuBarManager.updateRecordingState(true, meetingTitle);
 
       // Set up recording limit timer
@@ -440,6 +442,10 @@ ipcMain.handle('stop-recording', async () => {
     clearRecordingTimers();
     const result = await audioRecorder.stopRecording();
 
+    // Calculate recording duration
+    const durationSeconds = recordingStartedAt ? Math.round((Date.now() - recordingStartedAt) / 1000) : 0;
+    recordingStartedAt = null;
+
     // Update menu bar icon state
     menuBarManager.updateRecordingState(false);
     meetingAutoStartedRecording = false;
@@ -447,7 +453,14 @@ ipcMain.handle('stop-recording', async () => {
       notificationService.notifyRecordingStopped();
     }
 
-    return result;
+    // Check minimum recording duration for auto-upload
+    const minSeconds = configService.getMinRecordingSeconds();
+    const skipAutoUpload = minSeconds > 0 && durationSeconds < minSeconds;
+    if (skipAutoUpload && result.success) {
+      console.log(`Recording too short (${durationSeconds}s < ${minSeconds}s minimum) — skipping auto-upload`);
+    }
+
+    return { ...result, durationSeconds, skipAutoUpload };
   } catch (error) {
     console.error('Error stopping recording:', error);
     return { success: false, error: error instanceof Error ? error.message : String(error) };


### PR DESCRIPTION
## Summary
설정된 최소 시간(기본 60초)보다 짧은 녹음은 자동 업로드/트랜스크립션을 스킵합니다.

## Changes (4 files, +35 lines)

### `configService.ts`
- `minRecordingSeconds` 설정 추가 (기본값: 60초)
- getter/setter 추가

### `main.ts`
- `recordingStartedAt` 타임스탬프로 녹음 시간 추적
- `stop-recording` 결과에 `durationSeconds`, `skipAutoUpload` 플래그 추가
- 최소 시간 미달 시 콘솔 로그 출력

### `renderer.js`
- `skipAutoUpload` 플래그 체크하여 `processAutoMode` 스킵
- 스킵 시 토스트 알림: "Recording too short — auto-upload skipped"

### `cli.ts`
- `minRecordingSeconds` config key 추가 (`listener config set minRecordingSeconds 90`)

## Usage
```bash
# 최소 90초로 변경
listener config set minRecordingSeconds 90

# 비활성화 (항상 업로드)
listener config set minRecordingSeconds 0
```

## Notes
- 수동 업로드(녹음 목록에서 직접 업로드)는 시간 제한 없이 항상 가능
- `tsc --noEmit` 타입체크 통과 ✅

Closes #71