### PR TITLE
Redesign main window and modals for resizable macOS-style layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
     </div>
     <p class="subtitle">Record and transcribe your meetings with AI</p>
 
+    <div class="main-layout">
     <div class="recording-section">
       <div class="status-indicator" id="statusIndicator">
         <span class="status-dot"></span>
@@ -87,10 +88,15 @@
         <p class="no-recordings">No recordings yet</p>
       </div>
     </div>
+    </div>
 
     <div id="configModal" class="modal">
-      <div class="modal-content">
-        <h2>API Configuration</h2>
+      <div class="modal-content config-modal">
+        <div class="modal-header">
+          <h2>API Configuration</h2>
+          <button type="button" class="close" id="configClose" aria-label="Close">&times;</button>
+        </div>
+        <div class="config-body">
         <div class="form-group">
           <label for="geminiApiKey">Gemini API Key:</label>
           <input type="password" id="geminiApiKey" placeholder="Enter your Gemini API key">
@@ -155,17 +161,20 @@
           <textarea id="summaryPrompt" rows="10" placeholder="Enter your custom summary prompt..."></textarea>
           <small>Customize the prompt sent to Gemini for generating summaries. The JSON response format (suggestedTitle, summary, keyPoints, actionItems, emoji) should be preserved.</small>
         </div>
-        <div class="modal-buttons">
-          <button id="saveConfig" class="save-button">Save</button>
+        </div>
+        <div class="config-footer">
           <button id="cancelConfig" class="cancel-button">Cancel</button>
+          <button id="saveConfig" class="save-button">Save</button>
         </div>
       </div>
     </div>
 
     <div id="transcriptionModal" class="modal">
       <div class="modal-content transcription-content">
-        <span class="close">&times;</span>
-        <h2 id="transcriptionTitle">Transcription</h2>
+        <div class="modal-header">
+          <h2 id="transcriptionTitle">Transcription</h2>
+          <span class="close">&times;</span>
+        </div>
         <div id="transcriptionProgress" class="progress-container" style="display: none;">
           <div class="progress-bar">
             <div class="progress-fill" id="progressFill"></div>
@@ -183,16 +192,18 @@
             <span class="notion-icon">📝</span> Upload to Notion
           </button>
         </div>
-        <div class="tab-content">
-          <div id="all" class="tab-pane active">
-            <p class="loading">Loading...</p>
-          </div>
-          <div id="summary" class="tab-pane">
-            <p class="loading">Loading summary...</p>
-          </div>
-          <!-- dynamic panes inserted here by JS -->
-          <div id="transcript" class="tab-pane">
-            <p class="loading">Loading transcription...</p>
+        <div class="transcription-body">
+          <div class="tab-content">
+            <div id="all" class="tab-pane active">
+              <p class="loading">Loading...</p>
+            </div>
+            <div id="summary" class="tab-pane">
+              <p class="loading">Loading summary...</p>
+            </div>
+            <!-- dynamic panes inserted here by JS -->
+            <div id="transcript" class="tab-pane">
+              <p class="loading">Loading transcription...</p>
+            </div>
           </div>
         </div>
       </div>

--- a/renderer.js
+++ b/renderer.js
@@ -209,7 +209,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     notionDatabaseIdInput = document.getElementById('notionDatabaseId');
     globalShortcutInput = document.getElementById('globalShortcut');
     knownWordsInput = document.getElementById('knownWords');
-    closeTranscriptionBtn = document.querySelector('.close');
+    closeTranscriptionBtn = document.querySelector('#transcriptionModal .close');
     uploadToNotionBtn = document.getElementById('uploadToNotion');
     progressContainer = document.getElementById('transcriptionProgress');
     progressFill = document.getElementById('progressFill');
@@ -582,9 +582,10 @@ function setupEventListeners() {
     }
   });
 
-  cancelConfigBtn.addEventListener('click', () => {
-    configModal.style.display = 'none';
-  });
+  const hideConfig = () => { configModal.style.display = 'none'; };
+  cancelConfigBtn.addEventListener('click', hideConfig);
+  const configCloseBtn = document.getElementById('configClose');
+  if (configCloseBtn) configCloseBtn.addEventListener('click', hideConfig);
 
   // Global shortcut input handling
   if (globalShortcutInput) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,6 +155,8 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1000,
     height: 700,
+    minWidth: 480,
+    minHeight: 520,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,

