### PR TITLE
Skip auto-upload for recordings below minimum duration

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,11 @@
           <input type="number" id="recordingReminderMinutes" min="0" max="1440" step="1" placeholder="0 = disabled">
         </div>
         <div class="form-group">
+          <label for="minRecordingSeconds">Minimum Recording Duration (seconds)</label>
+          <input type="number" id="minRecordingSeconds" min="0" max="3600" step="1" placeholder="0 = disabled">
+          <small>Auto mode will skip transcription/upload for recordings shorter than this (0 disables)</small>
+        </div>
+        <div class="form-group">
           <label for="knownWords">Known Words:</label>
           <textarea id="knownWords" rows="4" placeholder="Enter words or phrases, one per line&#10;e.g. Listener.AI&#10;GPT-4o"></textarea>
           <small>Proper nouns, names, and terms to improve transcription accuracy (one per line)</small>

--- a/renderer.js
+++ b/renderer.js
@@ -323,12 +323,14 @@ async function processAutoMode(audioPath, recordingTitle, durationMs) {
   const config = await window.electronAPI.getConfig();
   const minSeconds = Number(config.minRecordingSeconds) || 0;
   if (minSeconds > 0 && typeof durationMs === 'number' && durationMs < minSeconds * 1000) {
-    const actualSeconds = Math.round(durationMs / 1000);
+    const actualSeconds = Math.floor(durationMs / 1000);
     const message = `Auto mode: Skipped (${actualSeconds}s < ${minSeconds}s minimum)`;
     console.log(message);
     statusText.textContent = message;
     setTimeout(() => {
-      statusText.textContent = 'Ready to record';
+      if (!isRecording && statusText.textContent === message) {
+        statusText.textContent = 'Ready to record';
+      }
     }, 5000);
     return;
   }

--- a/renderer.js
+++ b/renderer.js
@@ -317,8 +317,21 @@ function resetRecordingUI() {
   recordingTime.classList.remove('active');
 }
 
-async function processAutoMode(audioPath, recordingTitle) {
+async function processAutoMode(audioPath, recordingTitle, durationMs) {
   if (!autoModeToggle.checked || !audioPath) return;
+
+  const config = await window.electronAPI.getConfig();
+  const minSeconds = Number(config.minRecordingSeconds) || 0;
+  if (minSeconds > 0 && typeof durationMs === 'number' && durationMs < minSeconds * 1000) {
+    const actualSeconds = Math.round(durationMs / 1000);
+    const message = `Auto mode: Skipped (${actualSeconds}s < ${minSeconds}s minimum)`;
+    console.log(message);
+    statusText.textContent = message;
+    setTimeout(() => {
+      statusText.textContent = 'Ready to record';
+    }, 5000);
+    return;
+  }
 
   isAutoModeProcessing = true;
   recordButton.disabled = true;
@@ -339,8 +352,7 @@ async function processAutoMode(audioPath, recordingTitle) {
         console.log('Auto mode: File renamed to:', finalAudioPath);
       }
 
-      const notionConfig = await window.electronAPI.getConfig();
-      if (notionConfig.notionApiKey && notionConfig.notionDatabaseId) {
+      if (config.notionApiKey && config.notionDatabaseId) {
         console.log('Auto mode: Uploading to Notion...');
 
         const finalTitle = (recordingTitle === '' || recordingTitle === 'Untitled_Meeting') && transcriptionResult.data.suggestedTitle
@@ -387,19 +399,19 @@ async function processAutoMode(audioPath, recordingTitle) {
   }, 5000);
 }
 
-async function handleRecordingStopped(audioPath) {
+async function handleRecordingStopped(audioPath, durationMs) {
   resetRecordingUI();
   const recordingTitle = meetingTitle.value.trim() || 'Untitled_Meeting';
   meetingTitle.value = '';
   await refreshRecordingsList();
-  await processAutoMode(audioPath, recordingTitle);
+  await processAutoMode(audioPath, recordingTitle, durationMs);
 }
 
 async function stopRecording() {
   try {
     const result = await window.electronAPI.stopRecording();
     if (result.success) {
-      await handleRecordingStopped(result.filePath);
+      await handleRecordingStopped(result.filePath, result.durationMs);
     }
   } catch (error) {
     alert('Failed to stop recording: ' + error.message);
@@ -432,7 +444,7 @@ window.electronAPI.onRecordingStatus((status) => {
 if (window.electronAPI.onRecordingAutoStopped) {
   window.electronAPI.onRecordingAutoStopped(async (data) => {
     showToast('Recording auto-stopped - reached time limit');
-    await handleRecordingStopped(data?.filePath);
+    await handleRecordingStopped(data?.filePath, data?.durationMs);
   });
 }
 
@@ -459,6 +471,8 @@ function setupEventListeners() {
     const maxRecordingMinutes = Math.max(0, Math.floor(parseInt(maxRecordingMinutesEl?.value) || 0));
     const recordingReminderMinutesEl = document.getElementById('recordingReminderMinutes');
     const recordingReminderMinutes = Math.max(0, Math.floor(parseInt(recordingReminderMinutesEl?.value) || 0));
+    const minRecordingSecondsEl = document.getElementById('minRecordingSeconds');
+    const minRecordingSeconds = Math.max(0, Math.floor(parseInt(minRecordingSecondsEl?.value) || 0));
 
     if (geminiKey) {
       await window.electronAPI.saveConfig({
@@ -471,7 +485,8 @@ function setupEventListeners() {
         knownWords: knownWords,
         summaryPrompt: summaryPrompt || DEFAULT_SUMMARY_PROMPT,
         maxRecordingMinutes: maxRecordingMinutes,
-        recordingReminderMinutes: recordingReminderMinutes
+        recordingReminderMinutes: recordingReminderMinutes,
+        minRecordingSeconds: minRecordingSeconds
       });
       configModal.style.display = 'none';
     } else {
@@ -948,6 +963,10 @@ async function showConfigModal() {
   const recordingReminderMinutesInput = document.getElementById('recordingReminderMinutes');
   if (recordingReminderMinutesInput) {
     recordingReminderMinutesInput.value = config.recordingReminderMinutes || '';
+  }
+  const minRecordingSecondsInput = document.getElementById('minRecordingSeconds');
+  if (minRecordingSecondsInput) {
+    minRecordingSecondsInput.value = config.minRecordingSeconds || '';
   }
 
   // Pre-fill summary prompt

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ function usage(): never {
   process.exit(1);
 }
 
-const KNOWN_CONFIG_KEYS = ['geminiApiKey', 'geminiModel', 'geminiFlashModel', 'notionApiKey', 'notionDatabaseId', 'autoMode', 'globalShortcut'] as const;
+const KNOWN_CONFIG_KEYS = ['geminiApiKey', 'geminiModel', 'geminiFlashModel', 'notionApiKey', 'notionDatabaseId', 'autoMode', 'globalShortcut', 'minRecordingSeconds'] as const;
 type ConfigKey = typeof KNOWN_CONFIG_KEYS[number];
 
 function maskValue(key: string, value: string | undefined): string {
@@ -110,6 +110,14 @@ function handleConfig(subArgs: string[]): void {
         config.setAutoMode(v === 'true');
       },
       globalShortcut: (v) => config.setGlobalShortcut(v),
+      minRecordingSeconds: (v) => {
+        const n = parseInt(v, 10);
+        if (isNaN(n) || n < 0 || String(n) !== v.trim()) {
+          process.stderr.write('Error: minRecordingSeconds must be a non-negative integer (0 disables)\n');
+          process.exit(1);
+        }
+        config.setMinRecordingSeconds(n);
+      },
     };
     setters[key](value);
     process.stderr.write(`Set ${key}\n`);

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -15,6 +15,7 @@ export interface AppConfig {
   summaryPrompt?: string;
   maxRecordingMinutes?: number;
   recordingReminderMinutes?: number;
+  minRecordingSeconds?: number;
 }
 
 export const DEFAULT_SUMMARY_PROMPT = `Based on this meeting transcript, provide:
@@ -193,6 +194,15 @@ export class ConfigService {
     this.saveConfig();
   }
 
+  getMinRecordingSeconds(): number {
+    return this.config.minRecordingSeconds || 0;
+  }
+
+  setMinRecordingSeconds(seconds: number): void {
+    this.config.minRecordingSeconds = Math.max(0, Math.floor(seconds));
+    this.saveConfig();
+  }
+
   getSummaryPrompt(): string {
     return this.config.summaryPrompt || DEFAULT_SUMMARY_PROMPT;
   }
@@ -225,7 +235,8 @@ export class ConfigService {
       knownWords: this.getKnownWords(),
       summaryPrompt: this.getSummaryPrompt(),
       maxRecordingMinutes: this.getMaxRecordingMinutes(),
-      recordingReminderMinutes: this.getRecordingReminderMinutes()
+      recordingReminderMinutes: this.getRecordingReminderMinutes(),
+      minRecordingSeconds: this.getMinRecordingSeconds()
     };
   }
 }

--- a/src/simpleAudioRecorder.ts
+++ b/src/simpleAudioRecorder.ts
@@ -16,6 +16,7 @@ async function findFFmpegBinary(): Promise<string | null> {
 export class SimpleAudioRecorder {
   private recordingProcess: ChildProcess | null = null;
   private outputPath: string | null = null;
+  private startTime: number | null = null;
 
   constructor() {
     // Create recordings directory if it doesn't exist
@@ -169,7 +170,8 @@ export class SimpleAudioRecorder {
       ];
 
       console.log('Starting recording...');
-      
+
+      this.startTime = Date.now();
       this.recordingProcess = spawn(ffmpegPath, args);
       
       // Track if process started successfully
@@ -225,12 +227,14 @@ export class SimpleAudioRecorder {
       // Check if there was a startup error
       if (startupError) {
         this.recordingProcess = null;
+        this.startTime = null;
         return { success: false, error: startupError };
       }
-      
+
       // Check if process is still running
       if (this.recordingProcess.killed || this.recordingProcess.exitCode !== null) {
         this.recordingProcess = null;
+        this.startTime = null;
         return { success: false, error: 'FFmpeg process terminated unexpectedly' };
       }
 
@@ -245,32 +249,35 @@ export class SimpleAudioRecorder {
     return this.recordingProcess !== null;
   }
 
-  async stopRecording(): Promise<{ success: boolean; filePath?: string; error?: string }> {
+  async stopRecording(): Promise<{ success: boolean; filePath?: string; durationMs?: number; error?: string }> {
     try {
       if (this.recordingProcess) {
+        const durationMs = this.startTime !== null ? Date.now() - this.startTime : undefined;
+
         // Send 'q' to gracefully stop ffmpeg
         this.recordingProcess.stdin?.write('q');
-        
+
         // Wait for process to finish
         await new Promise<void>((resolve) => {
           this.recordingProcess?.on('close', () => {
             resolve();
           });
-          
+
           // Fallback: force kill after 2 seconds
           setTimeout(() => {
             this.recordingProcess?.kill('SIGTERM');
             resolve();
           }, 2000);
         });
-        
+
         this.recordingProcess = null;
-        
+        this.startTime = null;
+
         // Check if file exists
         if (this.outputPath && fs.existsSync(this.outputPath)) {
           const stats = fs.statSync(this.outputPath);
-          console.log(`Recording saved: ${this.outputPath} (${stats.size} bytes)`);
-          return { success: true, filePath: this.outputPath };
+          console.log(`Recording saved: ${this.outputPath} (${stats.size} bytes, ${durationMs}ms)`);
+          return { success: true, filePath: this.outputPath, durationMs };
         } else {
           return { success: false, error: 'Recording file not found' };
         }


### PR DESCRIPTION
## Summary

Closes #71. Adds `minRecordingSeconds` config (default `0` = disabled). When set, auto mode silently skips transcription/upload if the recording is shorter than the threshold; manual upload is unaffected.

## Design decisions (deviating from the issue proposal)

- **Default `0` (disabled)** instead of `60` — matches the existing "0 disables" convention of `maxRecordingMinutes` and `recordingReminderMinutes`, keeps behavior unchanged for existing users.
- **Key name `minRecordingSeconds`** (not `minDuration`) — units-in-name matches the rest of the config surface.
- **No system notification** on skip. Background Recording Policy favors quiet operation; `statusText` + `console.log` is enough signal, and reinstating a modal per short recording gets annoying fast.
- **Applies only to live recordings**, not imported files (drag-drop). Imports are intentional user actions.

## Implementation

- `SimpleAudioRecorder` tracks `startTime` and returns `durationMs` from `stopRecording`; `startTime` is cleared on failure paths.
- `processAutoMode` gates on `config.minRecordingSeconds` before calling `transcribeAudio`. Both stop paths (UI button, max-timer auto-stop) forward `durationMs` through `handleRecordingStopped`.
- CLI: `KNOWN_CONFIG_KEYS` gets the new key with a strict integer validator (rejects `NaN`, negatives, non-integer strings).
- Settings modal: new `form-group` with `placeholder="0 = disabled"`, wired into save/load.

## Test plan

- [x] `pnpm run build` clean
- [x] CLI validation: `listener config set minRecordingSeconds abc` rejects; `-5` rejects; `90` accepts; `0` accepts (disables)
- [x] CLI `config get`/`list` shows the key
- [ ] Record < threshold with auto mode on → status shows `"Auto mode: Skipped (Xs < Ys minimum)"`, no transcription call fired
- [ ] Record ≥ threshold → normal auto-upload proceeds
- [ ] Record any length with `minRecordingSeconds=0` → normal auto-upload (feature off)
- [ ] Manual "Upload to Notion" on a short recording still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)