### PR TITLE
Replace intrusive update dialog with in-header badge

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
   <div class="container">
     <div class="header">
       <h1>Listener.AI</h1>
+      <button id="updateBadge" class="update-badge" type="button" hidden aria-live="polite"></button>
       <button id="settingsButton" class="settings-button" title="API Settings">⚙️</button>
     </div>
     <p class="subtitle">Record and transcribe your meetings with AI</p>

--- a/renderer.js
+++ b/renderer.js
@@ -137,20 +137,88 @@ function showReleaseNotes(notes) {
   modal.style.display = 'block';
 }
 
-// Listen for auto-update events
+// Auto-update badge (small indicator in the header)
+const updateBadgeEl = document.getElementById('updateBadge');
+let updateBadgeState = { type: 'idle' };
+
+function renderUpdateBadge(state) {
+  updateBadgeState = state || { type: 'idle' };
+  if (!updateBadgeEl) return;
+
+  updateBadgeEl.classList.remove('is-downloading', 'is-ready');
+
+  switch (updateBadgeState.type) {
+    case 'available':
+      updateBadgeEl.hidden = false;
+      updateBadgeEl.disabled = false;
+      updateBadgeEl.title = updateBadgeState.version
+        ? `Click to download version ${updateBadgeState.version}`
+        : 'Click to download the new version';
+      updateBadgeEl.textContent = updateBadgeState.version
+        ? `Update to v${updateBadgeState.version}`
+        : 'Update available';
+      break;
+    case 'downloading': {
+      updateBadgeEl.hidden = false;
+      updateBadgeEl.disabled = true;
+      updateBadgeEl.classList.add('is-downloading');
+      const percent = Math.max(0, Math.min(100, Math.round(updateBadgeState.percent || 0)));
+      updateBadgeEl.title = 'Downloading update...';
+      updateBadgeEl.textContent = `Downloading ${percent}%`;
+      break;
+    }
+    case 'downloaded':
+      updateBadgeEl.hidden = false;
+      updateBadgeEl.disabled = false;
+      updateBadgeEl.classList.add('is-ready');
+      updateBadgeEl.title = 'Click to restart and install';
+      updateBadgeEl.textContent = updateBadgeState.version
+        ? `Restart to install v${updateBadgeState.version}`
+        : 'Restart to install';
+      break;
+    default:
+      updateBadgeEl.hidden = true;
+      updateBadgeEl.disabled = false;
+      updateBadgeEl.textContent = '';
+      updateBadgeEl.title = '';
+  }
+}
+
+if (updateBadgeEl) {
+  updateBadgeEl.addEventListener('click', () => {
+    if (updateBadgeState.type === 'available' && window.electronAPI.downloadUpdate) {
+      window.electronAPI.downloadUpdate();
+    } else if (updateBadgeState.type === 'downloaded' && window.electronAPI.installUpdate) {
+      window.electronAPI.installUpdate();
+    }
+  });
+}
+
+if (window.electronAPI.getUpdateState) {
+  window.electronAPI.getUpdateState()
+    .then(renderUpdateBadge)
+    .catch(() => renderUpdateBadge({ type: 'idle' }));
+}
+
 if (window.electronAPI.onUpdateStatus) {
   window.electronAPI.onUpdateStatus((updateInfo) => {
     switch (updateInfo.event) {
-      case 'checking-for-update':
-        showNotification('Checking for updates...', 'info');
+      case 'update-available':
+        renderUpdateBadge({ type: 'available', version: updateInfo.data?.version });
         break;
       case 'download-progress':
-        if (updateInfo.data?.percent) {
-          showNotification(`Downloading update: ${updateInfo.data.percent.toFixed(2)}%`, 'info');
-        }
+        renderUpdateBadge({
+          type: 'downloading',
+          version: updateInfo.data?.version,
+          percent: updateInfo.data?.percent || 0
+        });
+        break;
+      case 'update-downloaded':
+        renderUpdateBadge({ type: 'downloaded', version: updateInfo.data?.version });
         break;
       case 'update-error':
-        showNotification(`Update error: ${updateInfo.data}`, 'error');
+      case 'update-not-available':
+        renderUpdateBadge({ type: 'idle' });
         break;
     }
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -245,9 +245,6 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
-  // Initialize auto-updater
-  autoUpdaterService.checkForUpdates();
-  
   // Create menu with DevTools option
   const template = [
     {
@@ -353,6 +350,10 @@ app.whenReady().then(() => {
     notificationService.setMainWindow(mainWindow);
   }
 
+  // Kick off initial + periodic update checks once the renderer can receive IPC.
+  autoUpdaterService.checkForUpdates();
+  autoUpdaterService.startPeriodicCheck();
+
   // Show release notes on first launch after an update.
   checkAndShowReleaseNotes().catch((err) => {
     console.error('Release notes check failed:', err);
@@ -433,6 +434,7 @@ app.on('window-all-closed', () => {
 app.on('before-quit', () => {
   meetingDetector.stop();
   displayDetector.stop();
+  autoUpdaterService.stopPeriodicCheck();
   global.isQuitting = true;
 });
 
@@ -641,6 +643,23 @@ ipcMain.handle('get-all-releases', async () => {
   const results = await fetchAllReleases();
   console.log(`Release list IPC: fetched ${results.length} releases`);
   return results;
+});
+
+ipcMain.handle('update:get-state', async () => {
+  return autoUpdaterService.getUpdateState();
+});
+
+ipcMain.handle('update:download', async () => {
+  autoUpdaterService.downloadUpdate();
+});
+
+ipcMain.handle('update:install', async () => {
+  autoUpdaterService.quitAndInstall();
+});
+
+// Dev-only: drive the badge state machine manually from DevTools.
+ipcMain.handle('update:simulate', async (_, event: string, data?: any) => {
+  autoUpdaterService.simulateUpdateEvent(event, data);
 });
 
 ipcMain.handle('check-config', async () => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -76,6 +76,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onUpdateStatus: (callback: (updateInfo: { event: string; data?: any }) => void) => {
     ipcRenderer.on('update-status', (_, updateInfo) => callback(updateInfo));
   },
+  getUpdateState: () => ipcRenderer.invoke('update:get-state'),
+  downloadUpdate: () => ipcRenderer.invoke('update:download'),
+  installUpdate: () => ipcRenderer.invoke('update:install'),
+  simulateUpdateEvent: (event: string, data?: any) => ipcRenderer.invoke('update:simulate', event, data),
 
   // Release notes (shown after a version update)
   onShowReleaseNotes: (callback: (notes: { version: string; body: string; url: string }) => void) => {

--- a/src/services/autoUpdaterService.ts
+++ b/src/services/autoUpdaterService.ts
@@ -2,11 +2,18 @@ import { autoUpdater } from 'electron-updater';
 import { BrowserWindow, dialog, app, shell } from 'electron';
 
 const RELEASES_URL = 'https://github.com/asleep-ai/listener-ai/releases/latest';
+const PERIODIC_CHECK_INTERVAL_MS = 2 * 60 * 60 * 1000;
+
+export type UpdateState =
+  | { type: 'idle' }
+  | { type: 'available'; version: string }
+  | { type: 'downloading'; version?: string; percent: number }
+  | { type: 'downloaded'; version: string };
 
 export class AutoUpdaterService {
   private mainWindow: BrowserWindow | null = null;
-  private updateAvailable = false;
-  private updateDownloaded = false;
+  private updateState: UpdateState = { type: 'idle' };
+  private periodicTimer: NodeJS.Timeout | null = null;
 
   constructor() {
     this.setupAutoUpdater();
@@ -32,73 +39,204 @@ export class AutoUpdaterService {
 
     autoUpdater.on('update-available', (info) => {
       console.log('Update available:', info);
-      this.updateAvailable = true;
+      this.updateState = { type: 'available', version: info.version };
       this.sendStatusToWindow('update-available', info);
-      
-      dialog.showMessageBox(this.mainWindow || new BrowserWindow({ show: false }), {
-        type: 'info',
-        title: 'Update Available',
-        message: `A new version (${info.version}) is available. Would you like to download it now?`,
-        detail: `Current version: ${app.getVersion()}\nNew version: ${info.version}`,
-        buttons: ['Download', 'Later'],
-        defaultId: 0,
-        cancelId: 1
-      }).then((result) => {
-        if (result.response === 0) {
-          autoUpdater.downloadUpdate();
-        }
-      });
     });
 
     autoUpdater.on('update-not-available', () => {
       console.log('Update not available');
-      this.sendStatusToWindow('update-not-available');
+      // Only emit on transition — a previously-advertised update was rolled back.
+      // Idle→idle ticks from the periodic check don't need to wake the renderer.
+      if (this.updateState.type === 'available') {
+        this.updateState = { type: 'idle' };
+        this.sendStatusToWindow('update-not-available');
+      }
     });
 
     autoUpdater.on('error', (err) => {
       console.error('Update error:', err);
+      const wasDownloading = this.updateState.type === 'downloading';
+      this.updateState = { type: 'idle' };
       this.sendStatusToWindow('update-error', err.message);
-      this.showUpdateFailedDialog(err.message);
+      if (wasDownloading) {
+        this.showUpdateFailedDialog(err.message);
+      }
     });
 
     autoUpdater.on('download-progress', (progressObj) => {
       console.log(`Download progress: ${progressObj.percent.toFixed(2)}%`);
-      this.sendStatusToWindow('download-progress', progressObj);
+      const version = this.currentVersion();
+      this.updateState = { type: 'downloading', version, percent: progressObj.percent };
+      this.sendStatusToWindow('download-progress', { ...progressObj, version });
     });
 
     autoUpdater.on('update-downloaded', (info) => {
       console.log('Update downloaded:', info);
-      this.updateDownloaded = true;
+      this.updateState = { type: 'downloaded', version: info.version };
       this.sendStatusToWindow('update-downloaded', info);
-      
-      dialog.showMessageBox(this.mainWindow || new BrowserWindow({ show: false }), {
-        type: 'info',
-        title: 'Update Ready',
-        message: 'Update downloaded. The application will restart to apply the update.',
-        detail: `Version ${info.version} has been downloaded and will be installed after restart.`,
-        buttons: ['Restart Now', 'Later'],
-        defaultId: 0,
-        cancelId: 1
-      }).then((result) => {
-        if (result.response === 0) {
-          autoUpdater.quitAndInstall();
-        }
-      });
+      this.showRestartPrompt(info.version);
+    });
+  }
+
+  private showRestartPrompt(version: string) {
+    dialog.showMessageBox(this.mainWindow || new BrowserWindow({ show: false }), {
+      type: 'info',
+      title: 'Update Ready',
+      message: 'Update downloaded. The application will restart to apply the update.',
+      detail: `Version ${version} has been downloaded and will be installed after restart.`,
+      buttons: ['Restart Now', 'Later'],
+      defaultId: 0,
+      cancelId: 1
+    }).then((result) => {
+      if (result.response === 0) {
+        this.quitAndInstall();
+      }
     });
   }
 
   private sendStatusToWindow(event: string, data?: any) {
-    if (this.mainWindow) {
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
       this.mainWindow.webContents.send('update-status', { event, data });
     }
   }
 
+  private currentVersion(): string | undefined {
+    const state = this.updateState;
+    if (state.type === 'idle') return undefined;
+    return state.version;
+  }
+
   public checkForUpdates() {
     if (this.isDevelopment()) return;
-    
+
     autoUpdater.checkForUpdatesAndNotify().catch((err) => {
       console.error('Failed to check for updates:', err);
     });
+  }
+
+  public startPeriodicCheck(intervalMs: number = PERIODIC_CHECK_INTERVAL_MS) {
+    if (this.isDevelopment()) return;
+    if (this.periodicTimer) return;
+
+    this.periodicTimer = setInterval(() => {
+      if (this.updateState.type === 'downloading' || this.updateState.type === 'downloaded') {
+        return;
+      }
+      this.checkForUpdates();
+    }, intervalMs);
+  }
+
+  public stopPeriodicCheck() {
+    if (this.periodicTimer) {
+      clearInterval(this.periodicTimer);
+      this.periodicTimer = null;
+    }
+  }
+
+  public getUpdateState(): UpdateState {
+    return this.updateState;
+  }
+
+  public downloadUpdate() {
+    if (this.updateState.type !== 'available') return;
+
+    const version = this.updateState.version;
+    const isDev = this.isDevelopment();
+
+    dialog.showMessageBox(this.mainWindow || new BrowserWindow({ show: false }), {
+      type: 'info',
+      title: 'Update Available',
+      message: `A new version (${version}) is available. Would you like to download it now?`,
+      detail: `Current version: ${app.getVersion()}\nNew version: ${version}`,
+      buttons: ['Download', 'Later'],
+      defaultId: 0,
+      cancelId: 1
+    }).then((result) => {
+      if (result.response !== 0) return;
+      if (this.updateState.type !== 'available') return;
+
+      this.updateState = { type: 'downloading', version, percent: 0 };
+      this.sendStatusToWindow('download-progress', { percent: 0, version });
+
+      if (isDev) {
+        this.simulateFakeDownload();
+        return;
+      }
+
+      autoUpdater.downloadUpdate().catch((err) => {
+        console.error('Failed to download update:', err);
+      });
+    });
+  }
+
+  private simulateFakeDownload() {
+    const steps = [25, 60, 90, 100];
+    steps.forEach((percent, idx) => {
+      setTimeout(() => {
+        if (this.updateState.type !== 'downloading') return;
+        if (percent < 100) {
+          this.simulateUpdateEvent('download-progress', { percent });
+        } else {
+          const version =
+            this.updateState.type === 'downloading' ? this.updateState.version : '9.9.9';
+          this.simulateUpdateEvent('update-downloaded', { version });
+        }
+      }, (idx + 1) * 500);
+    });
+  }
+
+  public quitAndInstall() {
+    if (this.isDevelopment()) return;
+    if (this.updateState.type !== 'downloaded') return;
+
+    // Prevent the macOS close handler's hide-instead-of-quit fallback from
+    // intercepting the window close that quitAndInstall triggers.
+    global.isQuitting = true;
+    autoUpdater.quitAndInstall();
+  }
+
+  public simulateUpdateEvent(event: string, data?: any) {
+    if (!this.isDevelopment()) {
+      console.warn('[autoUpdater] simulateUpdateEvent ignored outside development mode');
+      return;
+    }
+
+    switch (event) {
+      case 'update-available': {
+        const version = data?.version ?? '9.9.9';
+        this.updateState = { type: 'available', version };
+        this.sendStatusToWindow('update-available', { version });
+        break;
+      }
+      case 'download-progress': {
+        const version = this.currentVersion();
+        const percent = data?.percent ?? 0;
+        this.updateState = { type: 'downloading', version, percent };
+        this.sendStatusToWindow('download-progress', { percent, version });
+        break;
+      }
+      case 'update-downloaded': {
+        const version = data?.version
+          ?? (this.updateState.type === 'downloading' ? this.updateState.version : undefined)
+          ?? '9.9.9';
+        this.updateState = { type: 'downloaded', version };
+        this.sendStatusToWindow('update-downloaded', { version });
+        this.showRestartPrompt(version);
+        break;
+      }
+      case 'update-error': {
+        this.updateState = { type: 'idle' };
+        this.sendStatusToWindow('update-error', String(data ?? 'Simulated error'));
+        break;
+      }
+      case 'reset': {
+        this.updateState = { type: 'idle' };
+        this.sendStatusToWindow('update-not-available');
+        break;
+      }
+      default:
+        console.warn(`[autoUpdater] simulateUpdateEvent: unknown event "${event}"`);
+    }
   }
 
   private isDevelopment(): boolean {
@@ -117,7 +255,7 @@ export class AutoUpdaterService {
     }
 
     autoUpdater.checkForUpdates().then(() => {
-      if (!this.updateAvailable) {
+      if (this.updateState.type === 'idle') {
         dialog.showMessageBox(this.mainWindow || new BrowserWindow({ show: false }), {
           type: 'info',
           title: 'No Updates',

--- a/styles.css
+++ b/styles.css
@@ -86,6 +86,73 @@ h1 {
   background-color: rgba(0, 0, 0, 0.05);
 }
 
+.update-badge {
+  position: absolute;
+  right: 48px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  color: #1d4ed8;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s, transform 0.15s;
+}
+
+.update-badge[hidden] {
+  display: none;
+}
+
+.update-badge::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #2563eb;
+  animation: update-badge-pulse 1.8s ease-in-out infinite;
+}
+
+.update-badge:hover {
+  background: #dbeafe;
+  border-color: #93c5fd;
+}
+
+.update-badge:active {
+  transform: scale(0.97);
+}
+
+.update-badge.is-downloading {
+  color: #92400e;
+  background: #fffbeb;
+  border-color: #fde68a;
+  cursor: progress;
+}
+
+.update-badge.is-downloading::before {
+  background: #d97706;
+}
+
+.update-badge.is-ready {
+  color: #065f46;
+  background: #ecfdf5;
+  border-color: #a7f3d0;
+}
+
+.update-badge.is-ready::before {
+  background: #10b981;
+  animation: none;
+}
+
+@keyframes update-badge-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.85); }
+}
+
 .subtitle {
   text-align: center;
   color: #7f8c8d;


### PR DESCRIPTION
## Summary
- 헤더의 gear 버튼 왼쪽에 작은 pill 뱃지로 새 버전을 조용히 알림 (기존의 바로 뜨는 "Update Available" 모달 제거)
- 2시간 주기로 자동 체크 추가 (앱 시작 시 1회 체크는 유지)
- 뱃지 클릭 → 기존 Download/Later 다이얼로그 재활용. 확인 UX는 그대로, 발견 단계만 덜 방해되게 전환
- 100% 완료 → 초록 뱃지 + 기존 "Restart Now/Later" 다이얼로그
- Later 눌러도 초록 뱃지 남아서 언제든 재시작 가능
- `quitAndInstall()` 직전 `global.isQuitting = true` 설정으로 macOS의 hide-on-close 경로가 종료를 먹는 이슈 차단
- `update-not-available`은 `available → idle` 전환 시에만 발행 (주기 체크의 idle→idle tick은 renderer 깨우지 않음)
- `before-quit`에서 periodic timer 정리

## Dev helper
`simulateUpdateEvent` — DevTools 콘솔에서 서버 없이 전체 뱃지 플로우 재현. `isDevelopment()` 가드 있어 패키지 빌드에선 noop.

```js
await electronAPI.simulateUpdateEvent('update-available', {version: '9.9.9'});
// 뱃지 클릭 → Download → fake progress → Restart 다이얼로그까지 end-to-end 확인
```

## Architecture
- `AutoUpdaterService`: boolean 플래그 → discriminated `UpdateState` union
- 새 IPC: `update:get-state`, `update:download`, `update:install`, `update:simulate`
- 새 renderer 모듈: 뱃지 렌더링 + 상태별 색상/애니메이션 (파랑/주황/초록)

## Test plan
- [x] `pnpm run build` 통과
- [x] `pnpm test` 40/40 통과
- [x] Dev 모드에서 simulator로 available → downloading → downloaded 전환 및 다이얼로그 흐름 시각 확인
- [ ] **패키지 빌드로 실제 릴리즈 검증** (`pnpm dist:mac`) — merge 전 권장. 실제 `quitAndInstall` + `global.isQuitting` 조합이 macOS 트레이 기반 앱에서 의도대로 종료되는지 확인.
- [ ] Windows 패키지 빌드에서도 업데이트 흐름 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)