### PR TITLE
Add AI agent chat for meetings and settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,23 @@
     </div>
     </div>
 
+    <div class="chat-section" id="chatSection">
+      <div class="chat-header">
+        <h2>💬 Ask Listener</h2>
+        <button id="chatToggleButton" class="chat-toggle" aria-label="Toggle chat" aria-expanded="false">▾</button>
+      </div>
+      <div class="chat-body" id="chatBody" style="display: none;">
+        <div class="chat-messages" id="chatMessages" role="log" aria-live="polite">
+          <p class="chat-empty">Ask about any saved meeting, or say things like <em>"enable auto mode"</em> or <em>"change the shortcut to Cmd+Shift+R"</em>. I'll always confirm before changing a setting.</p>
+        </div>
+        <form class="chat-input-row" id="chatForm">
+          <input type="text" id="chatInput" class="chat-input" placeholder="Ask Listener anything..." autocomplete="off" spellcheck="false" />
+          <button type="submit" id="chatSend" class="chat-send-button">Send</button>
+        </form>
+        <p class="chat-hint">Credentials (API keys, Notion DB ID) can't be changed here — use the settings dialog.</p>
+      </div>
+    </div>
+
     <div id="configModal" class="modal">
       <div class="modal-content config-modal">
         <div class="modal-header">
@@ -190,6 +207,7 @@
             <button class="tab-button" data-tab="summary">Summary</button>
             <!-- dynamic tabs inserted here by JS -->
             <button class="tab-button" data-tab="transcript">Transcript</button>
+            <button class="tab-button" data-tab="ask">💬 Ask</button>
           </div>
           <button id="uploadToNotion" class="notion-button" style="display: none;">
             <span class="notion-icon">📝</span> Upload to Notion
@@ -207,6 +225,15 @@
             <div id="transcript" class="tab-pane">
               <p class="loading">Loading transcription...</p>
             </div>
+          </div>
+          <div id="ask" class="tab-pane chat-pane">
+            <div class="chat-messages" id="modalChatMessages" role="log" aria-live="polite">
+              <p class="chat-empty">Ask anything about this meeting -- "What were the action items?", "Summarize the risks mentioned", etc.</p>
+            </div>
+            <form class="chat-input-row" id="modalChatForm">
+              <input type="text" id="modalChatInput" class="chat-input" placeholder="Ask about this meeting..." autocomplete="off" spellcheck="false" />
+              <button type="submit" id="modalChatSend" class="chat-send-button">Send</button>
+            </form>
           </div>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
     "dist/geminiService.js",
     "dist/outputService.js",
     "dist/searchService.js",
