### PR TITLE
Add local search over saved transcriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,10 +78,13 @@
 
     <div class="recordings-section">
       <div class="recordings-header">
-        <h2>Recent Recordings</h2>
+        <h2 id="recordingsHeading">Recent Recordings</h2>
         <button id="openFolderButton" class="folder-button" title="Open recordings folder">
           📁
         </button>
+      </div>
+      <div class="search-row">
+        <input type="search" id="searchInput" class="search-input" placeholder="Search past meetings (title, summary, notes, transcript)" autocomplete="off" spellcheck="false" />
       </div>
       <div id="recordingsList" class="recordings-list">
         <p class="no-recordings">No recordings yet</p>

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
     "dist/configService.js",
     "dist/geminiService.js",
     "dist/outputService.js",
+    "dist/searchService.js",
     "dist/services/ffmpegManager.js"
   ],
   "scripts": {
     "start": "pnpm run build && electron .",
     "build": "tsc",
-    "test": "tsc && node --test dist/meetingDetectorService.test.js",
+    "test": "tsc && node --test dist/meetingDetectorService.test.js dist/searchService.test.js",
     "dist": "pnpm run build && electron-builder",
     "dist:mac": "pnpm run build && electron-builder --mac",
     "dist:mac-x64": "pnpm run build && electron-builder --mac --x64",

--- a/renderer.js
+++ b/renderer.js
@@ -244,6 +244,8 @@ window.addEventListener('DOMContentLoaded', async () => {
       });
     }
 
+    setupSearch();
+
     // Load existing recordings
     await loadRecordings();
 
@@ -886,6 +888,7 @@ function showSavedTranscript(filePath, title, metadata) {
       actionItems: metadata.actionItems || [],
       suggestedTitle: metadata.suggestedTitle,
       customFields: metadata.customFields,
+      emoji: metadata.emoji,
     };
     currentMeetingTitle = title;
     currentFilePath = filePath;
@@ -1183,7 +1186,127 @@ function formatFileSize(bytes) {
 
 // Function to refresh recordings list after a new recording
 async function refreshRecordingsList() {
+  const searchInput = document.getElementById('searchInput');
+  if (searchInput && searchInput.value.trim()) {
+    await runSearch(searchInput.value.trim());
+    return;
+  }
   await loadRecordings();
+}
+
+// --- Search ----------------------------------------------------------------
+
+let searchDebounceTimer = null;
+let lastSearchToken = 0;
+
+function setupSearch() {
+  const searchInput = document.getElementById('searchInput');
+  if (!searchInput) return;
+
+  searchInput.addEventListener('input', () => {
+    if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+    const q = searchInput.value.trim();
+    if (!q) {
+      lastSearchToken++; // drop any in-flight result so it can't overwrite the default list
+      setHeadingDefault();
+      loadRecordings();
+      return;
+    }
+    searchDebounceTimer = setTimeout(() => runSearch(q), 200);
+  });
+
+  searchInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      searchInput.value = '';
+      lastSearchToken++;
+      setHeadingDefault();
+      loadRecordings();
+    }
+  });
+}
+
+function setHeadingDefault() {
+  const h = document.getElementById('recordingsHeading');
+  if (h) h.textContent = 'Recent Recordings';
+}
+
+function setHeadingSearch(count, query) {
+  const h = document.getElementById('recordingsHeading');
+  if (!h) return;
+  h.textContent = count > 0
+    ? `Search Results (${count}) — "${query}"`
+    : `No matches for "${query}"`;
+}
+
+async function runSearch(query) {
+  const token = ++lastSearchToken;
+  try {
+    const result = await window.electronAPI.searchTranscriptions({ query, limit: 20 });
+    if (token !== lastSearchToken) return; // stale response
+    if (!result || !result.success) {
+      recordingsList.innerHTML = '<p class="no-recordings">Search failed</p>';
+      return;
+    }
+    renderSearchResults(result.hits, query);
+  } catch (err) {
+    if (token !== lastSearchToken) return;
+    console.error('Search error:', err);
+    recordingsList.innerHTML = '<p class="no-recordings">Search failed</p>';
+  }
+}
+
+function renderSearchResults(hits, query) {
+  setHeadingSearch(hits.length, query);
+  recordingsList.innerHTML = '';
+  if (hits.length === 0) {
+    recordingsList.innerHTML = '<p class="no-recordings">No matches</p>';
+    return;
+  }
+  for (const hit of hits) {
+    recordingsList.appendChild(createSearchResultItem(hit));
+  }
+}
+
+function createSearchResultItem(hit) {
+  const item = document.createElement('div');
+  item.className = 'recording-item search-result-item';
+
+  const date = hit.transcribedAt ? new Date(hit.transcribedAt).toLocaleDateString() : '';
+  const matches = (hit.matchedFields || []).join(', ');
+
+  const info = document.createElement('div');
+  info.className = 'recording-info';
+
+  const h3 = document.createElement('h3');
+  h3.textContent = hit.title || hit.folderName;
+  info.appendChild(h3);
+
+  const meta = document.createElement('p');
+  meta.className = 'recording-meta';
+  meta.textContent = date ? `${date} • matches: ${matches}` : `matches: ${matches}`;
+  info.appendChild(meta);
+
+  if (hit.snippet) {
+    const snippet = document.createElement('p');
+    snippet.className = 'search-snippet';
+    snippet.textContent = hit.snippet;
+    info.appendChild(snippet);
+  }
+
+  item.appendChild(info);
+
+  const actions = document.createElement('div');
+  actions.className = 'recording-actions';
+  const viewBtn = document.createElement('button');
+  viewBtn.className = 'action-button view-transcript-btn';
+  viewBtn.textContent = 'View Transcript';
+  viewBtn.addEventListener('click', () => {
+    showSavedTranscript(hit.audioFilePath || '', hit.title, hit.data);
+  });
+  actions.appendChild(viewBtn);
+  item.appendChild(actions);
+
+  return item;
 }
 
 // Copy functionality

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { getDataPath } from './dataPath';
 import { ConfigService } from './configService';
 import { GeminiService } from './geminiService';
 import { saveTranscription, listTranscriptions, parseFrontmatter, getTranscriptionsDir } from './outputService';
