### PR TITLE
Automate release notes with AI and browse history in-app

### DIFF
--- a/.github/scripts/generate_release_notes.py
+++ b/.github/scripts/generate_release_notes.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "openai>=1.55",
+# ]
+# ///
+"""Generate Korean markdown release notes from a git commit range via OpenAI.
+
+Env:
+  CUR              required — current tag (e.g., v1.6.3)
+  PREV             optional — previous tag; if empty, full history is used
+  OPENAI_API_KEY   required for AI summary; without it the commit list is returned
+  OPENAI_MODEL     optional — default: gpt-5.4
+  SYSTEM_PROMPT    optional — override default desktop/Korean prompt
+
+Stdout: markdown. Never exits non-zero for AI failure — always emits a usable
+fallback so release creation isn't blocked by an OpenAI outage.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from openai import OpenAI, OpenAIError
+
+DEFAULT_SYSTEM_PROMPT = (
+    "Generate bilingual release notes for the Electron desktop app (Listener.AI). "
+    "Output markdown only — no preamble, no trailing explanation. "
+    "Structure: English block first, then Korean block, separated by a horizontal rule. "
+    "English block — header '## English' followed by sections "
+    "'### New Features', '### Improvements', '### Bug Fixes', '### Internal Changes'. "
+    "Korean block — header '## 한국어' followed by sections "
+    "'### 신규 기능', '### 개선', '### 버그 수정', '### 내부 변경'. "
+    "Omit empty sections in each block. "
+    "Rewrite each commit as a user-facing bullet (not verbatim). "
+    "The two blocks must describe the same changes — Korean is a translation of the English content, "
+    "not independent notes."
+)
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def git_commit_list(prev: str | None, cur: str) -> str:
+    ref = f"{prev}..{cur}" if prev else cur
+    result = subprocess.run(
+        ["git", "log", "--pretty=format:- %s", ref],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def fallback(commits: str) -> str:
+    return f"## 변경사항\n\n{commits}\n"
+
+
+def generate_ai_notes(
+    *,
+    api_key: str,
+    model: str,
+    system_prompt: str,
+    version: str,
+    commits: str,
+) -> str | None:
+    try:
+        client = OpenAI(api_key=api_key, timeout=60.0, max_retries=2)
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {
+                    "role": "user",
+                    "content": f"버전: {version}\n\n커밋 목록:\n{commits}",
+                },
+            ],
+        )
+        content = (resp.choices[0].message.content or "").strip()
+        return content or None
+    except OpenAIError as e:
+        log(f"::warning::OpenAI request failed: {e}")
+        return None
+
+
+def main() -> int:
+    cur = os.environ.get("CUR")
+    if not cur:
+        log("::error::CUR (current tag) env var is required")
+        return 2
+
+    prev = os.environ.get("PREV") or None
+    api_key = os.environ.get("OPENAI_API_KEY")
+    model = os.environ.get("OPENAI_MODEL", "gpt-5.4")
+    system_prompt = os.environ.get("SYSTEM_PROMPT") or DEFAULT_SYSTEM_PROMPT
+
+    commits = git_commit_list(prev, cur)
+
+    if not api_key:
+        log("::warning::OPENAI_API_KEY not set, using commit list fallback")
+        sys.stdout.write(fallback(commits))
+        return 0
+
+    notes = generate_ai_notes(
+        api_key=api_key,
+        model=model,
+        system_prompt=system_prompt,
+        version=cur,
+        commits=commits,
+    )
+    if notes is None:
+        log("::warning::AI notes generation failed, using commit list fallback")
+        sys.stdout.write(fallback(commits))
+        return 0
+
+    sys.stdout.write(notes)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/generate_release_notes.py
+++ b/.github/scripts/generate_release_notes.py
@@ -5,17 +5,17 @@
 #     "openai>=1.55",
 # ]
 # ///
-"""Generate Korean markdown release notes from a git commit range via OpenAI.
+"""Generate bilingual markdown release notes from a git commit range via OpenAI.
 
 Env:
   CUR              required — current tag (e.g., v1.6.3)
   PREV             optional — previous tag; if empty, full history is used
   OPENAI_API_KEY   required for AI summary; without it the commit list is returned
-  OPENAI_MODEL     optional — default: gpt-5.4
-  SYSTEM_PROMPT    optional — override default desktop/Korean prompt
+  OPENAI_MODEL     optional — default: gpt-4o-mini
+  SYSTEM_PROMPT    optional — override default bilingual prompt
 
-Stdout: markdown. Never exits non-zero for AI failure — always emits a usable
-fallback so release creation isn't blocked by an OpenAI outage.
+Stdout: markdown. Never exits non-zero for any failure — always emits a usable
+fallback so release creation isn't blocked by an OpenAI outage or a bad git range.
 """
 from __future__ import annotations
 
