### PR TITLE
Convert transcription read path to async fs.promises

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1727,7 +1727,6 @@ function createChatController({ messagesEl, form, input, sendBtn, scopeProvider,
     if (!question || busy) return;
     busy = true;
     sendBtn.disabled = true;
-    input.disabled = true;
 
     appendMessage('user', question);
     input.value = '';
@@ -1763,7 +1762,6 @@ function createChatController({ messagesEl, form, input, sendBtn, scopeProvider,
       activeChatMessagesEl = priorActiveChat;
       busy = false;
       sendBtn.disabled = false;
-      input.disabled = false;
       input.focus();
     }
   }

--- a/src/agentService.ts
+++ b/src/agentService.ts
@@ -271,7 +271,7 @@ export class AgentService {
 
     // Load the single-meeting record once if needed; title + primer derive from it.
     const singleData = opts.scope.kind === 'single' && isValidFolderName(opts.scope.folderName)
-      ? readTranscription(path.join(getTranscriptionsDir(this.dataPath), opts.scope.folderName))
+      ? await readTranscription(path.join(getTranscriptionsDir(this.dataPath), opts.scope.folderName))
       : null;
     const systemInstruction = systemInstructionFor(opts.scope, singleData?.title);
 
@@ -359,7 +359,7 @@ export class AgentService {
           const limit = typeof args.limit === 'number' ? args.limit : 5;
           const includeTranscript = args.include_transcript === true;
           const fields: SearchField[] = includeTranscript ? [...ALL_FIELDS] : ['title', 'summary', 'keyPoints', 'actionItems'];
-          const hits = searchTranscriptions(this.dataPath, { query, fields, limit });
+          const hits = await searchTranscriptions(this.dataPath, { query, fields, limit });
           return {
             hits: hits.map((h) => ({
               folder_name: h.entry.folderName,
@@ -373,7 +373,7 @@ export class AgentService {
         }
         case 'list_recent_transcriptions': {
           const limit = typeof args.limit === 'number' ? args.limit : 10;
-          const entries = listTranscriptions(this.dataPath, limit);
+          const entries = await listTranscriptions(this.dataPath, limit);
           return {
             entries: entries.map((e) => ({
               folder_name: e.folderName,
@@ -386,7 +386,7 @@ export class AgentService {
           const folderName = typeof args.folder_name === 'string' ? args.folder_name : '';
           if (!isValidFolderName(folderName)) return { error: 'folder_name must be a bare folder name returned by search/list (no slashes, no ..)' };
           const folderPath = path.join(getTranscriptionsDir(this.dataPath), folderName);
-          const data = readTranscription(folderPath);
+          const data = await readTranscription(folderPath);
           if (!data) return { error: `transcription not found: ${folderName}` };
           const result: Record<string, unknown> = {
             title: data.title,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -135,10 +135,10 @@ function handleConfig(subArgs: string[]): void {
   usage();
 }
 
-function resolveRef(ref: string, dataPath: string): string {
+async function resolveRef(ref: string, dataPath: string): Promise<string> {
   if (/^\d+$/.test(ref)) {
     const index = parseInt(ref, 10);
-    const entries = listTranscriptions(dataPath, 0);
+    const entries = await listTranscriptions(dataPath, 0);
     if (entries.length === 0) {
       process.stderr.write('Error: No transcriptions found.\n');
       process.exit(1);
@@ -157,7 +157,7 @@ function resolveRef(ref: string, dataPath: string): string {
   return folderPath;
 }
 
-function handleList(args: string[]): void {
+async function handleList(args: string[]): Promise<void> {
   const dataPath = getDataPath();
   let limit: number | undefined;
   for (let i = 0; i < args.length; i++) {
@@ -169,7 +169,7 @@ function handleList(args: string[]): void {
       }
     }
   }
-  const entries = listTranscriptions(dataPath, limit);
+  const entries = await listTranscriptions(dataPath, limit);
   if (entries.length === 0) {
     process.stderr.write('No transcriptions found.\n');
     return;
@@ -184,14 +184,14 @@ function handleList(args: string[]): void {
   }
 }
 
-function handleShow(args: string[]): void {
+async function handleShow(args: string[]): Promise<void> {
   const ref = args[0];
   if (!ref) {
     process.stderr.write('Error: Missing ref. Usage: listener show <ref>\n');
     process.exit(1);
   }
   const dataPath = getDataPath();
-  const folderPath = resolveRef(ref, dataPath);
+  const folderPath = await resolveRef(ref, dataPath);
   const summaryPath = path.join(folderPath, 'summary.md');
   if (!fs.existsSync(summaryPath)) {
     process.stderr.write(`Error: summary.md not found in ${folderPath}\n`);
@@ -202,7 +202,7 @@ function handleShow(args: string[]): void {
   process.stdout.write(body);
 }
 
-function handleExport(args: string[]): void {
+async function handleExport(args: string[]): Promise<void> {
   let ref: string | undefined;
   let targetPath: string | undefined;
   let json = false;
@@ -225,7 +225,7 @@ function handleExport(args: string[]): void {
   }
 
   const dataPath = getDataPath();
-  const folderPath = resolveRef(ref, dataPath);
+  const folderPath = await resolveRef(ref, dataPath);
   const summaryPath = path.join(folderPath, 'summary.md');
 
   if (!fs.existsSync(summaryPath)) {
@@ -287,7 +287,7 @@ function handleExport(args: string[]): void {
   }
 }
 
-function handleSearch(args: string[]): void {
+async function handleSearch(args: string[]): Promise<void> {
   const VALID_FIELDS = [...ALL_FIELDS, 'all'] as const;
   let query: string | undefined;
   let limit = 20;
@@ -331,7 +331,7 @@ function handleSearch(args: string[]): void {
 
   const dataPath = getDataPath();
   const fields = resolveFields({ field, includeTranscript });
-  const hits = searchTranscriptions(dataPath, { query, fields, limit });
+  const hits = await searchTranscriptions(dataPath, { query, fields, limit });
 
   if (hits.length === 0) {
     process.stderr.write('No results.\n');
@@ -400,7 +400,7 @@ async function handleAsk(args: string[]): Promise<void> {
 
   let scope: AgentScope = { kind: 'all' };
   if (ref) {
-    const folderPath = resolveRef(ref, dataPath);
+    const folderPath = await resolveRef(ref, dataPath);
     scope = { kind: 'single', folderName: path.basename(folderPath) };
   }
 
@@ -434,22 +434,22 @@ async function main(): Promise<void> {
   }
 
   if (args[0] === 'list') {
-    handleList(args.slice(1));
+    await handleList(args.slice(1));
     return;
   }
 
   if (args[0] === 'show') {
-    handleShow(args.slice(1));
+    await handleShow(args.slice(1));
     return;
   }
 
   if (args[0] === 'export') {
-    handleExport(args.slice(1));
+    await handleExport(args.slice(1));
     return;
   }
 
   if (args[0] === 'search') {
-    handleSearch(args.slice(1));
+    await handleSearch(args.slice(1));
     return;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -835,7 +835,7 @@ ipcMain.handle('get-metadata', async (_, filePath: string) => {
 
     // New format: read from transcription folder
     if (metadata.transcriptionPath) {
-      const transcription = readTranscription(metadata.transcriptionPath);
+      const transcription = await readTranscription(metadata.transcriptionPath);
       if (transcription) {
         return {
           success: true,
@@ -896,7 +896,7 @@ ipcMain.handle('search-transcriptions', async (_, opts: { query: string; fields?
     const fields = filtered.length > 0 ? filtered : ALL_FIELDS;
     const limit = Number.isFinite(opts.limit) && (opts.limit as number) >= 0 ? (opts.limit as number) : 20;
     const dataPath = app.getPath('userData');
-    const raw = searchTranscriptions(dataPath, { query, fields, limit });
+    const raw = await searchTranscriptions(dataPath, { query, fields, limit });
 
     const hits = raw.map((h) => ({
       folderName: h.entry.folderName,

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -246,19 +246,19 @@ export interface TranscriptionEntry {
  */
 export async function listTranscriptions(dataPath: string, limit?: number): Promise<TranscriptionEntry[]> {
   const dir = getTranscriptionsDir(dataPath);
-  let names: string[];
+  let dirents: fs.Dirent[];
   try {
-    names = await fs.promises.readdir(dir);
+    dirents = await fs.promises.readdir(dir, { withFileTypes: true });
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
     throw err;
   }
 
   const entries: TranscriptionEntry[] = [];
-  for (const name of names) {
+  for (const dirent of dirents) {
+    if (!dirent.isDirectory()) continue;
+    const name = dirent.name;
     const folderPath = path.join(dir, name);
-    const stat = await fs.promises.stat(folderPath);
-    if (!stat.isDirectory()) continue;
     const summaryPath = path.join(folderPath, 'summary.md');
 
     let title = name;

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -244,25 +244,37 @@ export interface TranscriptionEntry {
  * List transcription folders sorted by most-recent-first.
  * Performs a lightweight line scan of each summary.md to extract only title and transcribedAt.
  */
-export function listTranscriptions(dataPath: string, limit?: number): TranscriptionEntry[] {
+export async function listTranscriptions(dataPath: string, limit?: number): Promise<TranscriptionEntry[]> {
   const dir = getTranscriptionsDir(dataPath);
-  if (!fs.existsSync(dir)) return [];
+  let names: string[];
+  try {
+    names = await fs.promises.readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
 
   const entries: TranscriptionEntry[] = [];
-  for (const name of fs.readdirSync(dir)) {
+  for (const name of names) {
     const folderPath = path.join(dir, name);
-    if (!fs.statSync(folderPath).isDirectory()) continue;
+    const stat = await fs.promises.stat(folderPath);
+    if (!stat.isDirectory()) continue;
     const summaryPath = path.join(folderPath, 'summary.md');
-    if (!fs.existsSync(summaryPath)) continue;
 
     let title = name;
     let transcribedAt = '';
 
     // Lightweight line scan -- read only frontmatter, not the full file
-    const fd = fs.openSync(summaryPath, 'r');
+    let fileHandle: fs.promises.FileHandle;
+    try {
+      fileHandle = await fs.promises.open(summaryPath, 'r');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
     try {
       const buf = Buffer.alloc(2048);
-      const bytesRead = fs.readSync(fd, buf, 0, 2048, 0);
+      const { bytesRead } = await fileHandle.read(buf, 0, 2048, 0);
       const head = buf.toString('utf-8', 0, bytesRead);
 
       for (const line of head.split('\n')) {
@@ -274,7 +286,7 @@ export function listTranscriptions(dataPath: string, limit?: number): Transcript
         if (line === '---' && transcribedAt) break;
       }
     } finally {
-      fs.closeSync(fd);
+      await fileHandle.close();
     }
 
     // Fall back to folder name timestamp suffix (e.g. _20260219_143000)
@@ -312,13 +324,11 @@ export interface ReadTranscriptionResult {
  * Read transcription data from a transcription folder.
  * Returns raw data from frontmatter (machine-readable), not the markdown body.
  */
-export function readTranscription(folderPath: string): ReadTranscriptionResult | null {
+export async function readTranscription(folderPath: string): Promise<ReadTranscriptionResult | null> {
   try {
     const summaryPath = path.join(folderPath, 'summary.md');
 
-    if (!fs.existsSync(summaryPath)) return null;
-
-    const summaryContent = fs.readFileSync(summaryPath, 'utf-8');
+    const summaryContent = await fs.promises.readFile(summaryPath, 'utf-8');
     const { meta } = parseFrontmatter(summaryContent);
 
     // Parse customFields from frontmatter (stored as JSON string)

--- a/src/searchService.ts
+++ b/src/searchService.ts
@@ -142,15 +142,15 @@ export function resolveFields(opts: { field?: SearchField | 'all'; includeTransc
 }
 
 /** Run a search against the local transcriptions archive. */
-export function searchTranscriptions(dataPath: string, opts: SearchOptions): SearchHit[] {
-  const entries = listTranscriptions(dataPath, 0);
+export async function searchTranscriptions(dataPath: string, opts: SearchOptions): Promise<SearchHit[]> {
+  const entries = await listTranscriptions(dataPath, 0);
   const fields = opts.fields ?? DEFAULT_FIELDS;
   const needle = opts.query.toLowerCase();
   const scope = new Set(fields);
   const hits: SearchHit[] = [];
 
   for (const entry of entries) {
-    const data = readTranscription(entry.folderPath);
+    const data = await readTranscription(entry.folderPath);
     if (!data) continue;
     const hit = scoreRecordPrepared(entry, data, needle, scope);
     if (hit) hits.push(hit);


### PR DESCRIPTION
## Summary

- Convert `listTranscriptions` / `readTranscription` (in `src/outputService.ts`) and `searchTranscriptions` (in `src/searchService.ts`) from synchronous `fs.*Sync` calls to `fs.promises`.
- Update every caller — the two IPC handlers in `src/main.ts`, the three agent tools (and the single-meeting primer) in `src/agentService.ts`, and the CLI handlers + `resolveRef` in `src/cli.ts` — to `await` the new async functions.
- Use `readdir({ withFileTypes: true })` in `listTranscriptions` to skip a per-entry `stat` syscall (gemini-code-assist review follow-up).
- Keep the agent chat input field enabled while a response is in flight — only the send button is disabled. The existing `busy` guard in `submit` prevents re-submission via Enter, so the user can compose the next message ahead of time.

Scoring logic, IPC payload shape, and CLI output are unchanged.

## Why

Search ran on the Electron main process via `fs.readdirSync` / `statSync` / `openSync` / `readSync` / `readFileSync`. As the user accumulates hundreds of saved meetings, every search blocks the event loop and freezes the UI for the full duration of the scan. PR #82's agent feature amplifies this because every chat turn in "all meetings" scope can trigger another `search_transcriptions` call.

This is the medium-severity finding that gemini-code-assist flagged on the [#82 review thread](https://github.com/asleep-ai/listener-ai/pull/82). The bug was introduced in #80 but only became user-visible through the agent loop in #82.

Sequential `await` in `searchTranscriptions` preserves the original semantics 1:1 — it doesn't speed up the wall clock, it just yields to the event loop between entries so other IPC handlers and renderer events can interleave. That's enough to fix the freeze without risking FD-limit issues from `Promise.all` over hundreds of files.

The agent chat input fix is a small UX polish spotted while manually testing this PR: disabling the input field felt intrusive and blocked the user from drafting follow-up questions during a slow agent turn.

## Reviewer notes

- `readTranscription` no longer pre-checks `existsSync(summaryPath)` — the existing outer `try/catch` already returns `null` for any error, including ENOENT, so the explicit check was redundant once the call became async.
- `listTranscriptions` distinguishes ENOENT on the parent dir (returns `[]`, matching the old `existsSync(dir)` guard) from ENOENT on individual `summary.md` files (skips that folder, matching the old per-entry `existsSync` skip). Other error codes still propagate.
- The 18 existing `searchService.test.ts` cases pass without modification because they only exercise the pure helpers (`makeSnippet`, `scoreRecord`, `resolveFields`), not the FS-touching functions.
- Direct `fs.readFileSync` calls inside `handleShow` / `handleExport` were left as-is. Those are CLI one-shots that don't share an event loop with anything else, and converting them is outside the scope of this fix.

## Test plan

- [x] `pnpm test` (runs `tsc &&` then `node --test`) — 40/40 tests pass.
- [x] Manual CLI: `listener list`, `listener search <q>`, `listener search <q> --field keyPoints`, `listener search nonexistent` (no results), `listener show 1`, `listener export 1 --json` — all produce expected output.
- [ ] Manual GUI: `pnpm start`, trigger search/agent chat, confirm UI stays responsive (window drag/resize, tab switch) while search runs.
- [ ] Manual GUI: confirm agent chat input stays focusable/typeable while the model is responding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)