--- a/styles.css
+++ b/styles.css
@@ -34,9 +34,22 @@ body {
 }
 
 .container {
-  max-width: 600px;
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 40px 20px;
+  padding: 28px 24px 32px;
+}
+
+.main-layout {
+  display: grid;
+  grid-template-columns: minmax(340px, 420px) 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+@media (max-width: 780px) {
+  .main-layout {
+    grid-template-columns: 1fr;
+  }
 }
 
 h1 {
@@ -76,15 +89,15 @@ h1 {
 .subtitle {
   text-align: center;
   color: #7f8c8d;
-  margin-bottom: 40px;
+  margin-bottom: 24px;
 }
 
 .recording-section {
   background: white;
   border-radius: 12px;
-  padding: 30px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  margin-bottom: 30px;
+  padding: 24px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.04);
 }
 
 .status-indicator {
@@ -189,13 +202,15 @@ h1 {
 .recordings-section {
   background: white;
   border-radius: 12px;
-  padding: 30px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  padding: 24px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.04);
 }
 
 .recordings-section h2 {
   color: #2c3e50;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
+  font-size: 18px;
 }
 
 .recordings-header {
@@ -224,7 +239,7 @@ h1 {
 }
 
 .recordings-list {
-  max-height: 300px;
+  max-height: calc(100vh - 260px);
   overflow-y: auto;
 }
 
@@ -290,10 +305,114 @@ h1 {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
 }
 
-.transcription-content {
-  max-width: 800px;
-  max-height: 80vh;
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 24px;
+  border-bottom: 1px solid #ecf0f1;
+  flex: 0 0 auto;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 18px;
+  color: #2c3e50;
+}
+
+.modal-header .close {
+  float: none;
+  font-size: 24px;
+  line-height: 1;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: none;
+  border: none;
+  color: #95a5a6;
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.modal-header .close:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+  color: #2c3e50;
+}
+
+.config-modal {
+  max-width: 640px;
+  width: 92%;
+  max-height: 88vh;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.config-body {
+  padding: 20px 24px;
   overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.config-body .form-group {
+  margin-bottom: 16px;
+}
+
+.config-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 14px 24px;
+  border-top: 1px solid #ecf0f1;
+  background-color: #fafbfc;
+  flex: 0 0 auto;
+}
+
+.transcription-content {
+  max-width: 860px;
+  width: 92%;
+  max-height: 88vh;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.transcription-content .transcription-header {
+  padding: 10px 24px 0;
+  margin-bottom: 0;
+  border-bottom: 2px solid #ecf0f1;
+  flex: 0 0 auto;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.transcription-content .transcription-tabs {
+  border-bottom: none;
+  margin-bottom: 0;
+  flex-wrap: wrap;
+}
+
+.transcription-content .tab-button {
+  padding: 8px 14px;
+  margin-bottom: -2px;
+}
+
+.transcription-content .notion-button {
+  align-self: center;
+  padding: 8px 14px;
+  font-size: 13px;
+  margin-bottom: 4px;
+}
+
+.transcription-body {
+  overflow-y: auto;
+  flex: 1 1 auto;
+  padding: 4px 24px 16px;
+}
+
+.transcription-content #transcriptionProgress {
+  margin: 0 24px;
 }
 
 .release-notes-body {
@@ -805,34 +924,39 @@ h1 {
 
 /* Auto mode toggle styles */
 .auto-mode-container {
-  margin-top: 20px;
-  padding-top: 20px;
+  margin-top: 16px;
+  padding-top: 16px;
   border-top: 1px solid #ecf0f1;
 }
 
 .toggle-container {
-  display: flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 12px;
+  row-gap: 4px;
   cursor: pointer;
   user-select: none;
+  align-items: center;
 }
 
 .toggle-container input[type="checkbox"] {
-  margin-right: 10px;
+  grid-row: 1 / span 2;
   width: 18px;
   height: 18px;
   cursor: pointer;
+  margin: 0;
 }
 
 .toggle-label {
   font-weight: 600;
   color: #2c3e50;
-  margin-right: 10px;
+  font-size: 14px;
 }
 
 .toggle-description {
-  font-size: 13px;
+  font-size: 12px;
   color: #7f8c8d;
+  line-height: 1.4;
 }
 
 /* Progress bar styles */


### PR DESCRIPTION
## Summary

The fixed-width 600px container made the window feel tiny and empty once resized or snapped with Rectangle. Config and transcription modals also cut off — title/tabs scrolled out of view and Save/Cancel required scrolling to reach.

## Changes

**Main window**
- Two-pane layout (recording controls | recordings list) that stacks below 780px; container grows to 1200px max
- `BrowserWindow` min size 480×520 so half/quarter-screen snaps stay usable
- Toggle rows switched to CSS grid so label + description stop wrapping awkwardly in the narrower left pane

**Modals**
- Shared `.modal-header` with sticky title + close (×) button; modal bodies scroll while footers stay pinned
- Config modal: 500 → 640px, explicit × close wired through a single `hideConfig` handler
- Transcription modal: 800 → 860px; tabs + "Upload to Notion" stay reachable through long transcripts

**Fix**
- `document.querySelector('.close')` was matching the new config close button and breaking the transcription modal's ×. Scoped to `#transcriptionModal .close`.

## Test plan

- [ ] Open the app, resize freely, Rectangle-snap to left/right halves — layout stays usable
- [ ] Open ⚙️ config, scroll through fields — title + Save/Cancel stay pinned, × closes
- [ ] Open a transcription — title + tabs + Upload to Notion stay pinned while scrolling; × closes
- [ ] Narrow the window below 780px — recording and recordings sections stack cleanly
- [ ] Empty recordings state — right panel is compact, not forced-tall

🤖 Generated with [Claude Code](https://claude.com/claude-code)