@@ -46,13 +46,17 @@ def log(msg: str) -> None:
 
 def git_commit_list(prev: str | None, cur: str) -> str:
     ref = f"{prev}..{cur}" if prev else cur
-    result = subprocess.run(
-        ["git", "log", "--pretty=format:- %s", ref],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return result.stdout.strip()
+    try:
+        result = subprocess.run(
+            ["git", "log", "--pretty=format:- %s", ref],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        log(f"::warning::git log {ref} failed: {e.stderr.strip() or e}")
+        return ""
 
 
 def fallback(commits: str) -> str:
@@ -94,7 +98,7 @@ def main() -> int:
 
     prev = os.environ.get("PREV") or None
     api_key = os.environ.get("OPENAI_API_KEY")
-    model = os.environ.get("OPENAI_MODEL", "gpt-5.4")
+    model = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
     system_prompt = os.environ.get("SYSTEM_PROMPT") or DEFAULT_SYSTEM_PROMPT
 
     commits = git_commit_list(prev, cur)

--- a/.github/scripts/generate_release_notes.py
+++ b/.github/scripts/generate_release_notes.py
@@ -11,7 +11,7 @@ Env:
   CUR              required — current tag (e.g., v1.6.3)
   PREV             optional — previous tag; if empty, full history is used
   OPENAI_API_KEY   required for AI summary; without it the commit list is returned
-  OPENAI_MODEL     optional — default: gpt-4o-mini
+  OPENAI_MODEL     optional — default: gpt-5.4
   SYSTEM_PROMPT    optional — override default bilingual prompt
 
 Stdout: markdown. Never exits non-zero for any failure — always emits a usable
@@ -98,7 +98,7 @@ def main() -> int:
 
     prev = os.environ.get("PREV") or None
     api_key = os.environ.get("OPENAI_API_KEY")
-    model = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+    model = os.environ.get("OPENAI_MODEL", "gpt-5.4")
     system_prompt = os.environ.get("SYSTEM_PROMPT") or DEFAULT_SYSTEM_PROMPT
 
     commits = git_commit_list(prev, cur)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,6 @@ jobs:
         id: ai_notes
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: gpt-5.4
           PREV: ${{ steps.prev_tag.outputs.tag }}
           CUR: HEAD
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,11 +156,37 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           path: release-artifacts
+
+      - name: Find previous tag
+        id: prev_tag
+        run: |
+          PREV=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || echo "")
+          echo "tag=$PREV" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${PREV:-<none>}"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Generate AI release notes
+        id: ai_notes
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: gpt-5.4
+          PREV: ${{ steps.prev_tag.outputs.tag }}
+          CUR: HEAD
+        run: |
+          NOTES=$(uv run .github/scripts/generate_release_notes.py)
+          {
+            echo "notes<<NOTES_EOF"
+            echo "$NOTES"
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create Release
         uses: ncipollo/release-action@v1
@@ -168,37 +194,17 @@ jobs:
           tag: v${{ needs.prepare.outputs.version }}
           name: Release v${{ needs.prepare.outputs.version }}
           body: |
-            ## Release v${{ needs.prepare.outputs.version }}
+            ### Downloads
+            - macOS (Intel): `Listener.AI-${{ needs.prepare.outputs.version }}-x64.dmg`
+            - macOS (Apple Silicon): `Listener.AI-${{ needs.prepare.outputs.version }}-arm64.dmg`
+            - Windows: `Listener.AI-Setup-${{ needs.prepare.outputs.version }}.exe`
+            - CLI: `npx listener-ai <audio-file>`
 
-            ### macOS Downloads
-            - Intel: `Listener.AI-${{ needs.prepare.outputs.version }}-x64.dmg`
-            - Apple Silicon: `Listener.AI-${{ needs.prepare.outputs.version }}-arm64.dmg`
+            Installation: see the [README](https://github.com/asleep-ai/listener-ai#installation).
 
-            ### Windows Downloads
-            - x64: `Listener.AI-Setup-${{ needs.prepare.outputs.version }}.exe`
+            ---
 
-            ### Installation
-
-            #### macOS
-            1. Download the appropriate DMG for your Mac (x64 for Intel, arm64 for Apple Silicon)
-            2. Open the DMG and drag Listener.AI to Applications
-            3. Open the app - it's fully signed and notarized!
-            4. FFmpeg will be automatically downloaded on first use
-
-            #### Windows
-            1. Download and run the installer
-            2. Follow the installation wizard
-            3. FFmpeg will be automatically downloaded on first use
-
-            ### CLI (npm)
-            ```
-            npx listener-ai <audio-file>
-            ```
-
-            ### First Run
-            1. Enter your Google Gemini API key
-            2. Enter your Notion API key and database ID
-            3. Start recording!
+            ${{ steps.ai_notes.outputs.notes }}
           draft: false
           artifacts: |
             release-artifacts/mac-build/*.dmg

--- a/index.html
+++ b/index.html
@@ -199,6 +199,34 @@
     </div>
   </div>
 
+  <!-- Release History (browse all past releases) -->
+  <div id="releaseHistoryModal" class="modal" style="display: none;">
+    <div class="modal-content release-history-content">
+      <span class="close" id="releaseHistoryClose">&times;</span>
+      <h2>Release History</h2>
+      <div id="releaseHistoryList" class="release-history-list">
+        <p class="loading">Loading releases...</p>
+      </div>
+      <div class="modal-buttons">
+        <button id="releaseHistoryOpenGithub" class="cancel-button">View all on GitHub</button>
+        <button id="releaseHistoryDismiss" class="save-button">Close</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- What's New (release notes after update) -->
+  <div id="releaseNotesModal" class="modal" style="display: none;">
+    <div class="modal-content">
+      <span class="close" id="releaseNotesClose">&times;</span>
+      <h2 id="releaseNotesTitle">What's New</h2>
+      <div id="releaseNotesBody" class="release-notes-body"></div>
+      <div class="modal-buttons">
+        <button id="releaseNotesOpenGithub" class="cancel-button">View on GitHub</button>
+        <button id="releaseNotesDismiss" class="save-button">Got it</button>
+      </div>
+    </div>
+  </div>
+
   <!-- FFmpeg Download Progress Overlay -->
   <div id="ffmpegDownloadOverlay" class="modal" style="display: none;">
     <div class="ffmpeg-download-card">

--- a/renderer.js
+++ b/renderer.js
@@ -51,6 +51,92 @@ window.electronAPI.onTranscriptionProgress((progress) => {
   }
 });
 
+// Listen for release notes after an update
+if (window.electronAPI.onShowReleaseNotes) {
+  window.electronAPI.onShowReleaseNotes((notes) => {
+    showReleaseNotes(notes);
+  });
+}
+
+// Listen for Help → Release Notes menu click
+if (window.electronAPI.onOpenReleaseHistory) {
+  window.electronAPI.onOpenReleaseHistory(() => {
+    openReleaseHistory();
+  });
+}
+
+async function openReleaseHistory() {
+  const modal = document.getElementById('releaseHistoryModal');
+  const list = document.getElementById('releaseHistoryList');
+  const closeBtn = document.getElementById('releaseHistoryClose');
+  const dismissBtn = document.getElementById('releaseHistoryDismiss');
+  const githubBtn = document.getElementById('releaseHistoryOpenGithub');
+  if (!modal || !list) return;
+
+  const hide = () => { modal.style.display = 'none'; };
+  if (closeBtn) closeBtn.onclick = hide;
+  if (dismissBtn) dismissBtn.onclick = hide;
+  if (githubBtn) {
+    githubBtn.onclick = () => {
+      window.electronAPI.openExternal('https://github.com/asleep-ai/listener-ai/releases');
+    };
+  }
+
+  list.innerHTML = '<p class="loading">Loading releases...</p>';
+  modal.style.display = 'block';
+
+  try {
+    const releases = await window.electronAPI.getAllReleases();
+    if (!releases || releases.length === 0) {
+      list.innerHTML = '<p class="loading">No releases found.</p>';
+      return;
+    }
+    list.innerHTML = releases.map((r) => {
+      const date = r.publishedAt ? new Date(r.publishedAt).toLocaleDateString() : '';
+      const prereleaseLabel = r.prerelease ? ' <span class="release-prerelease">pre-release</span>' : '';
+      const body = (r.body || '').trim() || '_No notes._';
+      return `
+        <details class="release-history-item">
+          <summary>
+            <span class="release-tag">${escapeHtml(r.name || r.tag)}</span>
+            <span class="release-date">${escapeHtml(date)}</span>${prereleaseLabel}
+          </summary>
+          <div class="release-notes-body">${renderMarkdown(body)}</div>
+        </details>
+      `;
+    }).join('');
+  } catch (error) {
+    console.error('Failed to load release history:', error);
+    list.innerHTML = '<p class="loading">Failed to load releases.</p>';
+  }
+}
+
+function showReleaseNotes(notes) {
+  const modal = document.getElementById('releaseNotesModal');
+  const title = document.getElementById('releaseNotesTitle');
+  const body = document.getElementById('releaseNotesBody');
+  const closeBtn = document.getElementById('releaseNotesClose');
+  const dismissBtn = document.getElementById('releaseNotesDismiss');
+  const githubBtn = document.getElementById('releaseNotesOpenGithub');
+  if (!modal || !title || !body) return;
+
+  title.textContent = `What's New in v${notes.version}`;
+  const md = (notes.body || '').trim() || '_No release notes available for this version._';
+  body.innerHTML = renderMarkdown(md);
+
+  const hide = () => { modal.style.display = 'none'; };
+  if (closeBtn) closeBtn.onclick = hide;
+  if (dismissBtn) dismissBtn.onclick = hide;
+  if (githubBtn) {
+    githubBtn.onclick = () => {
+      if (notes.url) window.electronAPI.openExternal(notes.url);
+      hide();
+    };
+  }
+
+  modal.style.display = 'block';
+}
+
 // Listen for auto-update events
 if (window.electronAPI.onUpdateStatus) {
   window.electronAPI.onUpdateStatus((updateInfo) => {

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -16,6 +16,7 @@ export interface AppConfig {
   maxRecordingMinutes?: number;
   recordingReminderMinutes?: number;
   minRecordingSeconds?: number;
+  lastSeenVersion?: string;
 }
 
 export const DEFAULT_SUMMARY_PROMPT = `Based on this meeting transcript, provide:
@@ -203,6 +204,15 @@ export class ConfigService {
     this.saveConfig();
   }
 
+  getLastSeenVersion(): string | undefined {
+    return this.config.lastSeenVersion;
+  }
+
+  setLastSeenVersion(version: string): void {
+    this.config.lastSeenVersion = version;
+    this.saveConfig();
+  }
+
   getSummaryPrompt(): string {
     return this.config.summaryPrompt || DEFAULT_SUMMARY_PROMPT;
   }
@@ -236,7 +246,8 @@ export class ConfigService {
       summaryPrompt: this.getSummaryPrompt(),
       maxRecordingMinutes: this.getMaxRecordingMinutes(),
       recordingReminderMinutes: this.getRecordingReminderMinutes(),
-      minRecordingSeconds: this.getMinRecordingSeconds()
+      minRecordingSeconds: this.getMinRecordingSeconds(),
+      lastSeenVersion: this.getLastSeenVersion()
     };
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,19 +104,25 @@ function compareSemver(a: string, b: string): number {
 }
 
 async function checkAndShowReleaseNotes() {
-  if (!app.isPackaged) return;
+  if (!app.isPackaged) {
+    console.log('Release notes check: skipped (not packaged, dev mode)');
+    return;
+  }
 
   const current = app.getVersion();
   const lastSeen = configService.getLastSeenVersion();
+  console.log(`Release notes check: current=${current} lastSeen=${lastSeen ?? '<none>'}`);
 
   // First-run (fresh install): record current version silently.
   if (!lastSeen) {
+    console.log('Release notes check: first-run, recording current version silently');
     configService.setLastSeenVersion(current);
     return;
   }
 
   // Same version or downgrade: bring lastSeen in sync but never show older notes.
   if (compareSemver(current, lastSeen) <= 0) {
+    console.log('Release notes check: not newer than lastSeen, skipping modal');
     if (lastSeen !== current) configService.setLastSeenVersion(current);
     return;
   }
@@ -124,14 +130,19 @@ async function checkAndShowReleaseNotes() {
   // Upgrade: only mark the version as seen once we've successfully handed the
   // notes to the renderer. If the fetch fails (offline, GitHub rate limits) or
   // the window is gone, retry on the next launch so the user doesn't miss them.
+  console.log(`Release notes check: upgrade detected (${lastSeen} -> ${current}), fetching notes`);
   const notes = await fetchReleaseNotes(current);
-  if (!notes || !mainWindow || mainWindow.isDestroyed()) return;
+  if (!notes || !mainWindow || mainWindow.isDestroyed()) {
+    console.log('Release notes check: fetch failed or window gone, will retry on next launch');
+    return;
+  }
 
   const payload = { version: current, body: notes.body, url: notes.url };
   const send = () => {
     if (!mainWindow || mainWindow.isDestroyed()) return;
     mainWindow.webContents.send('show-release-notes', payload);
     configService.setLastSeenVersion(current);
+    console.log(`Release notes check: modal delivered for ${current}, lastSeenVersion updated`);
   };
   if (mainWindow.webContents.isLoading()) {
     mainWindow.webContents.once('did-finish-load', send);
@@ -246,6 +257,7 @@ app.whenReady().then(() => {
         {
           label: 'Release Notes...',
           click: () => {
+            console.log('Release notes menu: clicked, sending open-release-history');
             if (mainWindow && !mainWindow.isDestroyed()) {
               if (!mainWindow.isVisible()) mainWindow.show();
               mainWindow.webContents.send('open-release-history');
@@ -575,7 +587,10 @@ ipcMain.handle('get-config', async () => {
 });
 
 ipcMain.handle('get-all-releases', async () => {
-  return fetchAllReleases();
+  console.log('Release list IPC: get-all-releases invoked');
+  const results = await fetchAllReleases();
+  console.log(`Release list IPC: fetched ${results.length} releases`);
+  return results;
 });
 
 ipcMain.handle('check-config', async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { MeetingDetectorService } from './meetingDetectorService';
 import { DisplayDetectorService } from './displayDetectorService';
 import { autoUpdaterService } from './services/autoUpdaterService';
 import { notificationService } from './services/notificationService';
+import { fetchReleaseNotes, fetchAllReleases } from './services/releaseNotesService';
 import { saveTranscription, readTranscription } from './outputService';
 
 // Global flag to track if app is quitting
@@ -88,6 +89,54 @@ function handleGlobalShortcutTrigger() {
   } else {
     // Start recording without bringing the window to front
     menuBarManager.startQuickRecording();
+  }
+}
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map((n) => parseInt(n, 10));
+  const pb = b.split('.').map((n) => parseInt(n, 10));
+  for (let i = 0; i < 3; i++) {
+    const x = pa[i];
+    const y = pb[i];
+    if (isNaN(x) || isNaN(y)) return 0;
+    if (x !== y) return x - y;
+  }
+  return 0;
+}
+
+async function checkAndShowReleaseNotes() {
+  if (!app.isPackaged) return;
+
+  const current = app.getVersion();
+  const lastSeen = configService.getLastSeenVersion();
+
+  // First-run (fresh install): record current version silently.
+  if (!lastSeen) {
+    configService.setLastSeenVersion(current);
+    return;
+  }
+
+  // Only show notes when current is strictly newer than lastSeen.
+  if (compareSemver(current, lastSeen) <= 0) {
+    if (lastSeen !== current) configService.setLastSeenVersion(current);
+    return;
+  }
+
+  const notes = await fetchReleaseNotes(current);
+  configService.setLastSeenVersion(current);
+
+  if (!notes || !mainWindow || mainWindow.isDestroyed()) return;
+
+  const payload = { version: current, body: notes.body, url: notes.url };
+  const send = () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('show-release-notes', payload);
+    }
+  };
+  if (mainWindow.webContents.isLoading()) {
+    mainWindow.webContents.once('did-finish-load', send);
+  } else {
+    send();
   }
 }
 
@@ -190,6 +239,26 @@ app.whenReady().then(() => {
           accelerator: 'CmdOrCtrl+W'
         }
       ]
+    },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'Release Notes...',
+          click: () => {
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              if (!mainWindow.isVisible()) mainWindow.show();
+              mainWindow.webContents.send('open-release-history');
+            }
+          }
+        },
+        {
+          label: 'Check for Updates...',
+          click: () => {
+            autoUpdaterService.checkForUpdatesManually();
+          }
+        }
+      ]
     }
   ];
 
@@ -230,6 +299,11 @@ app.whenReady().then(() => {
     autoUpdaterService.setMainWindow(mainWindow);
     notificationService.setMainWindow(mainWindow);
   }
+
+  // Show release notes on first launch after an update.
+  checkAndShowReleaseNotes().catch((err) => {
+    console.error('Release notes check failed:', err);
+  });
 
   // Register global shortcut
   registerGlobalShortcut();
@@ -498,6 +572,10 @@ ipcMain.handle('save-config', async (_, config: Partial<AppConfig>) => {
 
 ipcMain.handle('get-config', async () => {
   return configService.getAllConfig();
+});
+
+ipcMain.handle('get-all-releases', async () => {
+  return fetchAllReleases();
 });
 
 ipcMain.handle('check-config', async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,9 +96,8 @@ function compareSemver(a: string, b: string): number {
   const pa = a.split('.').map((n) => parseInt(n, 10));
   const pb = b.split('.').map((n) => parseInt(n, 10));
   for (let i = 0; i < 3; i++) {
-    const x = pa[i];
-    const y = pb[i];
-    if (isNaN(x) || isNaN(y)) return 0;
+    const x = Number.isFinite(pa[i]) ? pa[i] : 0;
+    const y = Number.isFinite(pb[i]) ? pb[i] : 0;
     if (x !== y) return x - y;
   }
   return 0;
@@ -116,22 +115,23 @@ async function checkAndShowReleaseNotes() {
     return;
   }
 
-  // Only show notes when current is strictly newer than lastSeen.
+  // Same version or downgrade: bring lastSeen in sync but never show older notes.
   if (compareSemver(current, lastSeen) <= 0) {
     if (lastSeen !== current) configService.setLastSeenVersion(current);
     return;
   }
 
+  // Upgrade: only mark the version as seen once we've successfully handed the
+  // notes to the renderer. If the fetch fails (offline, GitHub rate limits) or
+  // the window is gone, retry on the next launch so the user doesn't miss them.
   const notes = await fetchReleaseNotes(current);
-  configService.setLastSeenVersion(current);
-
   if (!notes || !mainWindow || mainWindow.isDestroyed()) return;
 
   const payload = { version: current, body: notes.body, url: notes.url };
   const send = () => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('show-release-notes', payload);
-    }
+    if (!mainWindow || mainWindow.isDestroyed()) return;
+    mainWindow.webContents.send('show-release-notes', payload);
+    configService.setLastSeenVersion(current);
   };
   if (mainWindow.webContents.isLoading()) {
     mainWindow.webContents.once('did-finish-load', send);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -64,6 +64,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('update-status', (_, updateInfo) => callback(updateInfo));
   },
 
+  // Release notes (shown after a version update)
+  onShowReleaseNotes: (callback: (notes: { version: string; body: string; url: string }) => void) => {
+    ipcRenderer.on('show-release-notes', (_, notes) => callback(notes));
+  },
+  onOpenReleaseHistory: (callback: () => void) => {
+    ipcRenderer.on('open-release-history', () => callback());
+  },
+  getAllReleases: () => ipcRenderer.invoke('get-all-releases'),
+
   // Meeting detection
   getMeetingStatus: () => ipcRenderer.invoke('get-meeting-status'),
   onMeetingStatusChanged: (callback: (status: { active: boolean; app?: string }) => void) => {

--- a/src/services/releaseNotesService.ts
+++ b/src/services/releaseNotesService.ts
@@ -1,0 +1,83 @@
+const REPO = 'asleep-ai/listener-ai';
+
+const COMMON_HEADERS = {
+  Accept: 'application/vnd.github+json',
+  'User-Agent': 'listener-ai',
+  'X-GitHub-Api-Version': '2022-11-28'
+};
+
+export interface ReleaseNotes {
+  version: string;
+  tag: string;
+  body: string;
+  url: string;
+  publishedAt: string | null;
+}
+
+export interface ReleaseSummary {
+  tag: string;
+  name: string;
+  body: string;
+  url: string;
+  publishedAt: string | null;
+  prerelease: boolean;
+  draft: boolean;
+}
+
+export async function fetchReleaseNotes(version: string): Promise<ReleaseNotes | null> {
+  const tag = version.startsWith('v') ? version : `v${version}`;
+  const apiUrl = `https://api.github.com/repos/${REPO}/releases/tags/${tag}`;
+
+  try {
+    const res = await fetch(apiUrl, { headers: COMMON_HEADERS });
+    if (!res.ok) {
+      console.warn(`Release notes fetch failed: ${res.status} ${res.statusText}`);
+      return null;
+    }
+    const data = await res.json() as { body?: string; html_url?: string; published_at?: string | null; tag_name?: string };
+    return {
+      version,
+      tag,
+      body: data.body || '',
+      url: data.html_url || `https://github.com/${REPO}/releases/tag/${tag}`,
+      publishedAt: data.published_at ?? null
+    };
+  } catch (error) {
+    console.error('Failed to fetch release notes:', error);
+    return null;
+  }
+}
+
+export async function fetchAllReleases(limit = 30): Promise<ReleaseSummary[]> {
+  const apiUrl = `https://api.github.com/repos/${REPO}/releases?per_page=${Math.min(limit, 100)}`;
+  try {
+    const res = await fetch(apiUrl, { headers: COMMON_HEADERS });
+    if (!res.ok) {
+      console.warn(`Release list fetch failed: ${res.status} ${res.statusText}`);
+      return [];
+    }
+    const data = await res.json() as Array<{
+      tag_name?: string;
+      name?: string;
+      body?: string;
+      html_url?: string;
+      published_at?: string | null;
+      prerelease?: boolean;
+      draft?: boolean;
+    }>;
+    return data
+      .filter((r) => !r.draft)
+      .map((r) => ({
+        tag: r.tag_name || '',
+        name: r.name || r.tag_name || '',
+        body: r.body || '',
+        url: r.html_url || `https://github.com/${REPO}/releases`,
+        publishedAt: r.published_at ?? null,
+        prerelease: Boolean(r.prerelease),
+        draft: Boolean(r.draft)
+      }));
+  } catch (error) {
+    console.error('Failed to fetch release list:', error);
+    return [];
+  }
+}

--- a/src/services/releaseNotesService.ts
+++ b/src/services/releaseNotesService.ts
@@ -27,6 +27,7 @@ export interface ReleaseSummary {
 export async function fetchReleaseNotes(version: string): Promise<ReleaseNotes | null> {
   const tag = version.startsWith('v') ? version : `v${version}`;
   const apiUrl = `https://api.github.com/repos/${REPO}/releases/tags/${tag}`;
+  console.log(`Release notes fetch: GET ${apiUrl}`);
 
   try {
     const res = await fetch(apiUrl, { headers: COMMON_HEADERS });
@@ -35,6 +36,7 @@ export async function fetchReleaseNotes(version: string): Promise<ReleaseNotes |
       return null;
     }
     const data = await res.json() as { body?: string; html_url?: string; published_at?: string | null; tag_name?: string };
+    console.log(`Release notes fetch: ok, body=${(data.body || '').length} chars`);
     return {
       version,
       tag,
@@ -50,6 +52,7 @@ export async function fetchReleaseNotes(version: string): Promise<ReleaseNotes |
 
 export async function fetchAllReleases(limit = 30): Promise<ReleaseSummary[]> {
   const apiUrl = `https://api.github.com/repos/${REPO}/releases?per_page=${Math.min(limit, 100)}`;
+  console.log(`Release list fetch: GET ${apiUrl}`);
   try {
     const res = await fetch(apiUrl, { headers: COMMON_HEADERS });
     if (!res.ok) {
@@ -65,7 +68,7 @@ export async function fetchAllReleases(limit = 30): Promise<ReleaseSummary[]> {
       prerelease?: boolean;
       draft?: boolean;
     }>;
-    return data
+    const results = data
       .filter((r) => !r.draft)
       .map((r) => ({
         tag: r.tag_name || '',
@@ -76,6 +79,8 @@ export async function fetchAllReleases(limit = 30): Promise<ReleaseSummary[]> {
         prerelease: Boolean(r.prerelease),
         draft: Boolean(r.draft)
       }));
+    console.log(`Release list fetch: ok, ${results.length} releases`);
+    return results;
   } catch (error) {
     console.error('Failed to fetch release list:', error);
     return [];

--- a/styles.css
+++ b/styles.css
@@ -296,6 +296,110 @@ h1 {
   overflow-y: auto;
 }
 
+.release-notes-body {
+  max-height: 55vh;
+  overflow-y: auto;
+  margin: 16px 0 24px;
+  padding: 12px 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background-color: #fafafa;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.release-notes-body h1,
+.release-notes-body h2,
+.release-notes-body h3 {
+  margin: 12px 0 6px;
+}
+
+.release-notes-body ul,
+.release-notes-body ol {
+  padding-left: 22px;
+  margin: 6px 0;
+}
+
+.release-notes-body code {
+  background-color: #eef0f3;
+  padding: 1px 4px;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em;
+}
+
+.release-notes-body a {
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.release-notes-body a:hover {
+  text-decoration: underline;
+}
+
+.release-history-content {
+  max-width: 760px;
+  max-height: 85vh;
+}
+
+.release-history-list {
+  max-height: 60vh;
+  overflow-y: auto;
+  margin: 16px 0;
+  padding-right: 4px;
+}
+
+.release-history-item {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  margin-bottom: 8px;
+  background-color: #fff;
+}
+
+.release-history-item[open] {
+  background-color: #fafafa;
+}
+
+.release-history-item summary {
+  cursor: pointer;
+  padding: 10px 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  user-select: none;
+}
+
+.release-history-item summary::-webkit-details-marker {
+  color: #9ca3af;
+}
+
+.release-history-item .release-tag {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: #111827;
+}
+
+.release-history-item .release-date {
+  color: #6b7280;
+  font-weight: 400;
+  font-size: 13px;
+  margin-left: auto;
+}
+
+.release-history-item .release-prerelease {
+  color: #b45309;
+  background-color: #fef3c7;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.release-history-item .release-notes-body {
+  margin: 0 14px 14px;
+  max-height: none;
+}
+
 .close {
   color: #aaa;
   float: right;


### PR DESCRIPTION
## Summary

Two connected changes for the release feedback loop:

1. **CI auto-generates bilingual release notes** (English first, Korean second) from the commit range since the previous tag, via OpenAI. Falls back to the raw commit list on any API failure so the release is never blocked.
2. **The desktop app shows release notes in-app**: a "What's New" modal pops up on first launch after a version bump, and a **Help → Release Notes…** menu lets users browse the full release history at any time.

> Stacked on #73 — this branch was cut from `feat/min-recording-seconds`. GitHub will auto-rebase the base to `main` once #73 merges.

## Workflow side

- **New**: [\`.github/scripts/generate_release_notes.py\`](https://github.com/asleep-ai/listener-ai/blob/feat/release-notes-automation/.github/scripts/generate_release_notes.py) — PEP 723 inline-deps \`uv\` script modeled after the sleephub-android pattern in asleep-ai/sleephub-android#318. Prompt asks for two blocks describing the **same changes**: \`## English\` (New Features / Improvements / Bug Fixes / Internal Changes) then \`## 한국어\` (신규 기능 / 개선 / 버그 수정 / 내부 변경). Empty sections omitted.
- **Modified**: [\`.github/workflows/release.yml\`](https://github.com/asleep-ai/listener-ai/blob/feat/release-notes-automation/.github/workflows/release.yml) — release job now has \`fetch-depth: 0\`, finds the previous tag via \`git describe\`, runs the script, and passes the output as body to \`ncipollo/release-action\` (keeps the Downloads header above the AI notes).

Requires the org-level **\`OPENAI_API_KEY\`** secret to be accessible to this repo (same one sleephub-android uses).

## In-app side

- **New**: [\`src/services/releaseNotesService.ts\`](https://github.com/asleep-ai/listener-ai/blob/feat/release-notes-automation/src/services/releaseNotesService.ts) — \`fetchReleaseNotes(version)\` for a specific tag, \`fetchAllReleases(limit)\` for history. Public repo, no auth needed.
- \`src/main.ts\`: \`checkAndShowReleaseNotes\` runs on \`app.whenReady\` — only when packaged and the current version is strictly newer than \`lastSeenVersion\` (simple 3-part semver compare). First-run sets \`lastSeenVersion\` silently. New \`Help\` menu with "Release Notes…" + "Check for Updates…" entries, cross-platform.
- \`src/preload.ts\`: \`onShowReleaseNotes\`, \`onOpenReleaseHistory\`, \`getAllReleases\`.
- \`renderer.js\` / \`index.html\` / \`styles.css\`: "What's New" modal (post-update) and Release History modal (\`<details>\`/\`<summary>\` per version). Reuses the existing marked-based \`renderMarkdown\` which already escapes raw HTML via the custom renderer override — no new XSS surface.

## Test plan

- [x] \`pnpm run build\` clean
- [x] \`release.yml\` parses as valid YAML
- [ ] Dry-run: manually invoke the release workflow on a non-main branch; confirm AI notes step succeeds with OpenAI available, and fallback kicks in when \`OPENAI_API_KEY\` is unset
- [ ] After a real version bump, confirm the "What's New" modal appears on the next packaged-app launch and not on subsequent launches
- [ ] Help → Release Notes… opens the history modal, \`<details>\` entries expand per version, "View all on GitHub" opens the releases page
- [ ] Fresh install (no \`lastSeenVersion\`): modal does NOT appear; \`lastSeenVersion\` is set silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)