+import { searchTranscriptions, resolveFields, ALL_FIELDS, type SearchField } from './searchService';
 
 const SUPPORTED_EXTENSIONS = new Set([
   '.mp3', '.m4a', '.wav', '.ogg', '.flac', '.aac', '.wma', '.opus', '.webm',
@@ -18,6 +19,8 @@ function usage(): never {
     '       listener show <ref>                 Print summary to stdout\n' +
     '       listener export <ref> [<path>] [--json] [--transcript]\n' +
     '                                           Export transcription\n' +
+    '       listener search <query> [--limit <n>] [--transcript] [--field <name>]\n' +
+    '                                           Search past transcriptions\n' +
     '       listener config list|get|set|path   Manage configuration\n' +
     '\n' +
     '<ref> is a number from `listener list` or a folder name.\n' +
@@ -26,7 +29,8 @@ function usage(): never {
     '  --output <dir>   Parent directory for the output folder\n' +
     '  --limit <n>      Max results (0 = all, default: 20)\n' +
     '  --json           Export as JSON instead of markdown\n' +
-    '  --transcript     Include full transcript in export output\n' +
+    '  --transcript     Include transcript body (export: append; search: widen scope)\n' +
+    '  --field <name>   Restrict search to one of: title, summary, keyPoints, actionItems, transcript, all\n' +
     '  --help           Show this help message\n'
   );
   process.exit(1);
@@ -280,6 +284,70 @@ function handleExport(args: string[]): void {
   }
 }
 
+function handleSearch(args: string[]): void {
+  const VALID_FIELDS = [...ALL_FIELDS, 'all'] as const;
+  let query: string | undefined;
+  let limit = 20;
+  let includeTranscript = false;
+  let field: SearchField | 'all' | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--limit' && i + 1 < args.length) {
+      const n = parseInt(args[++i], 10);
+      if (isNaN(n) || n < 0) {
+        process.stderr.write('Error: --limit must be a non-negative integer\n');
+        process.exit(1);
+      }
+      limit = n;
+      continue;
+    }
+    if (a === '--transcript') { includeTranscript = true; continue; }
+    if (a === '--field' && i + 1 < args.length) {
+      const v = args[++i];
+      if (!(VALID_FIELDS as readonly string[]).includes(v)) {
+        process.stderr.write(`Error: --field must be one of: ${VALID_FIELDS.join(', ')}\n`);
+        process.exit(1);
+      }
+      field = v as SearchField | 'all';
+      continue;
+    }
+    if (a.startsWith('-')) {
+      process.stderr.write(`Error: Unknown option: ${a}\n`);
+      process.exit(1);
+    }
+    if (!query) { query = a; continue; }
+    process.stderr.write(`Error: Unexpected argument: ${a} (quote multi-word queries)\n`);
+    process.exit(1);
+  }
+
+  if (!query || query.trim() === '') {
+    process.stderr.write('Error: Missing query. Usage: listener search <query> [--limit <n>] [--transcript] [--field <name>]\n');
+    process.exit(1);
+  }
+
+  const dataPath = getDataPath();
+  const fields = resolveFields({ field, includeTranscript });
+  const hits = searchTranscriptions(dataPath, { query, fields, limit });
+
+  if (hits.length === 0) {
+    process.stderr.write('No results.\n');
+    return;
+  }
+
+  for (const hit of hits) {
+    const date = hit.entry.transcribedAt ? hit.entry.transcribedAt.slice(0, 10) : '          ';
+    const title = hit.data.title.length > 60 ? hit.data.title.slice(0, 57) + '...' : hit.data.title;
+    process.stdout.write(`${date}  ${title}\n`);
+    process.stdout.write(`  ref:     ${hit.entry.folderName}\n`);
+    process.stdout.write(`  matches: ${hit.matchedFields.join(', ')}\n`);
+    if (hit.snippet) {
+      process.stdout.write(`  ${hit.snippet}\n`);
+    }
+    process.stdout.write('\n');
+  }
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
@@ -304,6 +372,11 @@ async function main(): Promise<void> {
 
   if (args[0] === 'export') {
     handleExport(args.slice(1));
+    return;
+  }
+
+  if (args[0] === 'search') {
+    handleSearch(args.slice(1));
     return;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { autoUpdaterService } from './services/autoUpdaterService';
 import { notificationService } from './services/notificationService';
 import { fetchReleaseNotes, fetchAllReleases } from './services/releaseNotesService';
 import { saveTranscription, readTranscription } from './outputService';
+import { searchTranscriptions, ALL_FIELDS, type SearchField } from './searchService';
 
 // Global flag to track if app is quitting
 declare global {
@@ -796,6 +797,7 @@ ipcMain.handle('get-metadata', async (_, filePath: string) => {
             keyPoints: transcription.keyPoints,
             actionItems: transcription.actionItems,
             customFields: transcription.customFields ?? metadata.customFields,
+            emoji: transcription.emoji,
           }
         };
       }
@@ -829,6 +831,49 @@ ipcMain.handle('open-recordings-folder', async () => {
 
   // Open the folder in the system file explorer
   shell.openPath(recordingsPath);
+});
+
+// Search past transcriptions
+ipcMain.handle('search-transcriptions', async (_, opts: { query: string; fields?: SearchField[]; limit?: number }) => {
+  try {
+    const query = (opts?.query ?? '').trim();
+    if (!query) return { success: true, hits: [] };
+
+    // Validate fields against the known whitelist; drop anything else. Unvalidated input
+    // (e.g. a stringified 'title') would be passed to `new Set(...)` and silently match nothing.
+    const requested = Array.isArray(opts.fields) ? opts.fields : [];
+    const filtered = requested.filter((f): f is SearchField => (ALL_FIELDS as readonly string[]).includes(f));
+    const fields = filtered.length > 0 ? filtered : ALL_FIELDS;
+    const limit = Number.isFinite(opts.limit) && (opts.limit as number) >= 0 ? (opts.limit as number) : 20;
+    const dataPath = app.getPath('userData');
+    const raw = searchTranscriptions(dataPath, { query, fields, limit });
+
+    const hits = raw.map((h) => ({
+      folderName: h.entry.folderName,
+      folderPath: h.entry.folderPath,
+      transcribedAt: h.entry.transcribedAt,
+      title: h.data.title,
+      audioFilePath: h.data.audioFilePath ?? '',
+      score: h.score,
+      matchedFields: h.matchedFields,
+      snippet: h.snippet,
+      snippetField: h.snippetField ?? null,
+      data: {
+        title: h.data.title,
+        suggestedTitle: h.data.suggestedTitle,
+        summary: h.data.summary,
+        transcript: h.data.transcript,
+        keyPoints: h.data.keyPoints ?? [],
+        actionItems: h.data.actionItems ?? [],
+        customFields: h.data.customFields ?? {},
+        emoji: h.data.emoji,
+      },
+    }));
+
+    return { success: true, hits };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
 });
 
 // Get list of recordings

--- a/src/notionService.ts
+++ b/src/notionService.ts
@@ -212,7 +212,7 @@ export class NotionService {
         },
         icon: {
           type: 'emoji',
-          emoji: transcriptionResult.emoji as any
+          emoji: (transcriptionResult.emoji || '📝') as any
         },
         properties: properties,
         children: children

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -84,6 +84,7 @@ interface SummaryFrontmatter {
   customFields?: Record<string, unknown>;
   audioFilePath?: string;
   transcribedAt: string;
+  emoji?: string;
 }
 
 function buildFrontmatter(meta: SummaryFrontmatter): string {
@@ -108,6 +109,9 @@ function buildFrontmatter(meta: SummaryFrontmatter): string {
   }
   if (meta.audioFilePath) {
     lines.push(`audioFilePath: ${yamlQuote(meta.audioFilePath)}`);
+  }
+  if (meta.emoji) {
+    lines.push(`emoji: ${yamlQuote(meta.emoji)}`);
   }
   lines.push('---');
   return lines.join('\n');
@@ -218,6 +222,7 @@ export function saveTranscription(opts: SaveTranscriptionOptions): string {
     customFields: opts.result.customFields,
     audioFilePath: opts.audioFilePath,
     transcribedAt,
+    emoji: opts.result.emoji,
   });
   const summaryBody = formatSummary(opts.result, opts.title);
   fs.writeFileSync(path.join(folderPath, 'summary.md'), `${frontmatter}\n\n${summaryBody}`, 'utf-8');
@@ -300,6 +305,7 @@ export interface ReadTranscriptionResult {
   customFields?: Record<string, unknown>;
   audioFilePath?: string;
   transcribedAt?: string;
+  emoji?: string;
 }
 
 /**
@@ -337,6 +343,7 @@ export function readTranscription(folderPath: string): ReadTranscriptionResult |
       customFields,
       audioFilePath: meta.audioFilePath as string | undefined,
       transcribedAt: meta.transcribedAt as string | undefined,
+      emoji: meta.emoji as string | undefined,
     };
   } catch {
     return null;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -17,6 +17,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
   openRecordingsFolder: () => ipcRenderer.invoke('open-recordings-folder'),
   getRecordings: () => ipcRenderer.invoke('get-recordings'),
+  searchTranscriptions: (opts: { query: string; fields?: string[]; limit?: number }) =>
+    ipcRenderer.invoke('search-transcriptions', opts),
   onTranscriptionProgress: (callback: (progress: { percent: number; message: string }) => void) => {
     ipcRenderer.on('transcription-progress', (_, progress) => callback(progress));
   },

--- a/src/searchService.test.ts
+++ b/src/searchService.test.ts
@@ -1,0 +1,162 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  makeSnippet,
+  scoreRecord,
+  resolveFields,
+  FIELD_WEIGHTS,
+  DEFAULT_FIELDS,
+  ALL_FIELDS,
+} from './searchService';
+import type { ReadTranscriptionResult, TranscriptionEntry } from './outputService';
+
+const sampleEntry: TranscriptionEntry = {
+  folderPath: '/tmp/Roadmap_20260420_143000',
+  folderName: 'Roadmap_20260420_143000',
+  title: 'Roadmap Review',
+  transcribedAt: '2026-04-20T14:30:00Z',
+};
+
+const sampleData: ReadTranscriptionResult = {
+  title: 'Roadmap Review',
+  summary: 'We discussed the Q2 roadmap and platform priorities.',
+  transcript: 'Jaden talked about the roadmap. The billing system came up.',
+  keyPoints: ['Prioritize billing UX', 'Ship search V1'],
+  actionItems: ['Draft roadmap doc', 'Review billing tickets'],
+  transcribedAt: '2026-04-20T14:30:00Z',
+};
+
+describe('makeSnippet', () => {
+  it('returns empty string when there is no match', () => {
+    assert.equal(makeSnippet('hello world', 'foo'), '');
+  });
+
+  it('centers snippet around first occurrence and adds ellipses', () => {
+    const text = 'a'.repeat(100) + ' needle ' + 'b'.repeat(100);
+    const snippet = makeSnippet(text, 'needle', 40);
+    assert.ok(snippet.includes('needle'));
+    assert.ok(snippet.startsWith('...'));
+    assert.ok(snippet.endsWith('...'));
+  });
+
+  it('is case-insensitive', () => {
+    assert.ok(makeSnippet('Hello WORLD', 'world').includes('WORLD'));
+  });
+
+  it('omits leading ellipsis when match is near start', () => {
+    const snippet = makeSnippet('needle followed by a tail of trailing content', 'needle', 40);
+    assert.ok(!snippet.startsWith('...'));
+    assert.ok(snippet.includes('needle'));
+  });
+
+  it('collapses whitespace', () => {
+    const snippet = makeSnippet('line one\n\nline two   needle   after', 'needle', 40);
+    assert.ok(!/\s\s/.test(snippet), `snippet has double-space: ${snippet}`);
+  });
+});
+
+describe('resolveFields', () => {
+  it('defaults to everything except transcript', () => {
+    assert.deepEqual(resolveFields({}), DEFAULT_FIELDS);
+  });
+
+  it('includeTranscript widens to ALL_FIELDS', () => {
+    assert.deepEqual(resolveFields({ includeTranscript: true }), ALL_FIELDS);
+  });
+
+  it('field=all returns ALL_FIELDS', () => {
+    assert.deepEqual(resolveFields({ field: 'all' }), ALL_FIELDS);
+  });
+
+  it('specific field overrides defaults', () => {
+    assert.deepEqual(resolveFields({ field: 'summary' }), ['summary']);
+  });
+
+  it('specific field wins over includeTranscript', () => {
+    assert.deepEqual(resolveFields({ field: 'title', includeTranscript: true }), ['title']);
+  });
+});
+
+describe('scoreRecord', () => {
+  it('returns null when nothing matches', () => {
+    const hit = scoreRecord(sampleEntry, sampleData, 'xyz-nonexistent', ALL_FIELDS);
+    assert.equal(hit, null);
+  });
+
+  it('matches title case-insensitively', () => {
+    const hit = scoreRecord(sampleEntry, sampleData, 'ROADMAP review', ALL_FIELDS);
+    assert.ok(hit);
+    assert.ok(hit!.matchedFields.includes('title'));
+  });
+
+  it('matches inside keyPoints array', () => {
+    const hit = scoreRecord(sampleEntry, sampleData, 'billing UX', ALL_FIELDS);
+    assert.ok(hit);
+    assert.ok(hit!.matchedFields.includes('keyPoints'));
+  });
+
+  it('respects field scope -- transcript-only term skipped when transcript not in scope', () => {
+    const hit = scoreRecord(sampleEntry, sampleData, 'jaden', ['summary', 'keyPoints']);
+    assert.equal(hit, null);
+    const hit2 = scoreRecord(sampleEntry, sampleData, 'jaden', ['transcript']);
+    assert.ok(hit2);
+    assert.ok(hit2!.matchedFields.includes('transcript'));
+  });
+
+  it('aggregates score across every matching field', () => {
+    const hit = scoreRecord(sampleEntry, sampleData, 'roadmap', ALL_FIELDS);
+    assert.ok(hit);
+    const expected =
+      FIELD_WEIGHTS.title +
+      FIELD_WEIGHTS.summary +
+      FIELD_WEIGHTS.actionItems +
+      FIELD_WEIGHTS.transcript;
+    assert.equal(hit!.score, expected);
+    assert.deepEqual(
+      hit!.matchedFields.slice().sort(),
+      ['actionItems', 'summary', 'title', 'transcript'],
+    );
+  });
+
+  it('ranks title match above transcript-only match', () => {
+    const titleOnly: ReadTranscriptionResult = {
+      ...sampleData,
+      summary: '',
+      transcript: '',
+      keyPoints: [],
+      actionItems: [],
+    };
+    const transcriptOnly: ReadTranscriptionResult = {
+      ...sampleData,
+      title: 'Unrelated',
+      summary: '',
+      keyPoints: [],
+      actionItems: [],
+    };
+    const hitA = scoreRecord(sampleEntry, titleOnly, 'roadmap', ALL_FIELDS);
+    const hitB = scoreRecord(sampleEntry, transcriptOnly, 'roadmap', ALL_FIELDS);
+    assert.ok(hitA && hitB);
+    assert.ok(hitA!.score > hitB!.score);
+  });
+
+  it('prefers higher-weighted field for snippet source', () => {
+    const hit = scoreRecord(sampleEntry, sampleData, 'roadmap', ALL_FIELDS);
+    assert.ok(hit);
+    assert.equal(hit!.snippetField, 'summary');
+    assert.ok(hit!.snippet.toLowerCase().includes('roadmap'));
+  });
+
+  it('does not produce snippet when only title matches', () => {
+    const titleOnly: ReadTranscriptionResult = {
+      ...sampleData,
+      summary: '',
+      transcript: '',
+      keyPoints: [],
+      actionItems: [],
+    };
+    const hit = scoreRecord(sampleEntry, titleOnly, 'roadmap', ALL_FIELDS);
+    assert.ok(hit);
+    assert.equal(hit!.snippet, '');
+    assert.equal(hit!.snippetField, undefined);
+  });
+});

--- a/src/searchService.ts
+++ b/src/searchService.ts
@@ -1,0 +1,153 @@
+import { listTranscriptions, readTranscription } from './outputService';
+import type { ReadTranscriptionResult, TranscriptionEntry } from './outputService';
+
+export type SearchField = 'title' | 'summary' | 'keyPoints' | 'actionItems' | 'transcript';
+
+export const FIELD_WEIGHTS: Record<SearchField, number> = {
+  title: 10,
+  summary: 5,
+  keyPoints: 3,
+  actionItems: 3,
+  transcript: 1,
+};
+
+export const DEFAULT_FIELDS: SearchField[] = ['title', 'summary', 'keyPoints', 'actionItems'];
+export const ALL_FIELDS: SearchField[] = ['title', 'summary', 'keyPoints', 'actionItems', 'transcript'];
+
+export interface SearchHit {
+  entry: TranscriptionEntry;
+  data: ReadTranscriptionResult;
+  score: number;
+  matchedFields: SearchField[];
+  snippet: string;
+  snippetField?: SearchField;
+}
+
+export interface SearchOptions {
+  query: string;
+  fields?: SearchField[];
+  limit?: number;
+}
+
+/** Extract a ~width-char snippet centered on the first occurrence of needle. */
+export function makeSnippet(text: string, needle: string, width = 80, matchIndex?: number): string {
+  if (!text || !needle) return '';
+  const idx = matchIndex ?? text.toLowerCase().indexOf(needle.toLowerCase());
+  if (idx === -1) return '';
+  const half = Math.floor(width / 2);
+  const start = Math.max(0, idx - half);
+  const end = Math.min(text.length, idx + needle.length + half);
+  let snippet = text.slice(start, end).replace(/\s+/g, ' ').trim();
+  if (start > 0) snippet = '...' + snippet;
+  if (end < text.length) snippet = snippet + '...';
+  return snippet;
+}
+
+/** Returns the match index in haystack (lowercased) for a pre-lowercased needle, or -1. */
+function findIndex(haystack: string | undefined, needleLower: string): number {
+  if (!haystack) return -1;
+  return haystack.toLowerCase().indexOf(needleLower);
+}
+
+function firstArrayHit(haystack: string[] | undefined, needleLower: string): { text: string; index: number } | undefined {
+  if (!haystack) return undefined;
+  for (const s of haystack) {
+    const idx = s.toLowerCase().indexOf(needleLower);
+    if (idx !== -1) return { text: s, index: idx };
+  }
+  return undefined;
+}
+
+/** Score a single transcription record. Returns null if no field in scope matches. */
+export function scoreRecord(
+  entry: TranscriptionEntry,
+  data: ReadTranscriptionResult,
+  query: string,
+  fields: SearchField[],
+): SearchHit | null {
+  const needle = query.toLowerCase();
+  if (!needle) return null;
+
+  const scope = new Set(fields);
+  let score = 0;
+  const matched: SearchField[] = [];
+  let snippetSource = '';
+  let snippetIndex = -1;
+  let snippetField: SearchField | undefined;
+
+  const setSnippet = (field: SearchField, source: string, index: number) => {
+    if (!snippetField) { snippetField = field; snippetSource = source; snippetIndex = index; }
+  };
+
+  if (scope.has('title') && findIndex(data.title, needle) !== -1) {
+    score += FIELD_WEIGHTS.title;
+    matched.push('title');
+  }
+  {
+    const idx = scope.has('summary') ? findIndex(data.summary, needle) : -1;
+    if (idx !== -1) {
+      score += FIELD_WEIGHTS.summary;
+      matched.push('summary');
+      setSnippet('summary', data.summary, idx);
+    }
+  }
+  if (scope.has('keyPoints')) {
+    const hit = firstArrayHit(data.keyPoints, needle);
+    if (hit) {
+      score += FIELD_WEIGHTS.keyPoints;
+      matched.push('keyPoints');
+      setSnippet('keyPoints', hit.text, hit.index);
+    }
+  }
+  if (scope.has('actionItems')) {
+    const hit = firstArrayHit(data.actionItems, needle);
+    if (hit) {
+      score += FIELD_WEIGHTS.actionItems;
+      matched.push('actionItems');
+      setSnippet('actionItems', hit.text, hit.index);
+    }
+  }
+  {
+    const idx = scope.has('transcript') ? findIndex(data.transcript, needle) : -1;
+    if (idx !== -1) {
+      score += FIELD_WEIGHTS.transcript;
+      matched.push('transcript');
+      setSnippet('transcript', data.transcript, idx);
+    }
+  }
+
+  if (score === 0) return null;
+
+  const snippet = snippetSource ? makeSnippet(snippetSource, needle, 80, snippetIndex) : '';
+  return { entry, data, score, matchedFields: matched, snippet, snippetField };
+}
+
+/** Resolve which fields to search based on CLI flags. */
+export function resolveFields(opts: { field?: SearchField | 'all'; includeTranscript?: boolean }): SearchField[] {
+  if (opts.field === 'all') return [...ALL_FIELDS];
+  if (opts.field) return [opts.field];
+  return opts.includeTranscript ? [...ALL_FIELDS] : [...DEFAULT_FIELDS];
+}
+
+/** Run a search against the local transcriptions archive. */
+export function searchTranscriptions(dataPath: string, opts: SearchOptions): SearchHit[] {
+  const entries = listTranscriptions(dataPath, 0);
+  const fields = opts.fields ?? DEFAULT_FIELDS;
+  const hits: SearchHit[] = [];
+
+  for (const entry of entries) {
+    const data = readTranscription(entry.folderPath);
+    if (!data) continue;
+    const hit = scoreRecord(entry, data, opts.query, fields);
+    if (hit) hits.push(hit);
+  }
+
+  hits.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return (b.entry.transcribedAt || '').localeCompare(a.entry.transcribedAt || '');
+  });
+
+  const limit = opts.limit;
+  if (limit && limit > 0) return hits.slice(0, limit);
+  return hits; // limit=0 or undefined → return all
+}

--- a/src/searchService.ts
+++ b/src/searchService.ts
@@ -58,17 +58,19 @@ function firstArrayHit(haystack: string[] | undefined, needleLower: string): { t
   return undefined;
 }
 
-/** Score a single transcription record. Returns null if no field in scope matches. */
-export function scoreRecord(
+/**
+ * Score one record against a pre-lowercased needle and pre-built scope Set.
+ * The bulk-search path hoists these out of the per-entry loop; `scoreRecord`
+ * below is a thin convenience wrapper for direct callers (tests).
+ */
+function scoreRecordPrepared(
   entry: TranscriptionEntry,
   data: ReadTranscriptionResult,
-  query: string,
-  fields: SearchField[],
+  needle: string,
+  scope: Set<SearchField>,
 ): SearchHit | null {
-  const needle = query.toLowerCase();
   if (!needle) return null;
 
-  const scope = new Set(fields);
   let score = 0;
   const matched: SearchField[] = [];
   let snippetSource = '';
@@ -122,6 +124,16 @@ export function scoreRecord(
   return { entry, data, score, matchedFields: matched, snippet, snippetField };
 }
 
+/** Convenience wrapper: lowercases the query and builds the scope Set per call. */
+export function scoreRecord(
+  entry: TranscriptionEntry,
+  data: ReadTranscriptionResult,
+  query: string,
+  fields: SearchField[],
+): SearchHit | null {
+  return scoreRecordPrepared(entry, data, query.toLowerCase(), new Set(fields));
+}
+
 /** Resolve which fields to search based on CLI flags. */
 export function resolveFields(opts: { field?: SearchField | 'all'; includeTranscript?: boolean }): SearchField[] {
   if (opts.field === 'all') return [...ALL_FIELDS];
@@ -133,12 +145,14 @@ export function resolveFields(opts: { field?: SearchField | 'all'; includeTransc
 export function searchTranscriptions(dataPath: string, opts: SearchOptions): SearchHit[] {
   const entries = listTranscriptions(dataPath, 0);
   const fields = opts.fields ?? DEFAULT_FIELDS;
+  const needle = opts.query.toLowerCase();
+  const scope = new Set(fields);
   const hits: SearchHit[] = [];
 
   for (const entry of entries) {
     const data = readTranscription(entry.folderPath);
     if (!data) continue;
-    const hit = scoreRecord(entry, data, opts.query, fields);
+    const hit = scoreRecordPrepared(entry, data, needle, scope);
     if (hit) hits.push(hit);
   }
 

--- a/styles.css
+++ b/styles.css
@@ -266,6 +266,44 @@ h1 {
   padding: 20px;
 }
 
+.search-row {
+  margin-bottom: 15px;
+}
+
+.search-input {
+  width: 100%;
+  padding: 10px 14px;
+  font-size: 14px;
+  font-family: inherit;
+  color: #2c3e50;
+  background-color: #f8f9fa;
+  border: 1px solid #e1e4e8;
+  border-radius: 8px;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #3498db;
+  background-color: #fff;
+}
+
+.search-input::placeholder {
+  color: #95a5a6;
+}
+
+.search-snippet {
+  margin-top: 6px;
+  font-size: 13px;
+  color: #5a6c7d;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.search-result-item .recording-meta {
+  color: #7f8c8d;
+}
+
 /* Modal styles */
 .modal {
   display: none;


### PR DESCRIPTION
## Summary

- Closes #78. Adds `listener search <query> [--limit <n>] [--transcript] [--field <name>]` to the CLI and a debounced search input inside the GUI's "Recent Recordings" section. Weighted scoring (title 10, summary 5, keyPoints/actionItems 3, transcript 1; transcript opt-in), matched-field labels, and a snippet around the first hit.
- Persists the model-chosen emoji in `summary.md` frontmatter so re-uploading a saved transcription to Notion preserves the icon. Older recordings that lack the field fall back to 📝 on upload, closing a pre-existing Notion API rejection for any previously saved meeting.

## Implementation notes

- Core `searchService.ts` is a pure module with 18 unit tests (`makeSnippet`, `scoreRecord`, `resolveFields`).
- Match index is threaded from scoring into snippet extraction to avoid re-lowercasing long transcripts.
- Stale IPC responses are dropped via a monotonic token — clearing the box or pressing Esc invalidates in-flight searches.
- `search-transcriptions` IPC validates `opts.fields` against the `SearchField` whitelist and normalizes `limit` before calling into the search service.
- Search scope in the GUI defaults to all fields (title/summary/keyPoints/actionItems/transcript); the CLI keeps the original default of excluding transcript and exposes `--transcript` / `--field <name>` to widen or narrow the scope.

## Deliberate V1 scope (noted for follow-up)

- `searchTranscriptions` still reads every `summary.md` per query. A two-phase scan using `listTranscriptions`' lightweight frontmatter peek for title-only matches would cut hot-path I/O but is out of scope here.
- The IPC response currently includes the full transcript per hit so the existing `showSavedTranscript` modal works without a second round-trip. Trimming + on-click re-fetch is a later optimization.

## Test plan

- [x] `pnpm test` — 27/27 (18 new search tests + 9 existing meeting-detector tests)
- [x] CLI smoke against Korean real data and 9 fixture scenarios: ranking, field scope, tie-break, `--limit`, `--transcript`, invalid args, empty query, `search → show` pipeline
- [x] End-to-end emoji round-trip simulation: new recording (🎯) → save → read → renderer state → Notion payload; old recording (no emoji) → falls back to 📝
- [x] Dev Electron instance boots cleanly from worktree with no console errors
- [ ] Manual GUI check on packaged build: search input appears under "Recent Recordings"; typing filters results; clicking a hit opens transcript modal; Upload to Notion succeeds for both new (emoji-preserving) and old (📝 fallback) transcriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)