+    "dist/agentService.js",
     "dist/services/ffmpegManager.js"
   ],
   "scripts": {
     "start": "pnpm run build && electron .",
     "build": "tsc",
-    "test": "tsc && node --test dist/meetingDetectorService.test.js dist/searchService.test.js",
+    "test": "tsc && node --test dist/meetingDetectorService.test.js dist/searchService.test.js dist/agentService.test.js",
     "dist": "pnpm run build && electron-builder",
     "dist:mac": "pnpm run build && electron-builder --mac",
     "dist:mac-x64": "pnpm run build && electron-builder --mac --x64",

--- a/renderer.js
+++ b/renderer.js
@@ -245,6 +245,9 @@ window.addEventListener('DOMContentLoaded', async () => {
     }
 
     setupSearch();
+    setupHomeChat();
+    setupModalChat();
+    setupAgentConfirmHandler();
 
     // Load existing recordings
     await loadRecordings();
@@ -264,39 +267,38 @@ window.addEventListener('DOMContentLoaded', async () => {
     </div>`;
   }
 
-  // Load auto mode preference
-  const config = await window.electronAPI.getConfig();
-  if (config.autoMode !== undefined) {
-    autoModeToggle.checked = config.autoMode;
-  }
-
-  // Save auto mode preference when toggled
-  autoModeToggle.addEventListener('change', async () => {
-    await window.electronAPI.saveConfig({ autoMode: autoModeToggle.checked });
-  });
-
-  // Meeting detection toggle
+  // Home-screen toggles reflect current config. Both the user toggling them and
+  // the agent applying a set_config write should land here -- the agent path
+  // goes through the 'config-changed' event subscription below.
   const meetingDetectionToggle = document.getElementById('meetingDetectionToggle');
   const meetingDetectionStatus = document.getElementById('meetingDetectionStatus');
   const meetingDetectionApp = document.getElementById('meetingDetectionApp');
+  const displayDetectionToggle = document.getElementById('displayDetectionToggle');
 
-  if (config.meetingDetection !== undefined) {
-    meetingDetectionToggle.checked = config.meetingDetection;
+  function applyHomeTogglesFromConfig(cfg) {
+    if (!cfg) return;
+    if (cfg.autoMode !== undefined) autoModeToggle.checked = !!cfg.autoMode;
+    if (cfg.meetingDetection !== undefined) meetingDetectionToggle.checked = !!cfg.meetingDetection;
+    if (cfg.displayDetection !== undefined) displayDetectionToggle.checked = !!cfg.displayDetection;
   }
 
+  const config = await window.electronAPI.getConfig();
+  applyHomeTogglesFromConfig(config);
+
+  autoModeToggle.addEventListener('change', async () => {
+    await window.electronAPI.saveConfig({ autoMode: autoModeToggle.checked });
+  });
   meetingDetectionToggle.addEventListener('change', async () => {
     await window.electronAPI.saveConfig({ meetingDetection: meetingDetectionToggle.checked });
   });
-
-  // Display detection toggle
-  const displayDetectionToggle = document.getElementById('displayDetectionToggle');
-
-  if (config.displayDetection !== undefined) {
-    displayDetectionToggle.checked = config.displayDetection;
-  }
-
   displayDetectionToggle.addEventListener('change', async () => {
     await window.electronAPI.saveConfig({ displayDetection: displayDetectionToggle.checked });
+  });
+
+  // Agent-applied config writes arrive here so the home toggles stay in sync
+  // without requiring the user to reopen the settings dialog.
+  window.electronAPI.onConfigChanged((cfg) => {
+    applyHomeTogglesFromConfig(cfg);
   });
 
   // Listen for meeting status changes
@@ -865,7 +867,7 @@ function populateTranscriptionUI(data) {
 }
 
 // Function to show saved transcript
-function showSavedTranscript(filePath, title, metadata) {
+function showSavedTranscript(filePath, title, metadata, folderName) {
   // Make sure modal elements are loaded
   if (!transcriptionModal) {
     transcriptionModal = document.getElementById('transcriptionModal');
@@ -893,6 +895,9 @@ function showSavedTranscript(filePath, title, metadata) {
     };
     currentMeetingTitle = title;
     currentFilePath = filePath;
+
+    // Prefer an explicit folderName; fall back to the one get-metadata attaches.
+    resetModalChatFor(folderName || (metadata && metadata.folderName) || null);
 
     populateTranscriptionUI(currentTranscriptionData);
 
@@ -946,6 +951,7 @@ async function handleTranscribe(filePath, title) {
   document.getElementById('all').innerHTML = '<p class="loading">Loading...</p>';
   document.getElementById('summary').innerHTML = '<p class="loading">Loading summary...</p>';
   document.getElementById('transcript').innerHTML = '<p class="loading">Loading transcription...</p>';
+  resetModalChatFor(null);
   document.querySelectorAll('.tab-button.dynamic').forEach(el => el.remove());
   document.querySelectorAll('.tab-pane.dynamic').forEach(el => el.remove());
   document.querySelectorAll('.tab-button').forEach(b => b.classList.remove('active'));
@@ -1302,7 +1308,7 @@ function createSearchResultItem(hit) {
   viewBtn.className = 'action-button view-transcript-btn';
   viewBtn.textContent = 'View Transcript';
   viewBtn.addEventListener('click', () => {
-    showSavedTranscript(hit.audioFilePath || '', hit.title, hit.data);
+    showSavedTranscript(hit.audioFilePath || '', hit.title, hit.data, hit.folderName);
   });
   actions.appendChild(viewBtn);
   item.appendChild(actions);
@@ -1658,5 +1664,206 @@ function setupPasteListener() {
         dragDropZone.removeAttribute('data-paste-hint');
       }
     }
+  });
+}
+
+// --- Chat (AI agent) --------------------------------------------------------
+//
+// Two chat views share one implementation:
+//   - Home chat: scope = { kind: 'all' } (searches across every saved meeting).
+//   - Modal chat: scope = { kind: 'single', folderName } (one specific meeting).
+//
+// During an in-flight agentChat call, the main process may emit
+// 'agent-confirm-request' so the user can approve a setting change. We route
+// those confirmation bubbles into whichever chat is currently awaiting a reply
+// (tracked via activeChatMessagesEl).
+
+let activeChatMessagesEl = null;
+let currentModalScope = null; // { kind: 'single', folderName } once a transcript is open
+
+function createChatController({ messagesEl, form, input, sendBtn, scopeProvider, emptyEl }) {
+  let history = [];
+  let busy = false;
+
+  function appendMessage(role, text, { pending = false, html = false } = {}) {
+    if (emptyEl && emptyEl.parentNode) {
+      emptyEl.remove();
+    }
+    const el = document.createElement('div');
+    el.className = `chat-message chat-${role}${pending ? ' chat-pending' : ''}`;
+    if (html) el.innerHTML = text;
+    else el.textContent = text;
+    messagesEl.appendChild(el);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+    return el;
+  }
+
+  async function submit(question) {
+    if (!question || busy) return;
+    busy = true;
+    sendBtn.disabled = true;
+    input.disabled = true;
+
+    appendMessage('user', question);
+    input.value = '';
+    const pending = appendMessage('model', 'Thinking...', { pending: true });
+
+    const priorActiveChat = activeChatMessagesEl;
+    activeChatMessagesEl = messagesEl;
+
+    try {
+      const scope = scopeProvider();
+      if (!scope) {
+        pending.remove();
+        appendMessage('error', 'No meeting context. Open a transcript first.');
+        return;
+      }
+      const result = await window.electronAPI.agentChat({ question, history, scope });
+      pending.remove();
+      if (result && result.success) {
+        appendMessage('model', result.result.answer || '(no answer)');
+        history = result.result.history || history;
+        if (result.result.appliedActions && result.result.appliedActions.length > 0) {
+          for (const action of result.result.appliedActions) {
+            appendMessage('system', `Applied: ${action.key} = ${JSON.stringify(action.value)}`);
+          }
+        }
+      } else {
+        appendMessage('error', (result && result.error) || 'Agent failed.');
+      }
+    } catch (err) {
+      pending.remove();
+      appendMessage('error', err && err.message ? err.message : String(err));
+    } finally {
+      activeChatMessagesEl = priorActiveChat;
+      busy = false;
+      sendBtn.disabled = false;
+      input.disabled = false;
+      input.focus();
+    }
+  }
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    submit(input.value.trim());
+  });
+
+  function reset() {
+    history = [];
+    messagesEl.innerHTML = '';
+    if (emptyEl) messagesEl.appendChild(emptyEl);
+  }
+
+  return { submit, reset };
+}
+
+let homeChat = null;
+let modalChat = null;
+
+function setupHomeChat() {
+  const section = document.getElementById('chatSection');
+  const header = section ? section.querySelector('.chat-header') : null;
+  const toggle = document.getElementById('chatToggleButton');
+  const body = document.getElementById('chatBody');
+  const form = document.getElementById('chatForm');
+  const input = document.getElementById('chatInput');
+  const sendBtn = document.getElementById('chatSend');
+  const messagesEl = document.getElementById('chatMessages');
+  if (!section || !header || !toggle || !body || !form || !input || !sendBtn || !messagesEl) return;
+
+  const emptyEl = messagesEl.querySelector('.chat-empty');
+
+  const doToggle = () => {
+    const expanded = body.style.display !== 'none';
+    body.style.display = expanded ? 'none' : 'flex';
+    toggle.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+    section.classList.toggle('expanded', !expanded);
+    if (!expanded) input.focus();
+  };
+  header.addEventListener('click', (e) => {
+    // Only toggle when clicking empty header space or the toggle button.
+    if (e.target === header || e.target === toggle || e.target === header.querySelector('h2')) {
+      doToggle();
+    }
+  });
+
+  homeChat = createChatController({
+    messagesEl,
+    form,
+    input,
+    sendBtn,
+    emptyEl,
+    scopeProvider: () => ({ kind: 'all' }),
+  });
+}
+
+function setupModalChat() {
+  const form = document.getElementById('modalChatForm');
+  const input = document.getElementById('modalChatInput');
+  const sendBtn = document.getElementById('modalChatSend');
+  const messagesEl = document.getElementById('modalChatMessages');
+  if (!form || !input || !sendBtn || !messagesEl) return;
+
+  const emptyEl = messagesEl.querySelector('.chat-empty');
+
+  modalChat = createChatController({
+    messagesEl,
+    form,
+    input,
+    sendBtn,
+    emptyEl,
+    scopeProvider: () => currentModalScope,
+  });
+}
+
+function resetModalChatFor(folderName) {
+  currentModalScope = folderName ? { kind: 'single', folderName } : null;
+  if (modalChat) modalChat.reset();
+  const input = document.getElementById('modalChatInput');
+  const sendBtn = document.getElementById('modalChatSend');
+  if (input && sendBtn) {
+    const available = !!folderName;
+    input.disabled = !available;
+    sendBtn.disabled = !available;
+    input.placeholder = available
+      ? 'Ask about this meeting...'
+      : 'Transcript not saved -- ask unavailable';
+  }
+}
+
+function setupAgentConfirmHandler() {
+  window.electronAPI.onAgentConfirmRequest(({ id, proposal }) => {
+    const target = activeChatMessagesEl;
+    if (!target) {
+      const ok = window.confirm(`${proposal.description}\n\nApply change?`);
+      window.electronAPI.sendAgentConfirmResponse({ id, approved: ok });
+      return;
+    }
+    const el = document.createElement('div');
+    el.className = 'chat-message chat-confirm';
+    const desc = document.createElement('p');
+    desc.textContent = proposal.description;
+    el.appendChild(desc);
+    const btnRow = document.createElement('div');
+    btnRow.className = 'chat-confirm-buttons';
+    const yes = document.createElement('button');
+    yes.className = 'chat-confirm-yes';
+    yes.textContent = 'Apply';
+    const no = document.createElement('button');
+    no.className = 'chat-confirm-no';
+    no.textContent = 'Cancel';
+    btnRow.appendChild(yes);
+    btnRow.appendChild(no);
+    el.appendChild(btnRow);
+    target.appendChild(el);
+    target.scrollTop = target.scrollHeight;
+
+    const respond = (approved) => {
+      yes.disabled = true;
+      no.disabled = true;
+      window.electronAPI.sendAgentConfirmResponse({ id, approved });
+    };
+    yes.addEventListener('click', () => respond(true));
+    no.addEventListener('click', () => respond(false));
   });
 }

--- a/renderer.js
+++ b/renderer.js
@@ -1698,6 +1698,31 @@ function createChatController({ messagesEl, form, input, sendBtn, scopeProvider,
     return el;
   }
 
+  // Pending bubble carries a Stop affordance so the user can bail out of a
+  // set_config confirmation they no longer want to answer -- clicking it
+  // rejects any in-flight confirm so the agent call unwinds and the input
+  // re-enables, breaking the deadlock Gemini review flagged.
+  function appendPendingBubble() {
+    if (emptyEl && emptyEl.parentNode) emptyEl.remove();
+    const el = document.createElement('div');
+    el.className = 'chat-message chat-model chat-pending';
+    const label = document.createElement('span');
+    label.textContent = 'Thinking...';
+    const stop = document.createElement('button');
+    stop.type = 'button';
+    stop.className = 'chat-pending-stop';
+    stop.textContent = 'Stop';
+    stop.addEventListener('click', () => {
+      stop.disabled = true;
+      window.electronAPI.cancelAgentPending();
+    });
+    el.appendChild(label);
+    el.appendChild(stop);
+    messagesEl.appendChild(el);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+    return el;
+  }
+
   async function submit(question) {
     if (!question || busy) return;
     busy = true;
@@ -1706,7 +1731,7 @@ function createChatController({ messagesEl, form, input, sendBtn, scopeProvider,
 
     appendMessage('user', question);
     input.value = '';
-    const pending = appendMessage('model', 'Thinking...', { pending: true });
+    const pending = appendPendingBubble();
 
     const priorActiveChat = activeChatMessagesEl;
     activeChatMessagesEl = messagesEl;

--- a/src/agentService.test.ts
+++ b/src/agentService.test.ts
@@ -1,0 +1,106 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  coerceConfigValue,
+  describeProposal,
+  WRITABLE_CONFIG_KEYS,
+  READABLE_CONFIG_KEYS,
+  type WritableConfigKey,
+} from './agentService';
+
+describe('coerceConfigValue', () => {
+  it('accepts native booleans for toggle keys', () => {
+    const r = coerceConfigValue('autoMode', true);
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.value, true);
+  });
+
+  it('accepts "true"/"false" strings for toggle keys', () => {
+    const t = coerceConfigValue('meetingDetection', 'true');
+    const f = coerceConfigValue('displayDetection', 'false');
+    assert.equal(t.ok, true);
+    assert.equal(f.ok, true);
+    if (t.ok) assert.equal(t.value, true);
+    if (f.ok) assert.equal(f.value, false);
+  });
+
+  it('rejects garbage for toggle keys', () => {
+    const r = coerceConfigValue('autoMode', 'yes');
+    assert.equal(r.ok, false);
+  });
+
+  it('accepts non-empty strings for globalShortcut, trims, rejects empty', () => {
+    const ok = coerceConfigValue('globalShortcut', '  CmdOrCtrl+Shift+L  ');
+    const bad = coerceConfigValue('globalShortcut', '  ');
+    assert.equal(ok.ok, true);
+    if (ok.ok) assert.equal(ok.value, 'CmdOrCtrl+Shift+L');
+    assert.equal(bad.ok, false);
+  });
+
+  it('accepts numeric strings and numbers for minute keys, floors them, rejects negatives', () => {
+    const num = coerceConfigValue('maxRecordingMinutes', 30);
+    const str = coerceConfigValue('recordingReminderMinutes', '45');
+    const frac = coerceConfigValue('minRecordingSeconds', 5.9);
+    const neg = coerceConfigValue('maxRecordingMinutes', -1);
+    const nan = coerceConfigValue('maxRecordingMinutes', 'soon');
+    assert.equal(num.ok, true);
+    assert.equal(str.ok, true);
+    assert.equal(frac.ok, true);
+    assert.equal(neg.ok, false);
+    assert.equal(nan.ok, false);
+    if (num.ok) assert.equal(num.value, 30);
+    if (str.ok) assert.equal(str.value, 45);
+    if (frac.ok) assert.equal(frac.value, 5);
+  });
+});
+
+describe('config key whitelists', () => {
+  it('does not include API credentials or database IDs in writable keys', () => {
+    const dangerous = ['geminiApiKey', 'notionApiKey', 'notionDatabaseId'];
+    for (const k of dangerous) {
+      assert.equal(
+        (WRITABLE_CONFIG_KEYS as readonly string[]).includes(k),
+        false,
+        `${k} must not be agent-writable`,
+      );
+      assert.equal(
+        (READABLE_CONFIG_KEYS as readonly string[]).includes(k),
+        false,
+        `${k} must not be agent-readable`,
+      );
+    }
+  });
+
+  it('exposes expected writable toggles and numbers', () => {
+    const expected: WritableConfigKey[] = [
+      'autoMode',
+      'meetingDetection',
+      'displayDetection',
+      'globalShortcut',
+      'maxRecordingMinutes',
+      'recordingReminderMinutes',
+      'minRecordingSeconds',
+    ];
+    for (const k of expected) {
+      assert.ok(
+        (WRITABLE_CONFIG_KEYS as readonly string[]).includes(k),
+        `${k} should be writable`,
+      );
+    }
+  });
+});
+
+describe('describeProposal', () => {
+  it('formats toggle flip with reason', () => {
+    const s = describeProposal('autoMode', true, false, 'enable hands-free upload');
+    assert.match(s, /autoMode/);
+    assert.match(s, /false -> true/);
+    assert.match(s, /enable hands-free upload/);
+  });
+
+  it('handles unset previous values', () => {
+    const s = describeProposal('globalShortcut', 'Cmd+Shift+R', undefined);
+    assert.match(s, /\(unset\)/);
+    assert.match(s, /"Cmd\+Shift\+R"/);
+  });
+});

--- a/src/agentService.test.ts
+++ b/src/agentService.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   coerceConfigValue,
   describeProposal,
+  isValidFolderName,
   WRITABLE_CONFIG_KEYS,
   READABLE_CONFIG_KEYS,
   type WritableConfigKey,
@@ -102,5 +103,32 @@ describe('describeProposal', () => {
     const s = describeProposal('globalShortcut', 'Cmd+Shift+R', undefined);
     assert.match(s, /\(unset\)/);
     assert.match(s, /"Cmd\+Shift\+R"/);
+  });
+});
+
+describe('isValidFolderName', () => {
+  it('accepts names produced by saveTranscription', () => {
+    assert.equal(isValidFolderName('Q4_OKR_Sync_20260201_140000'), true);
+    assert.equal(isValidFolderName('meeting with spaces_20260201_140000'), true);
+  });
+
+  it('rejects path traversal attempts', () => {
+    assert.equal(isValidFolderName('..'), false);
+    assert.equal(isValidFolderName('../etc/passwd'), false);
+    assert.equal(isValidFolderName('foo/bar'), false);
+    assert.equal(isValidFolderName('foo\\bar'), false);
+    assert.equal(isValidFolderName('foo\0bar'), false);
+  });
+
+  it('rejects empty and dotfile-style names', () => {
+    assert.equal(isValidFolderName(''), false);
+    assert.equal(isValidFolderName('.'), false);
+    assert.equal(isValidFolderName('.hidden'), false);
+  });
+
+  it('rejects non-string input', () => {
+    assert.equal(isValidFolderName(null as unknown as string), false);
+    assert.equal(isValidFolderName(undefined as unknown as string), false);
+    assert.equal(isValidFolderName(42 as unknown as string), false);
   });
 });

--- a/src/agentService.ts
+++ b/src/agentService.ts
@@ -21,6 +21,11 @@ export type AgentConfirmHandler = (proposal: ConfigProposal) => Promise<boolean>
 export interface AgentChatMessage {
   role: 'user' | 'model';
   text: string;
+  // Raw Gemini turns belonging to this message (model turns may carry
+  // function_call parts, with the matching tool-response user turns interleaved).
+  // Preserved so the next run sees the full tool-use history, not just text.
+  // Only populated on model messages produced by `run`.
+  turns?: Content[];
 }
 
 export interface AgentRunOptions {
@@ -186,6 +191,16 @@ function systemInstructionFor(scope: AgentScope, currentTranscriptionTitle?: str
   return `${common}\n\nScope: ALL saved meetings. Use search_transcriptions to find relevant meetings (title/summary/key points are searched by default; pass include_transcript=true if keywords are likely only in the transcript body). Use list_recent_transcriptions for "recent/latest" questions. Use get_transcription to read a specific meeting when you have its folder name.`;
 }
 
+/** Reject folder names that could escape the transcriptions directory. A valid
+ *  entry produced by `saveTranscription` never contains path separators, so we
+ *  can keep the guard simple without duplicating the sanitizer. */
+export function isValidFolderName(name: string): boolean {
+  if (typeof name !== 'string' || name === '' || name === '.' || name === '..') return false;
+  if (name.includes('/') || name.includes('\\') || name.includes('\0')) return false;
+  if (name.startsWith('.')) return false;
+  return true;
+}
+
 function buildSinglePrimer(data: ReadTranscriptionResult): string {
   const lines: string[] = [];
   lines.push(`[Context: meeting "${data.title}"${data.transcribedAt ? ` recorded ${data.transcribedAt.slice(0, 10)}` : ''}]`);
@@ -206,10 +221,17 @@ function buildSinglePrimer(data: ReadTranscriptionResult): string {
 }
 
 function historyToContents(history: AgentChatMessage[]): Content[] {
-  return history.map((m) => ({
-    role: m.role,
-    parts: [{ text: m.text }],
-  }));
+  const out: Content[] = [];
+  for (const m of history) {
+    // Model messages replay their full turn cluster (text + function calls +
+    // tool responses) so the agent can reason about prior tool use.
+    if (m.role === 'model' && m.turns && m.turns.length > 0) {
+      out.push(...m.turns);
+      continue;
+    }
+    out.push({ role: m.role, parts: [{ text: m.text }] });
+  }
+  return out;
 }
 
 function extractFinalText(parts: Part[] | undefined): string {
@@ -248,21 +270,27 @@ export class AgentService {
     const tools = buildTools(opts.scope, !!opts.confirm);
 
     // Load the single-meeting record once if needed; title + primer derive from it.
-    const singleData = opts.scope.kind === 'single'
+    const singleData = opts.scope.kind === 'single' && isValidFolderName(opts.scope.folderName)
       ? readTranscription(path.join(getTranscriptionsDir(this.dataPath), opts.scope.folderName))
       : null;
     const systemInstruction = systemInstructionFor(opts.scope, singleData?.title);
 
     const history = opts.history ? [...opts.history] : [];
-    const contents: Content[] = historyToContents(history);
 
+    // For single-meeting scope the primer must precede all prior turns so the
+    // model sees the meeting context before its own earlier responses about it.
+    const contents: Content[] = [];
     if (singleData) {
-      const primer = buildSinglePrimer(singleData);
-      contents.push({ role: 'user', parts: [{ text: primer }] });
+      contents.push({ role: 'user', parts: [{ text: buildSinglePrimer(singleData) }] });
     }
+    for (const c of historyToContents(history)) contents.push(c);
 
     contents.push({ role: 'user', parts: [{ text: opts.question }] });
     history.push({ role: 'user', text: opts.question });
+
+    // Track turns added from here on so they can be attached to the model
+    // message for multi-turn tool memory.
+    const modelTurnsStart = contents.length;
 
     const applied: AppliedAction[] = [];
     let finalAnswer = '';
@@ -312,7 +340,8 @@ export class AgentService {
       finalAnswer = '(no answer produced within step limit)';
     }
 
-    history.push({ role: 'model', text: finalAnswer });
+    const modelTurns = contents.slice(modelTurnsStart);
+    history.push({ role: 'model', text: finalAnswer, turns: modelTurns });
     return { answer: finalAnswer, appliedActions: applied, history };
   }
 
@@ -355,7 +384,7 @@ export class AgentService {
         }
         case 'get_transcription': {
           const folderName = typeof args.folder_name === 'string' ? args.folder_name : '';
-          if (!folderName) return { error: 'folder_name is required' };
+          if (!isValidFolderName(folderName)) return { error: 'folder_name must be a bare folder name returned by search/list (no slashes, no ..)' };
           const folderPath = path.join(getTranscriptionsDir(this.dataPath), folderName);
           const data = readTranscription(folderPath);
           if (!data) return { error: `transcription not found: ${folderName}` };

--- a/src/agentService.ts
+++ b/src/agentService.ts
@@ -1,0 +1,408 @@
+import { GoogleGenAI, Type, type Content, type FunctionCall, type FunctionDeclaration, type Part } from '@google/genai';
+import * as path from 'path';
+import type { ConfigService } from './configService';
+import { searchTranscriptions, ALL_FIELDS, type SearchField } from './searchService';
+import { listTranscriptions, readTranscription, getTranscriptionsDir, type ReadTranscriptionResult } from './outputService';
+
+export type AgentScope =
+  | { kind: 'all' }
+  | { kind: 'single'; folderName: string };
+
+export interface ConfigProposal {
+  kind: 'setConfig';
+  key: WritableConfigKey;
+  value: unknown;
+  currentValue?: unknown;
+  description: string;
+}
+
+export type AgentConfirmHandler = (proposal: ConfigProposal) => Promise<boolean>;
+
+export interface AgentChatMessage {
+  role: 'user' | 'model';
+  text: string;
+}
+
+export interface AgentRunOptions {
+  question: string;
+  history?: AgentChatMessage[];
+  scope: AgentScope;
+  confirm?: AgentConfirmHandler;
+  model?: string;
+  maxSteps?: number;
+}
+
+export interface AppliedAction {
+  type: 'setConfig';
+  key: string;
+  value: unknown;
+  previousValue: unknown;
+}
+
+export interface AgentRunResult {
+  answer: string;
+  appliedActions: AppliedAction[];
+  history: AgentChatMessage[];
+}
+
+export const WRITABLE_CONFIG_KEYS = [
+  'autoMode',
+  'meetingDetection',
+  'displayDetection',
+  'globalShortcut',
+  'maxRecordingMinutes',
+  'recordingReminderMinutes',
+  'minRecordingSeconds',
+] as const;
+
+export type WritableConfigKey = typeof WRITABLE_CONFIG_KEYS[number];
+
+export const READABLE_CONFIG_KEYS = [
+  ...WRITABLE_CONFIG_KEYS,
+  'geminiModel',
+  'geminiFlashModel',
+] as const;
+
+export type ReadableConfigKey = typeof READABLE_CONFIG_KEYS[number];
+
+function isWritableKey(key: string): key is WritableConfigKey {
+  return (WRITABLE_CONFIG_KEYS as readonly string[]).includes(key);
+}
+
+function isReadableKey(key: string): key is ReadableConfigKey {
+  return (READABLE_CONFIG_KEYS as readonly string[]).includes(key);
+}
+
+/** Coerce agent-supplied value to the right type per key. */
+export function coerceConfigValue(key: WritableConfigKey, raw: unknown): { ok: true; value: unknown } | { ok: false; error: string } {
+  switch (key) {
+    case 'autoMode':
+    case 'meetingDetection':
+    case 'displayDetection': {
+      if (typeof raw === 'boolean') return { ok: true, value: raw };
+      if (raw === 'true') return { ok: true, value: true };
+      if (raw === 'false') return { ok: true, value: false };
+      return { ok: false, error: `${key} expects a boolean` };
+    }
+    case 'globalShortcut': {
+      if (typeof raw !== 'string' || raw.trim() === '') {
+        return { ok: false, error: `${key} expects a non-empty string` };
+      }
+      return { ok: true, value: raw.trim() };
+    }
+    case 'maxRecordingMinutes':
+    case 'recordingReminderMinutes':
+    case 'minRecordingSeconds': {
+      const n = typeof raw === 'number' ? raw : parseInt(String(raw), 10);
+      if (!Number.isFinite(n) || n < 0) {
+        return { ok: false, error: `${key} expects a non-negative integer` };
+      }
+      return { ok: true, value: Math.floor(n) };
+    }
+  }
+}
+
+function buildTools(scope: AgentScope, hasConfirm: boolean): FunctionDeclaration[] {
+  const tools: FunctionDeclaration[] = [];
+
+  if (scope.kind === 'all') {
+    tools.push({
+      name: 'search_transcriptions',
+      description: 'Full-text search across saved meeting transcriptions. Returns top-k hits with title, date, snippet, and folder name. Use this to find meetings relevant to the user question.',
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          query: { type: Type.STRING, description: 'Search keywords. Can be Korean or English.' },
+          limit: { type: Type.INTEGER, description: 'Max hits to return (default 5).' },
+          include_transcript: { type: Type.BOOLEAN, description: 'Also search the full transcript body (slower). Default false.' },
+        },
+        required: ['query'],
+      },
+    });
+
+    tools.push({
+      name: 'list_recent_transcriptions',
+      description: 'List the most recent saved transcriptions, newest first. Use when the user asks "what did we talk about recently" or "show me yesterday\'s meetings".',
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          limit: { type: Type.INTEGER, description: 'Max entries (default 10).' },
+        },
+      },
+    });
+
+    tools.push({
+      name: 'get_transcription',
+      description: 'Fetch a saved meeting record (summary, key points, action items) by folder name. Pass include_transcript=true only when you need the verbatim transcript body; omit it for summary-level questions to keep the response compact.',
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          folder_name: { type: Type.STRING, description: 'The folderName returned by search_transcriptions or list_recent_transcriptions.' },
+          include_transcript: { type: Type.BOOLEAN, description: 'Include the full transcript body. Default false.' },
+        },
+        required: ['folder_name'],
+      },
+    });
+  }
+
+  tools.push({
+    name: 'get_config',
+    description: 'Read a single Listener.AI setting value. Allowed keys: ' + READABLE_CONFIG_KEYS.join(', ') + '. API keys and database IDs are never readable here.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        key: { type: Type.STRING, description: 'One of: ' + READABLE_CONFIG_KEYS.join(', ') },
+      },
+      required: ['key'],
+    },
+  });
+
+  if (hasConfirm) {
+    tools.push({
+      name: 'set_config',
+      description: 'Propose a change to a Listener.AI setting. Requires user confirmation before taking effect. Allowed keys: ' + WRITABLE_CONFIG_KEYS.join(', ') + '. Do NOT try to set API keys, Notion database ID, or other credentials here.',
+      parameters: {
+        type: Type.OBJECT,
+        properties: {
+          key: { type: Type.STRING, description: 'One of: ' + WRITABLE_CONFIG_KEYS.join(', ') },
+          value: { type: Type.STRING, description: 'The new value. For booleans pass "true"/"false"; for numbers pass the digits as a string; for strings pass the string.' },
+          reason: { type: Type.STRING, description: 'Short human-readable reason shown to the user in the confirmation prompt.' },
+        },
+        required: ['key', 'value'],
+      },
+    });
+  }
+
+  return tools;
+}
+
+function systemInstructionFor(scope: AgentScope, currentTranscriptionTitle?: string): string {
+  const common = `You are the assistant inside Listener.AI, a Korean-first meeting recorder. Answer concisely in the user's language (default to Korean if the question is in Korean). Ground factual claims in tool results — never invent meeting content. If the user asks for something outside your tools (e.g. sending email, starting a recording), politely say you can't do that yet.`;
+
+  if (scope.kind === 'single') {
+    return `${common}\n\nYou are currently focused on a single meeting titled "${currentTranscriptionTitle ?? 'this meeting'}". The full transcription data is already provided in the conversation. Prefer answering directly from that data. Do not call search_transcriptions or list_recent_transcriptions in this mode — they are disabled. You may still read or change app settings via get_config / set_config (set_config always requires user confirmation).`;
+  }
+
+  return `${common}\n\nScope: ALL saved meetings. Use search_transcriptions to find relevant meetings (title/summary/key points are searched by default; pass include_transcript=true if keywords are likely only in the transcript body). Use list_recent_transcriptions for "recent/latest" questions. Use get_transcription to read a specific meeting when you have its folder name.`;
+}
+
+function buildSinglePrimer(data: ReadTranscriptionResult): string {
+  const lines: string[] = [];
+  lines.push(`[Context: meeting "${data.title}"${data.transcribedAt ? ` recorded ${data.transcribedAt.slice(0, 10)}` : ''}]`);
+  if (data.summary) lines.push(`Summary: ${data.summary}`);
+  if (data.keyPoints?.length) {
+    lines.push('Key points:');
+    for (const p of data.keyPoints) lines.push(`- ${p}`);
+  }
+  if (data.actionItems?.length) {
+    lines.push('Action items:');
+    for (const a of data.actionItems) lines.push(`- ${a}`);
+  }
+  if (data.transcript) {
+    lines.push('Transcript:');
+    lines.push(data.transcript);
+  }
+  return lines.join('\n');
+}
+
+function historyToContents(history: AgentChatMessage[]): Content[] {
+  return history.map((m) => ({
+    role: m.role,
+    parts: [{ text: m.text }],
+  }));
+}
+
+function extractFinalText(parts: Part[] | undefined): string {
+  if (!parts) return '';
+  return parts
+    .map((p) => (typeof p.text === 'string' ? p.text : ''))
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+}
+
+export interface AgentServiceOptions {
+  apiKey: string;
+  dataPath: string;
+  configService: ConfigService;
+  /** Default model for agent reasoning. Falls back to configService.getGeminiFlashModel(). */
+  defaultModel?: string;
+}
+
+export class AgentService {
+  private ai: GoogleGenAI;
+  private dataPath: string;
+  private configService: ConfigService;
+  private defaultModel: string;
+
+  constructor(opts: AgentServiceOptions) {
+    this.ai = new GoogleGenAI({ apiKey: opts.apiKey });
+    this.dataPath = opts.dataPath;
+    this.configService = opts.configService;
+    this.defaultModel = opts.defaultModel ?? opts.configService.getGeminiFlashModel();
+  }
+
+  async run(opts: AgentRunOptions): Promise<AgentRunResult> {
+    const model = opts.model ?? this.defaultModel;
+    const maxSteps = opts.maxSteps ?? 6;
+    const tools = buildTools(opts.scope, !!opts.confirm);
+
+    // Load the single-meeting record once if needed; title + primer derive from it.
+    const singleData = opts.scope.kind === 'single'
+      ? readTranscription(path.join(getTranscriptionsDir(this.dataPath), opts.scope.folderName))
+      : null;
+    const systemInstruction = systemInstructionFor(opts.scope, singleData?.title);
+
+    const history = opts.history ? [...opts.history] : [];
+    const contents: Content[] = historyToContents(history);
+
+    if (singleData) {
+      const primer = buildSinglePrimer(singleData);
+      contents.push({ role: 'user', parts: [{ text: primer }] });
+    }
+
+    contents.push({ role: 'user', parts: [{ text: opts.question }] });
+    history.push({ role: 'user', text: opts.question });
+
+    const applied: AppliedAction[] = [];
+    let finalAnswer = '';
+
+    for (let step = 0; step < maxSteps; step++) {
+      const response = await this.ai.models.generateContent({
+        model,
+        contents,
+        config: {
+          systemInstruction,
+          temperature: 0.3,
+          tools: tools.length > 0 ? [{ functionDeclarations: tools }] : undefined,
+        },
+      });
+
+      const candidate = response.candidates?.[0];
+      const parts: Part[] = candidate?.content?.parts ?? [];
+      const functionCalls: FunctionCall[] = response.functionCalls ?? [];
+
+      // Record model turn verbatim (keeps function call history correct).
+      if (candidate?.content) {
+        contents.push(candidate.content);
+      }
+
+      if (functionCalls.length === 0) {
+        finalAnswer = extractFinalText(parts);
+        break;
+      }
+
+      // Dispatch all tool calls from this turn in parallel. Read-only tools
+      // (search/list/get) benefit directly; set_config awaits a user click but
+      // that still happens concurrently with the reads rather than after them.
+      const results = await Promise.all(
+        functionCalls.map((call) => this.dispatchTool(call, opts, applied)),
+      );
+      const toolResponseParts: Part[] = functionCalls.map((call, i) => ({
+        functionResponse: {
+          id: call.id,
+          name: call.name ?? '',
+          response: results[i],
+        },
+      }));
+      contents.push({ role: 'user', parts: toolResponseParts });
+    }
+
+    if (!finalAnswer) {
+      finalAnswer = '(no answer produced within step limit)';
+    }
+
+    history.push({ role: 'model', text: finalAnswer });
+    return { answer: finalAnswer, appliedActions: applied, history };
+  }
+
+  private async dispatchTool(
+    call: FunctionCall,
+    opts: AgentRunOptions,
+    applied: AppliedAction[],
+  ): Promise<Record<string, unknown>> {
+    const args = (call.args ?? {}) as Record<string, unknown>;
+    try {
+      switch (call.name) {
+        case 'search_transcriptions': {
+          const query = typeof args.query === 'string' ? args.query : '';
+          if (!query.trim()) return { error: 'query is required' };
+          const limit = typeof args.limit === 'number' ? args.limit : 5;
+          const includeTranscript = args.include_transcript === true;
+          const fields: SearchField[] = includeTranscript ? [...ALL_FIELDS] : ['title', 'summary', 'keyPoints', 'actionItems'];
+          const hits = searchTranscriptions(this.dataPath, { query, fields, limit });
+          return {
+            hits: hits.map((h) => ({
+              folder_name: h.entry.folderName,
+              title: h.data.title,
+              transcribed_at: h.entry.transcribedAt,
+              matched_fields: h.matchedFields,
+              snippet: h.snippet,
+              summary: h.data.summary,
+            })),
+          };
+        }
+        case 'list_recent_transcriptions': {
+          const limit = typeof args.limit === 'number' ? args.limit : 10;
+          const entries = listTranscriptions(this.dataPath, limit);
+          return {
+            entries: entries.map((e) => ({
+              folder_name: e.folderName,
+              title: e.title,
+              transcribed_at: e.transcribedAt,
+            })),
+          };
+        }
+        case 'get_transcription': {
+          const folderName = typeof args.folder_name === 'string' ? args.folder_name : '';
+          if (!folderName) return { error: 'folder_name is required' };
+          const folderPath = path.join(getTranscriptionsDir(this.dataPath), folderName);
+          const data = readTranscription(folderPath);
+          if (!data) return { error: `transcription not found: ${folderName}` };
+          const result: Record<string, unknown> = {
+            title: data.title,
+            transcribed_at: data.transcribedAt,
+            summary: data.summary,
+            key_points: data.keyPoints ?? [],
+            action_items: data.actionItems ?? [],
+          };
+          if (args.include_transcript === true) result.transcript = data.transcript;
+          return result;
+        }
+        case 'get_config': {
+          const key = typeof args.key === 'string' ? args.key : '';
+          if (!isReadableKey(key)) return { error: `unknown or non-readable key: ${key}` };
+          const value = (this.configService.getAllConfig() as Record<string, unknown>)[key];
+          return { key, value: value ?? null };
+        }
+        case 'set_config': {
+          if (!opts.confirm) return { error: 'set_config not available in this session' };
+          const key = typeof args.key === 'string' ? args.key : '';
+          if (!isWritableKey(key)) return { error: `key is not settable via agent: ${key}` };
+          const coerced = coerceConfigValue(key, args.value);
+          if (!coerced.ok) return { error: coerced.error };
+          const previousValue = (this.configService.getAllConfig() as Record<string, unknown>)[key];
+          const description = describeProposal(key, coerced.value, previousValue, typeof args.reason === 'string' ? args.reason : undefined);
+          const approved = await opts.confirm({ kind: 'setConfig', key, value: coerced.value, currentValue: previousValue, description });
+          if (!approved) {
+            return { approved: false, note: 'User declined the change.' };
+          }
+          this.configService.updateConfig({ [key]: coerced.value });
+          applied.push({ type: 'setConfig', key, value: coerced.value, previousValue });
+          return { approved: true, key, value: coerced.value };
+        }
+        default:
+          return { error: `unknown tool: ${call.name}` };
+      }
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+}
+
+export function describeProposal(key: WritableConfigKey, value: unknown, current: unknown, reason?: string): string {
+  const currentStr = current === undefined || current === null || current === '' ? '(unset)' : JSON.stringify(current);
+  const valueStr = JSON.stringify(value);
+  const base = `Change ${key}: ${currentStr} -> ${valueStr}`;
+  return reason ? `${base} (${reason})` : base;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { ConfigService } from './configService';
 import { GeminiService } from './geminiService';
 import { saveTranscription, listTranscriptions, parseFrontmatter, getTranscriptionsDir } from './outputService';
 import { searchTranscriptions, resolveFields, ALL_FIELDS, type SearchField } from './searchService';
+import { AgentService, type AgentScope, type ConfigProposal } from './agentService';
 
 const SUPPORTED_EXTENSIONS = new Set([
   '.mp3', '.m4a', '.wav', '.ogg', '.flac', '.aac', '.wma', '.opus', '.webm',
@@ -21,6 +22,8 @@ function usage(): never {
     '                                           Export transcription\n' +
     '       listener search <query> [--limit <n>] [--transcript] [--field <name>]\n' +
     '                                           Search past transcriptions\n' +
+    '       listener ask <question> [--ref <ref>]\n' +
+    '                                           Ask the AI agent about saved meetings or settings\n' +
     '       listener config list|get|set|path   Manage configuration\n' +
     '\n' +
     '<ref> is a number from `listener list` or a folder name.\n' +
@@ -348,6 +351,76 @@ function handleSearch(args: string[]): void {
   }
 }
 
+async function promptYesNo(message: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    process.stderr.write(`${message} [y/N] `);
+    const stdin = process.stdin;
+    const onData = (chunk: Buffer) => {
+      stdin.off('data', onData);
+      stdin.pause();
+      const answer = chunk.toString('utf-8').trim().toLowerCase();
+      resolve(answer === 'y' || answer === 'yes');
+    };
+    stdin.resume();
+    stdin.on('data', onData);
+  });
+}
+
+async function handleAsk(args: string[]): Promise<void> {
+  let question: string | undefined;
+  let ref: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--ref' && i + 1 < args.length) {
+      ref = args[++i];
+      continue;
+    }
+    if (a.startsWith('-')) {
+      process.stderr.write(`Error: Unknown option: ${a}\n`);
+      process.exit(1);
+    }
+    if (!question) { question = a; continue; }
+    process.stderr.write(`Error: Unexpected argument: ${a} (quote multi-word questions)\n`);
+    process.exit(1);
+  }
+
+  if (!question || question.trim() === '') {
+    process.stderr.write('Error: Missing question. Usage: listener ask <question> [--ref <ref>]\n');
+    process.exit(1);
+  }
+
+  const dataPath = getDataPath();
+  const config = new ConfigService(dataPath);
+  const apiKey = config.getGeminiApiKey();
+  if (!apiKey) {
+    process.stderr.write('Error: Gemini API key not found. Set GEMINI_API_KEY env var or configure via the Listener.AI app.\n');
+    process.exit(1);
+  }
+
+  let scope: AgentScope = { kind: 'all' };
+  if (ref) {
+    const folderPath = resolveRef(ref, dataPath);
+    scope = { kind: 'single', folderName: path.basename(folderPath) };
+  }
+
+  const agent = new AgentService({ apiKey, dataPath, configService: config });
+
+  const confirm = async (proposal: ConfigProposal): Promise<boolean> => {
+    process.stderr.write('\n');
+    return promptYesNo(`Proposed change -> ${proposal.description}\nApply?`);
+  };
+
+  const result = await agent.run({ question, scope, confirm });
+  process.stdout.write(`${result.answer}\n`);
+  if (result.appliedActions.length > 0) {
+    process.stderr.write('\nApplied:\n');
+    for (const action of result.appliedActions) {
+      process.stderr.write(`  ${action.key}: ${JSON.stringify(action.previousValue ?? null)} -> ${JSON.stringify(action.value)}\n`);
+    }
+  }
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
@@ -377,6 +450,11 @@ async function main(): Promise<void> {
 
   if (args[0] === 'search') {
     handleSearch(args.slice(1));
+    return;
+  }
+
+  if (args[0] === 'ask') {
+    await handleAsk(args.slice(1));
     return;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1054,4 +1054,12 @@ ipcMain.handle('agent-confirm-response', async (_, payload: { id: string; approv
   return { success: true };
 });
 
+// Renderer-triggered bail-out: if the user clicks "Stop" on a pending chat
+// bubble while a set_config confirm is outstanding, reject it so the awaiting
+// agent call unwinds and the input unlocks. No-op when nothing is pending.
+ipcMain.handle('agent-cancel-pending', async () => {
+  rejectAllPendingConfirms();
+  return { success: true };
+});
+
 fileHandlerService.registerHandlers();

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import { notificationService } from './services/notificationService';
 import { fetchReleaseNotes, fetchAllReleases } from './services/releaseNotesService';
 import { saveTranscription, readTranscription } from './outputService';
 import { searchTranscriptions, ALL_FIELDS, type SearchField } from './searchService';
+import { AgentService, type AgentChatMessage, type AgentRunResult, type AgentScope, type ConfigProposal } from './agentService';
 
 // Global flag to track if app is quitting
 declare global {
@@ -34,6 +35,33 @@ const displayDetector = new DisplayDetectorService();
 let meetingAutoStartedRecording = false;
 let geminiService: GeminiService | null = null;
 let notionService: NotionService | null = null;
+let agentService: AgentService | null = null;
+
+function getAgentService(): AgentService | null {
+  if (agentService) return agentService;
+  const apiKey = configService.getGeminiApiKey();
+  if (!apiKey) return null;
+  agentService = new AgentService({
+    apiKey,
+    dataPath: app.getPath('userData'),
+    configService,
+  });
+  return agentService;
+}
+
+// Pending agent confirmation resolvers keyed by request id. The renderer responds
+// via the 'agent-confirm-response' IPC and we resolve the promise the agent is awaiting.
+// If the window goes away (reload, crash, close) before the user answers, we
+// auto-reject so the awaiting agent-chat call can unwind instead of hanging.
+const pendingConfirms = new Map<string, (approved: boolean) => void>();
+let confirmIdCounter = 0;
+
+function rejectAllPendingConfirms(): void {
+  for (const resolver of pendingConfirms.values()) {
+    try { resolver(false); } catch { /* ignore */ }
+  }
+  pendingConfirms.clear();
+}
 let recordingMaxTimer: NodeJS.Timeout | null = null;
 let recordingReminderTimer: NodeJS.Timeout | null = null;
 
@@ -202,7 +230,17 @@ function createWindow() {
   });
 
   mainWindow.on('closed', () => {
+    rejectAllPendingConfirms();
     mainWindow = null;
+  });
+
+  // Reload or crash drops the renderer that would answer a confirm prompt;
+  // unblock any waiting agent call so it returns cleanly instead of hanging.
+  mainWindow.webContents.on('did-start-navigation', (_e, _url, isInPlace, isMainFrame) => {
+    if (isMainFrame && !isInPlace) rejectAllPendingConfirms();
+  });
+  mainWindow.webContents.on('render-process-gone', () => {
+    rejectAllPendingConfirms();
   });
 }
 
@@ -545,35 +583,44 @@ ipcMain.handle('stop-recording', async () => {
 
 // Configuration handlers
 
+// Apply runtime side effects for changed config keys (shortcut re-registration,
+// detector on/off, service re-creation). Called from both the GUI save-config
+// IPC and the agent-chat flow when set_config mutations land.
+function applyConfigSideEffects(changed: Partial<AppConfig>): void {
+  if (changed.knownWords !== undefined || changed.geminiApiKey !== undefined || changed.geminiModel !== undefined || changed.geminiFlashModel !== undefined) {
+    geminiService = createGeminiService();
+    agentService = null;
+  }
+  if (changed.globalShortcut !== undefined) {
+    registerGlobalShortcut();
+  }
+  if (changed.meetingDetection !== undefined) {
+    meetingDetector.setEnabled(changed.meetingDetection);
+  }
+  if (changed.displayDetection !== undefined) {
+    displayDetector.setEnabled(changed.displayDetection);
+  }
+  if (changed.notionApiKey !== undefined || changed.notionDatabaseId !== undefined) {
+    const apiKey = configService.getNotionApiKey();
+    const databaseId = configService.getNotionDatabaseId();
+    if (apiKey && databaseId) {
+      notionService = new NotionService({ apiKey, databaseId });
+    }
+  }
+}
+
+// Tell the renderer the config has changed out-of-band so it can re-read and
+// re-render its UI state (toggle checkboxes etc.). Used by the agent flow.
+function broadcastConfigChanged(): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('config-changed', configService.getAllConfig());
+  }
+}
+
 ipcMain.handle('save-config', async (_, config: Partial<AppConfig>) => {
   try {
     configService.updateConfig(config);
-
-    // Recreate GeminiService if any relevant setting changed
-    if (config.knownWords !== undefined || config.geminiApiKey !== undefined || config.geminiModel !== undefined || config.geminiFlashModel !== undefined) {
-      geminiService = createGeminiService();
-    }
-
-    if (config.globalShortcut !== undefined) {
-      registerGlobalShortcut();
-    }
-
-    if (config.meetingDetection !== undefined) {
-      meetingDetector.setEnabled(config.meetingDetection);
-    }
-
-    if (config.displayDetection !== undefined) {
-      displayDetector.setEnabled(config.displayDetection);
-    }
-
-    // Recreate Notion service if either field changed
-    if (config.notionApiKey !== undefined || config.notionDatabaseId !== undefined) {
-      const apiKey = configService.getNotionApiKey();
-      const databaseId = configService.getNotionDatabaseId();
-      if (apiKey && databaseId) {
-        notionService = new NotionService({ apiKey, databaseId });
-      }
-    }
+    applyConfigSideEffects(config);
 
     return {
       success: true,
@@ -794,6 +841,7 @@ ipcMain.handle('get-metadata', async (_, filePath: string) => {
           success: true,
           data: {
             ...metadata,
+            folderName: path.basename(metadata.transcriptionPath),
             transcript: transcription.transcript,
             summary: transcription.summary,
             keyPoints: transcription.keyPoints,
@@ -939,5 +987,71 @@ ipcMain.handle('open-microphone-settings', async () => {
   // For Linux, there's no standard way to open microphone settings
 });
 
-// Register file handler service
+// Agent chat: blocks until the agent produces a final answer. During the run the
+// main process may ask the renderer to confirm a config change via the
+// 'agent-confirm-request' event; the renderer answers with 'agent-confirm-response'.
+ipcMain.handle('agent-chat', async (
+  _event,
+  opts: { question: string; history?: AgentChatMessage[]; scope: AgentScope }
+): Promise<{ success: true; result: AgentRunResult } | { success: false; error: string }> => {
+  try {
+    const agent = getAgentService();
+    if (!agent) {
+      return { success: false, error: 'Gemini API key not configured.' };
+    }
+    const question = (opts?.question ?? '').trim();
+    if (!question) return { success: false, error: 'Empty question.' };
+
+    const scope: AgentScope = opts?.scope?.kind === 'single' && typeof opts.scope.folderName === 'string'
+      ? { kind: 'single', folderName: opts.scope.folderName }
+      : { kind: 'all' };
+
+    const confirm = async (proposal: ConfigProposal): Promise<boolean> => {
+      if (!mainWindow || mainWindow.isDestroyed()) return false;
+      const id = `cfm_${++confirmIdCounter}`;
+      const approval = new Promise<boolean>((resolve) => {
+        pendingConfirms.set(id, resolve);
+      });
+      mainWindow.webContents.send('agent-confirm-request', { id, proposal });
+      return approval;
+    };
+
+    const result = await agent.run({
+      question,
+      history: Array.isArray(opts?.history) ? opts.history : [],
+      scope,
+      confirm,
+    });
+
+    // The agent only mutates via set_config; replay each applied write into the
+    // runtime side-effect pipeline so shortcut/detector state matches the disk
+    // config, then push a 'config-changed' event so the renderer can re-render
+    // its toggle checkboxes without waiting for a full reload.
+    if (result.appliedActions.length > 0) {
+      const changed: Partial<AppConfig> = {};
+      for (const action of result.appliedActions) {
+        if (action.type === 'setConfig') {
+          (changed as Record<string, unknown>)[action.key] = action.value;
+        }
+      }
+      applyConfigSideEffects(changed);
+      broadcastConfigChanged();
+    }
+
+    return { success: true, result };
+  } catch (error) {
+    console.error('agent-chat failed:', error);
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+});
+
+ipcMain.handle('agent-confirm-response', async (_, payload: { id: string; approved: boolean }) => {
+  const resolver = pendingConfirms.get(payload.id);
+  if (resolver) {
+    pendingConfirms.delete(payload.id);
+    resolver(!!payload.approved);
+  }
+  return { success: true };
+});
+
 fileHandlerService.registerHandlers();

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -26,6 +26,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   sendAgentConfirmResponse: (payload: { id: string; approved: boolean }) =>
     ipcRenderer.invoke('agent-confirm-response', payload),
+  cancelAgentPending: () => ipcRenderer.invoke('agent-cancel-pending'),
   onConfigChanged: (callback: (config: unknown) => void) => {
     ipcRenderer.on('config-changed', (_, config) => callback(config));
   },

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -19,6 +19,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getRecordings: () => ipcRenderer.invoke('get-recordings'),
   searchTranscriptions: (opts: { query: string; fields?: string[]; limit?: number }) =>
     ipcRenderer.invoke('search-transcriptions', opts),
+  agentChat: (opts: { question: string; history?: Array<{ role: 'user' | 'model'; text: string }>; scope: { kind: 'all' } | { kind: 'single'; folderName: string } }) =>
+    ipcRenderer.invoke('agent-chat', opts),
+  onAgentConfirmRequest: (callback: (req: { id: string; proposal: { kind: 'setConfig'; key: string; value: unknown; currentValue?: unknown; description: string } }) => void) => {
+    ipcRenderer.on('agent-confirm-request', (_, req) => callback(req));
+  },
+  sendAgentConfirmResponse: (payload: { id: string; approved: boolean }) =>
+    ipcRenderer.invoke('agent-confirm-response', payload),
+  onConfigChanged: (callback: (config: unknown) => void) => {
+    ipcRenderer.on('config-changed', (_, config) => callback(config));
+  },
   onTranscriptionProgress: (callback: (progress: { percent: number; message: string }) => void) => {
     ipcRenderer.on('transcription-progress', (_, progress) => callback(progress));
   },

--- a/styles.css
+++ b/styles.css
@@ -1377,6 +1377,29 @@ h1 {
 .chat-pending {
   font-style: italic;
   color: #6b7280;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.chat-pending-stop {
+  font-style: normal;
+  font-size: 12px;
+  padding: 2px 10px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #374151;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.chat-pending-stop:hover {
+  background: #f3f4f6;
+}
+
+.chat-pending-stop:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .chat-error {

--- a/styles.css
+++ b/styles.css
@@ -1282,3 +1282,222 @@ h1 {
   font-size: 13px;
   color: #ef4444;
 }
+
+/* Chat (agent) section */
+.chat-section {
+  margin-top: 24px;
+  padding: 16px 20px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.chat-section .chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.chat-section .chat-header h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.chat-toggle {
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  color: #6b7280;
+  transition: transform 0.15s ease;
+}
+
+.chat-section.expanded .chat-toggle {
+  transform: rotate(180deg);
+}
+
+.chat-body {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-messages {
+  min-height: 140px;
+  max-height: 340px;
+  overflow-y: auto;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-empty {
+  margin: 0;
+  color: #6b7280;
+  font-size: 13px;
+  font-style: italic;
+}
+
+.chat-message {
+  max-width: 85%;
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.chat-user {
+  align-self: flex-end;
+  background: #4f46e5;
+  color: #ffffff;
+  border-bottom-right-radius: 2px;
+}
+
+.chat-model {
+  align-self: flex-start;
+  background: #ffffff;
+  color: #111827;
+  border: 1px solid #e5e7eb;
+  border-bottom-left-radius: 2px;
+}
+
+.chat-pending {
+  font-style: italic;
+  color: #6b7280;
+}
+
+.chat-error {
+  align-self: stretch;
+  background: #fef2f2;
+  color: #b91c1c;
+  border: 1px solid #fecaca;
+}
+
+.chat-system {
+  align-self: center;
+  background: #ecfdf5;
+  color: #065f46;
+  border: 1px solid #a7f3d0;
+  font-size: 12px;
+  max-width: 100%;
+}
+
+.chat-confirm {
+  align-self: stretch;
+  background: #fffbeb;
+  color: #92400e;
+  border: 1px solid #fde68a;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-confirm p {
+  margin: 0;
+}
+
+.chat-confirm-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.chat-confirm-buttons button {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.chat-confirm-buttons button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chat-confirm-yes {
+  background: #16a34a;
+  color: #ffffff;
+}
+
+.chat-confirm-no {
+  background: #ffffff;
+  color: #374151;
+  border-color: #d1d5db;
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 8px;
+}
+
+.chat-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.chat-input:focus {
+  border-color: #4f46e5;
+}
+
+.chat-send-button {
+  padding: 8px 16px;
+  background: #4f46e5;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.chat-send-button:hover {
+  background: #4338ca;
+}
+
+.chat-send-button:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+}
+
+.chat-hint {
+  margin: 0;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+/* Chat pane inside the transcription modal */
+.chat-pane.tab-pane {
+  display: none;
+  flex-direction: column;
+  gap: 10px;
+  height: 100%;
+}
+
+.chat-pane.tab-pane.active {
+  display: flex;
+}
+
+.chat-pane .chat-messages {
+  flex: 1;
+  min-height: 260px;
+  max-height: none;
+}


### PR DESCRIPTION
## Summary

- Stacked on [#80](https://github.com/asleep-ai/listener-ai/pull/80). Adds a Gemini-function-calling agent usable from (a) a collapsible "💬 Ask Listener" panel on the home screen scoped to *all* saved meetings, (b) a "💬 Ask" tab inside the transcript modal scoped to the *one* open meeting, and (c) a `listener ask <question> [--ref <ref>]` CLI that shares the same `AgentService`.
- Tools: `search_transcriptions`, `list_recent_transcriptions`, `get_transcription` (transcript body opt-in), `get_config`, `set_config`. Credentials (`geminiApiKey`, `notionApiKey`, `notionDatabaseId`) are absent from both the readable and writable key lists; writable keys cover only `autoMode`, `meetingDetection`, `displayDetection`, `globalShortcut`, and the three recording-time limits.
- Every `set_config` call routes through a user confirmation. In the GUI it renders as inline Apply/Cancel buttons in the chat bubble; on the CLI it prompts `[y/N]` on stdin. Nothing mutates without an explicit click/keypress.

## Implementation notes

- `applyConfigSideEffects` is now factored out of `save-config` so the agent replays the same shortcut/detector/service recreation pipeline after an approved write, and `broadcastConfigChanged` pushes a `config-changed` event so the home-screen toggles re-sync without a reload.
- Single-meeting chats load the transcription record exactly once per run (previously `loadSingleTitle` + `loadSinglePrimer` called `readTranscription` twice); primer formatting is a pure `buildSinglePrimer(data)` helper.
- Tool dispatch inside a turn runs through `Promise.all`, so multi-tool turns (e.g. `search` + `list` + `get_config` together) don't serialize.
- Pending-confirm promises are tracked in a `Map` in main.ts and force-rejected on `mainWindow.closed`, `render-process-gone`, and main-frame navigation, so an `agent-chat` call can't hang if the renderer dies mid-prompt.
- `get-metadata` IPC now attaches `folderName: path.basename(transcriptionPath)` so the renderer derives scope without path-splitting the string itself.

## Deliberate V1 scope

- Agent history is per-session and not length-capped. A long session will keep sending the full exchange; trim/window is a later concern.
- Single-meeting primer ships the full transcript on every turn rather than using Gemini's `cachedContent`. Measurable win if long-meeting chats become common; deferred.
- Tool-name strings aren't extracted into constants (appear in 2 places each).

## Test plan

- [x] `pnpm test` — 36/36 (18 search + 9 meeting-detector + 9 new agent tests covering writable/readable whitelists, type coercion, and the confirm-description formatter; negative assertions confirm API keys and the Notion DB ID stay out of both lists)
- [x] `pnpm run build` clean
- [x] Dev Electron boots with only the benign DevTools Autofill noise
- [x] CLI: `listener ask` help + empty-query error path
- [ ] Manual: home chat answers "recent meeting about X" by searching, then grounds the answer
- [ ] Manual: modal Ask tab answers meeting-specific questions without calling search
- [ ] Manual: "auto mode 켜줘" / "녹음 최대 30분으로" → Apply confirm button → home toggle updates live; Cancel → nothing changes
- [ ] Manual: "Gemini API 키를 xxx로 바꿔줘" → agent refuses (key is not in writable list)
- [ ] Manual: close window mid-confirm → agent-chat unwinds cleanly (no zombie handle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)