### PR TITLE
Replace ffmpeg recording with Chromium MediaRecorder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,165 +1,189 @@
 # Listener.AI - LLM Context
 
 ## Project Overview
-Listener.AI is a lightweight desktop application for recording audio and transcribing meetings using local microphones and AI services.
+Listener.AI is an Electron desktop application for recording meetings and producing AI-generated transcripts, summaries, key points, and action items. It also ships a `listener` CLI that shares the same config and transcription store for headless use.
 
 ## Core Features
 
 ### 1. Audio Recording
-- Use system microphone via ffmpeg for high-quality audio capture (MP3 format)
-- Start/stop recording functionality with real-time duration display
-- Local audio file storage with proper file management
-- Platform-specific audio device detection:
-  - macOS: AVFoundation integration
-  - Windows: DirectShow with Korean language support
-  - Linux: ALSA support
-- Audio quality optimizations (volume boost, limiter)
+- Chromium `MediaRecorder` in the renderer captures the mic via `navigator.mediaDevices.getUserMedia()`. No ffmpeg in the capture path.
+- Why: ffmpeg's `-f avfoundation` input (`AVCaptureAudioDataOutput`) produced periodic digital ticks on macOS. Chromium's audio path goes through Core Audio HAL directly and is clean.
+- `getUserMedia` is called with `echoCancellation: false`, `noiseSuppression: false`, `autoGainControl: false` so macOS Voice Isolation (`AUVoiceIO`) can't touch the signal.
+- Web Audio processing chain before `MediaRecorder`: highpass 80Hz → DynamicsCompressor (threshold -30dB, ratio 8, 3ms attack) → Gain ×4 (+12dB) → brick-wall limiter at -1 dBFS. Tuned for meeting/conference use: lifts distant speakers, tames close-range transients, prevents clipping.
+- Output: `audio/webm;codecs=opus` at 64 kbps mono (Chromium's native MediaRecorder codec). Falls back to other supported types via `MediaRecorder.isTypeSupported`.
+- Duration cap (`maxRecordingMinutes`), reminder cadence (`recordingReminderMinutes`), and minimum-length floor (`minRecordingSeconds`, discards accidental taps).
+- Known limitation: chunks accumulate in renderer memory until `stop`. A renderer crash mid-session loses the recording. Streaming chunks to main during capture is a planned future enhancement.
 
 ### 2. User Interface
-- Minimal Electron-based desktop UI with:
-  - Start/Stop recording button
-  - Text input field for meeting title (editable during/after recording)
-  - Status indicator showing recording state
-  - List of recent recordings with titles
-  - Auto mode toggle for automatic transcription and upload
-  - Progress tracking during transcription
-  - Configuration dialog for API key management
+- Resizable macOS-style window layout (redesigned from the earlier fixed compact mode)
+- Recording controls: start/stop, live duration, editable meeting title
+- Recent recordings list with per-item actions and a search box
+- Settings modal for API keys, models, auto mode, detection toggles, global shortcut, custom summary prompt, and known words
+- AI agent chat panel in the main window (see §6)
+- Progress indicators for transcription, Notion upload, and ffmpeg download
+- Renderer is vanilla JS (no React/framework); talks to main only via IPC
 
-### 3. AI Transcription & Processing
-- Integration with Google Gemini 2.5 Flash API
-- Audio file upload to Gemini API endpoint
-- Automatic segmentation for recordings longer than 5 minutes
-- Korean language focus with support for:
-  - Full meeting transcript with speaker identification
-  - Korean meeting summary
-  - Key points extraction
-  - Action items identification
-  - Auto-generated meeting titles from content
+### 3. AI Transcription and Summarization
+- Google Gemini 2.5 (Flash/Pro, configurable via `geminiModel` and `geminiFlashModel`)
+- Uploads audio through the Gemini files API; segments recordings longer than ~5 minutes
+- Korean-focused output: full transcript with speaker identification, summary, key points, action items, auto-generated title, and emoji icon
+- User-supplied `summaryPrompt` and `knownWords` (proper-noun hints) are injected into the prompt
 
-### 4. Notion Integration
-- Automatically upload transcription results to Notion
-- Create structured meeting notes in Notion database
-- Handle Notion's block size limits by splitting long transcripts
-- Include:
-  - Meeting title (with "by L.AI" suffix)
-  - Date/time
-  - Korean summary
-  - Key points
-  - Action items
-  - Full transcript
-  - Emoji icons for visual organization
+### 4. Notion Integration (BYOK)
+- User supplies `notionApiKey` + `notionDatabaseId`; the app writes structured pages into their own database
+- Long transcripts are split to respect Notion's block-size limits
+- Page contains: title (with "by L.AI" suffix), date, summary, key points, action items, transcript, emoji icon
+
+### 5. Local Search
+- Full-text search over stored transcriptions (`src/searchService.ts`)
+- No persistent index: each query rescans `transcriptions/` and re-reads frontmatter + body
+- Field weighting: title 10, summary 5, keyPoints/actionItems 3, transcript 1
+- Snippet extraction (~80 chars around first match)
+- Exposed via GUI search box and `listener search` CLI
+
+### 6. AI Agent Chat
+- Conversational access to saved meetings and settings (`src/agentService.ts`), backed by Gemini with a fixed tool set
+- Tools: `search_transcriptions`, `list_recent_transcriptions`, `get_transcription`, `get_config`, `set_config`
+- `set_config` write whitelist (non-secret keys only): `autoMode`, `meetingDetection`, `displayDetection`, `globalShortcut`, `maxRecordingMinutes`, `recordingReminderMinutes`, `minRecordingSeconds`, `geminiModel`, `geminiFlashModel`. API keys and Notion database ID can neither be read nor written by the agent.
+- Every `set_config` call requires explicit user confirmation through an IPC approval flow
+- Folder-name arguments are validated (NUL / path-separator rejection) to block traversal
+- Chat history lives only in renderer memory — lost on reload, not synced across devices or restarts
+- Available as GUI chat panel and `listener ask <question>` CLI
+
+### 7. Automatic Recording Triggers
+- **Meeting detection** (`src/meetingDetectorService.ts`, macOS): polls `pmset -g assertions` every 5s for `PreventUserIdleSleep` assertions owned by video-call processes, which distinguishes "app open" from "in a call". Confirms start after 2 consecutive detections, end after 3 non-detections.
+- **Display detection** (`src/displayDetectorService.ts`): listens to Electron `screen` `display-added`/`display-removed` events and prompts the user when an external display connects (projector-setup trigger).
+- Controlled by `meetingDetection` and `displayDetection` config flags.
 
 ## Technical Stack
-- Desktop framework: Electron (v37.2.0)
-- Audio recording: ffmpeg (auto-downloaded on first use)
-- AI Service: Google Gemini 2.5 Flash
-- Integration: Notion API
-- Language: TypeScript
-- Package Manager: pnpm
-- Node.js: v24.x
-
-## Current Implementation Status
-✅ 1. Audio recording with ffmpeg (auto-download support)
-✅ 2. Clean UI with recording controls and title management
-✅ 3. Gemini API integration for transcription with segmentation
-✅ 4. Notion API integration for structured note storage
-✅ 5. Error handling and progress tracking
-✅ 6. System tray integration with global shortcuts
-✅ 7. File drag-and-drop support for external audio files
-✅ 8. Metadata persistence for recordings
-✅ 9. CLI for headless transcription and config management
+- Electron 37.x
+- TypeScript 5.8, Node.js 24.x
+- pnpm (no workspaces)
+- `@google/genai` for Gemini
+- `@notionhq/client` (optional dependency)
+- `marked` for markdown rendering
+- Chromium `MediaRecorder` + Web Audio for mic capture (no external binary)
+- ffmpeg downloaded at runtime from `eugeneware/ffmpeg-static` GitHub releases, used only for long-audio segmentation in the transcription pipeline (NOT for recording — see FFmpeg Licensing)
+- Tests: Node's built-in `node --test` runner (no Jest/Vitest)
 
 ## CLI Usage
 
 ```
 listener <file> [--output <dir>]    Transcribe and summarize an audio file
-listener config list                Show all config values (API keys masked)
-listener config get <key>           Get a specific value
-listener config set <key> <value>   Set a value
-listener config path                Print config file path
+listener list [--limit <n>]         List past transcriptions
+listener show <ref>                  Print summary to stdout
+listener export <ref> [<path>] [--json] [--transcript]
+                                     Export a transcription
+listener search <query> [--limit <n>] [--transcript] [--field <name>]
+                                     Search past transcriptions
+listener ask <question> [--ref <ref>]
+                                     Ask the AI agent about meetings or settings
+listener config list|get|set|path    Manage configuration
 ```
 
-Config keys: `geminiApiKey`, `notionApiKey`, `notionDatabaseId`, `autoMode`, `globalShortcut`
+- `<ref>` is either an index from `listener list` or a transcription folder name.
+- `--field` accepts: `title`, `summary`, `keyPoints`, `actionItems`, `transcript`, `all`.
+- CLI and GUI share the same `config.json` in the app data directory.
 
-CLI and GUI share the same config file (`config.json` in the app data directory).
+## Configuration
 
-## Additional Implemented Features
-- Auto mode for hands-free operation
-- Korean language optimization
-- Cross-platform builds (macOS x64/arm64, Windows, Linux)
-- Secure API key storage in system config directory
-- macOS code signing and notarization support
-- Real-time transcription progress tracking
-- Automatic FFmpeg download with progress indicator
-- System tray/menu bar integration
-- Global keyboard shortcuts (configurable)
-- Audio file segmentation for long recordings (>5 minutes)
-- Automatic title generation from meeting content
-- File import via drag-and-drop or file dialog
-- Metadata storage for transcription results
+All values are stored in plaintext JSON at `getDataPath()/config.json`.
 
-## Background Recording Policy
-Recording starts silently -- never bring the window to foreground (no `show()`/`focus()`) and never fire a "Recording Started" notification. This applies to all recording triggers: global shortcut, tray click, meeting detection, and display detection. Display detection in particular is designed to be discreet -- the user allows recording via the notification without the app becoming visible. Only explicit user actions (dock click, tray menu "Open", notification click for non-recording events) should show the window.
+| Key | Purpose |
+|---|---|
+| `geminiApiKey` | Gemini API key (required for transcription) |
+| `geminiModel` | Gemini model for summary/agent |
+| `geminiFlashModel` | Flash model for cheaper/faster calls |
+| `notionApiKey`, `notionDatabaseId` | Optional Notion integration (BYOK) |
+| `autoMode` | Auto-transcribe and upload to Notion after recording |
+| `meetingDetection`, `displayDetection` | Auto-trigger sources |
+| `globalShortcut` | Start/stop hotkey |
+| `knownWords` | Proper nouns / jargon injected into Gemini prompt |
+| `summaryPrompt` | User-customized summary-stage prompt |
+| `maxRecordingMinutes` | Hard stop for long recordings |
+| `recordingReminderMinutes` | Reminder cadence |
+| `minRecordingSeconds` | Discards accidental short recordings |
+| `lastSeenVersion` | Drives "what's new" release-notes modal |
+
+Env-var fallbacks (read-only when the config key is empty): `GEMINI_API_KEY`, `NOTION_API_KEY`, `NOTION_DATABASE_ID`.
+
+## Transcription Storage
+
+- Root: `getDataPath()/transcriptions/`
+- One folder per meeting: `<sanitized-title>_<timestamp>/`
+  - `summary.md` — YAML frontmatter (`title`, `suggestedTitle`, `summary`, `keyPoints`, `actionItems`, `customFields`, `audioFilePath`, `transcribedAt`, `emoji`) plus markdown body
+  - `transcript.md` — full transcript
+  - Optional original audio file
+- `src/outputService.ts` is the only read/write surface: `saveTranscription`, `listTranscriptions`, `readTranscription`, `parseFrontmatter`, `getTranscriptionsDir`.
 
 ## Architecture Overview
 
-### CLI (`src/cli.ts`)
-- Headless transcription: `listener <file>`
-- Config management: `listener config list|get|set|path`
+### Entry points
+- `src/main.ts` — Electron main process, window lifecycle, and ~25 IPC handlers covering recording, config, agent chat, Notion, search, metadata, ffmpeg, and auto-update
+- `src/preload.ts` — `contextBridge` exposing `window.electronAPI` to the renderer
+- `src/cli.ts` — CLI entry, shares services with main
 
-### Main Process (`src/main.ts`)
-- Window management and IPC handlers
-- Menu bar/system tray integration
-- Global shortcut registration
-- File operations coordination
+### Renderer (at repo root, not under `src/`)
+- `index.html`, `renderer.js`, `styles.css` — vanilla JS, no framework
+- Included in the packaged build via `build.files`
 
-### Services
-- `simpleAudioRecorder.ts`: FFmpeg-based audio recording
-- `geminiService.ts`: Google Gemini API integration with chunking
-- `notionService.ts`: Notion API integration with block splitting
-- `configService.ts`: Secure configuration management
-- `ffmpegManager.ts`: FFmpeg download and management
-- `fileHandlerService.ts`: File import/export operations
-- `metadataService.ts`: Recording metadata persistence
-- `menuBarManager.ts`: System tray and menu management
+### Top-level services (`src/*.ts`)
+- `simpleAudioRecorder.ts` — thin session state + final file writer. Receives the encoded Opus/WebM blob from the renderer after `MediaRecorder` finalizes and writes it to the recordings directory. No ffmpeg spawn, no OS-specific device detection — all capture happens in the renderer.
+- `audioFormats.ts` — shared MIME/extension mapping (`mimeTypeForExtension`, `extensionForMimeType`, `SUPPORTED_AUDIO_EXTENSIONS`) used across main, CLI, Gemini upload, and file import paths.
+- `geminiService.ts` — file upload, transcription, summarization, segmentation
+- `notionService.ts` — Notion client, block splitting, page assembly
+- `configService.ts` — `config.json` read/write, env-var fallback, masking
+- `outputService.ts` — transcription folder layout and frontmatter serialization
+- `searchService.ts` — in-memory field-weighted search
+- `agentService.ts` — tool-using Gemini agent with confirmation flow
+- `meetingDetectorService.ts` — pmset-based in-call detection (macOS)
+- `displayDetectorService.ts` — Electron `screen` event wrapper
+- `menuBarManager.ts` — system tray / dock menu
+- `dataPath.ts` — platform-specific app data directory resolver
 
-### Renderer Process
-- `renderer.js`: UI logic and IPC communication
-- `index.html`: Main application UI
-- `styles.css`: Application styling
+### Subsystem services (`src/services/*.ts`)
+- `ffmpegManager.ts` — ffmpeg detection, download, checksum verification scaffolding
+- `fileHandlerService.ts` — drag-and-drop import and file dialogs
+- `metadataService.ts` — pre-transcription recording metadata
+- `notificationService.ts` — system notification helpers
+- `autoUpdaterService.ts` — electron-updater wrapper
+- `releaseNotesService.ts` — "what's new" modal driver (reads `lastSeenVersion`)
 
-### Release & Auto-Update
-- macOS x64 and arm64 must be built together in single job (`--mac --x64 --arm64`)
-- Reason: electron-builder generates `latest-mac.yml` with both architectures listed
-- If built separately, each job overwrites the yml and one architecture gets wrong binary
-- electron-updater uses filename patterns (x64/arm64) to serve correct binary to each user
-- Auto-update is disabled when `app.isPackaged === false` (dev mode)
-- To test auto-update, must use packaged build (not `pnpm start`)
-- Browser fallback: when auto-update fails, show dialog with link to GitHub releases
-- macOS auto-update requires ZIP files (not DMG) - electron-updater downloads ZIP for in-place updates
-- Blockmaps (*.blockmap) enable differential updates - users download only changed blocks
-- GitHub workflow must upload both ZIP and blockmap files alongside DMG for auto-update to work
+### Tests
+- Test files: `agentService.test.ts`, `searchService.test.ts`, `meetingDetectorService.test.ts`
+- Run: `pnpm test` (builds with tsc, then executes compiled `.test.js` with `node --test`)
+
+## Background Recording Policy
+Recording starts silently — never bring the window to foreground (no `show()`/`focus()`) and never fire a "Recording Started" notification. This applies to all recording triggers: global shortcut, tray click, meeting detection, and display detection. Display detection in particular is designed to be discreet — the user allows recording via the notification without the app becoming visible. Only explicit user actions (dock click, tray menu "Open", notification click for non-recording events) should show the window.
+
+## Release and Auto-Update
+- macOS x64 and arm64 must be built together in a single job (`--mac --x64 --arm64`).
+- Reason: electron-builder generates one `latest-mac.yml` listing both architectures. Separate jobs overwrite each other's yml and one arch ends up pointing at the wrong binary.
+- electron-updater uses filename patterns (x64/arm64) to serve the correct binary to each user.
+- Auto-update is disabled when `app.isPackaged === false` (dev mode). Test with a packaged build, not `pnpm start`.
+- Browser fallback: when auto-update fails, show a dialog with a link to GitHub releases.
+- macOS auto-update requires ZIP artifacts (not DMG); electron-updater downloads the ZIP for in-place replacement.
+- Blockmap files (`*.blockmap`) enable differential updates — users download only the changed blocks.
+- The GitHub workflow must publish ZIP + blockmap alongside DMG for auto-update to work.
 
 ## FFmpeg Licensing
-- FFmpeg binaries are downloaded at runtime from `eugeneware/ffmpeg-static` GitHub releases (not bundled)
-- The `ffmpeg-static` npm package/repo is **GPL-3.0** licensed
-- FFmpeg itself is LGPL 2.1+ for default builds; our use case (MP3 via libmp3lame) stays within LGPL
-- Do NOT add `ffmpeg-static` as an npm dependency -- it would impose GPL-3.0 on the project
-- For CLI npm distribution: prefer requiring user-installed ffmpeg, or keep the current runtime download approach
-- Runtime download (current): legally better than bundling, but still downloads from a GPL-3.0-wrapped repo
-- SHA256 checksums in `ffmpegManager.ts` are empty (`// TODO`) -- should be filled for integrity verification
+- ffmpeg binaries are downloaded at runtime from `eugeneware/ffmpeg-static` GitHub releases, not bundled.
+- `ffmpeg-static` (the npm package/repo) is GPL-3.0-licensed.
+- ffmpeg itself is LGPL 2.1+ for default builds; the MP3-via-libmp3lame use case stays within LGPL.
+- Do NOT add `ffmpeg-static` as an npm dependency — it would impose GPL-3.0 on the project.
+- For CLI npm distribution: prefer requiring user-installed ffmpeg, or keep the runtime-download approach.
+- SHA256 checksums in `ffmpegManager.ts` are currently empty (`// TODO`) — fill them in for integrity verification.
 
 ## npm Distribution
-- Package name: `listener-ai`
-- Only the CLI portion is published to npm (Electron app uses GitHub Releases)
-- Electron-only runtime deps (`electron-updater`, `@notionhq/client`) are in `optionalDependencies` -- honest semantics for a package serving both Electron and CLI users. `build.files` includes `node_modules/**/*`, so they're still bundled in Electron builds.
+- Package name: `listener-ai`. Only the CLI portion is published to npm (Electron app ships via GitHub Releases).
+- Electron-only runtime deps (`electron-updater`, `@notionhq/client`) live in `optionalDependencies` — honest semantics for a package serving both Electron and CLI users. `build.files` includes `node_modules/**/*`, so they are still bundled in Electron builds.
+- `package.json.files` whitelists the exact compiled JS shipped to npm: `dist/cli.js`, `dataPath.js`, `configService.js`, `geminiService.js`, `outputService.js`, `searchService.js`, `agentService.js`, `services/ffmpegManager.js`.
 
 ## Future Enhancements (Optional)
+- Cloud sync of transcriptions, settings, and agent chat history across devices
+- Email delivery of summaries / weekly digests
 - Live transcription during recording
-- Advanced keyword extraction and tagging
-- Full multi-language support (currently Korean-focused)
-- Export to other formats (PDF, Markdown)
-- Cloud backup of audio files
-- Bundled FFmpeg binaries for all platforms
 - Speaker diarization improvements
-- Meeting analytics and insights
+- Export to PDF
+- Full multi-language support beyond Korean
+- Bundled ffmpeg for all platforms (subject to licensing)

--- a/js/fileHandler.js
+++ b/js/fileHandler.js
@@ -2,11 +2,26 @@
 
 class FileHandler {
   constructor() {
-    // Use Set for O(1) lookups instead of Array O(n)
-    this.validTypes = new Set(['audio/mp3', 'audio/mpeg', 'audio/mp4', 'audio/x-m4a', 'audio/m4a']);
-    this.validExtensions = new Set(['.mp3', '.m4a']);
-    this.maxSize = 500 * 1024 * 1024; // 500MB
-    this.chunkSize = 0x8000; // 32KB for base64 conversion
+    this.validTypes = new Set([
+      'audio/mp3', 'audio/mpeg',
+      'audio/mp4', 'audio/x-m4a', 'audio/m4a',
+      'audio/wav', 'audio/x-wav', 'audio/wave',
+      'audio/webm', 'audio/ogg', 'audio/opus',
+      'audio/flac', 'audio/aac',
+    ]);
+    this.validExtensions = new Set(['.mp3', '.m4a', '.wav', '.webm', '.ogg', '.opus', '.flac', '.aac']);
+    this.extensionMimes = {
+      '.mp3': 'audio/mp3',
+      '.m4a': 'audio/mp4',
+      '.wav': 'audio/wav',
+      '.webm': 'audio/webm',
+      '.ogg': 'audio/ogg',
+      '.opus': 'audio/ogg',
+      '.flac': 'audio/flac',
+      '.aac': 'audio/aac',
+    };
+    this.maxSize = 500 * 1024 * 1024;
+    this.chunkSize = 0x8000;
   }
 
   // Validate file before processing
@@ -33,7 +48,7 @@ class FileHandler {
     const hasValidExtension = fileExtension && this.validExtensions.has(fileExtension);
 
     if (!hasValidType && !hasValidExtension) {
-      throw new Error('Please select an MP3 or M4A audio file');
+      throw new Error('Please select a supported audio file (MP3, M4A, WAV, WebM, OGG, Opus, FLAC, AAC)');
     }
 
     return true;
@@ -124,14 +139,14 @@ class FileHandler {
       const fileInfo = await window.electronAPI.getFileInfo(result.filePath);
       
       if (fileInfo.success) {
-        // Create a pseudo-file object with path for efficient copying
+        const ext = fileInfo.name.toLowerCase().substring(fileInfo.name.lastIndexOf('.'));
         const fileWithPath = {
           name: fileInfo.name,
           path: result.filePath,
           size: fileInfo.size,
-          type: fileInfo.name.endsWith('.mp3') ? 'audio/mp3' : 'audio/m4a'
+          type: this.extensionMimes[ext] || 'application/octet-stream',
         };
-        
+
         return await this.processAudioFile(fileWithPath);
       } else {
         throw new Error('Failed to get file info');

--- a/renderer.js
+++ b/renderer.js
@@ -1156,6 +1156,10 @@ async function handleTranscribe(filePath, title) {
 
       populateTranscriptionUI(result.data);
 
+      // Refresh the main recordings list so the renamed file and "View Transcript"
+      // state appear without requiring a manual reload.
+      await refreshRecordingsList();
+
       // Show upload to Notion button if configured
       const notionConfig = await window.electronAPI.getConfig();
       if (notionConfig.notionApiKey && notionConfig.notionDatabaseId) {

--- a/renderer.js
+++ b/renderer.js
@@ -36,6 +36,85 @@ let recordingStartTime = null;
 let timerInterval = null;
 let isAutoModeProcessing = false; // Track if auto mode is processing
 
+// MediaRecorder state (renderer owns audio capture; main only persists the final blob).
+// Constraints disable Chromium's AUVoiceIO path so macOS Voice Isolation can't touch the signal.
+let mediaStream = null;
+let mediaRecorder = null;
+let recordedChunks = [];
+let recordingMimeType = '';
+let audioContext = null;
+let processedStream = null;
+
+function pickRecordingMimeType() {
+  const candidates = [
+    'audio/webm;codecs=opus',
+    'audio/ogg;codecs=opus',
+    'audio/mp4;codecs=mp4a.40.2',
+    'audio/webm',
+  ];
+  for (const mime of candidates) {
+    if (typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported(mime)) {
+      return mime;
+    }
+  }
+  return '';
+}
+
+// Voice-meeting processing chain:
+//   highpass 80Hz (rumble/plosive cut)
+//   -> DynamicsCompressor (fast attack tames keyboard taps & close transients)
+//   -> makeup gain (+12dB) lifts distant speakers back up
+// Net effect: distant voices become audible without amplifying key clicks equally.
+function buildProcessedStream(inputStream) {
+  const ctx = new AudioContext({ sampleRate: 48000 });
+  const source = ctx.createMediaStreamSource(inputStream);
+
+  const highpass = ctx.createBiquadFilter();
+  highpass.type = 'highpass';
+  highpass.frequency.value = 80;
+
+  const compressor = ctx.createDynamicsCompressor();
+  compressor.threshold.value = -30;
+  compressor.knee.value = 20;
+  compressor.ratio.value = 8;
+  compressor.attack.value = 0.003;
+  compressor.release.value = 0.2;
+
+  const gain = ctx.createGain();
+  gain.gain.value = 4.0;
+
+  // Brick-wall limiter after the +12dB makeup gain so close-range speech can't
+  // clip into the Opus encoder when the compressor's attack/release lets a peak through.
+  const limiter = ctx.createDynamicsCompressor();
+  limiter.threshold.value = -1;
+  limiter.knee.value = 0;
+  limiter.ratio.value = 20;
+  limiter.attack.value = 0;
+  limiter.release.value = 0.1;
+
+  const destination = ctx.createMediaStreamDestination();
+  source.connect(highpass).connect(compressor).connect(gain).connect(limiter).connect(destination);
+  return { ctx, stream: destination.stream };
+}
+
+function teardownAudioGraph() {
+  if (audioContext) {
+    audioContext.close().catch((e) => console.warn('AudioContext close:', e));
+    audioContext = null;
+  }
+  processedStream = null;
+}
+
+function cleanupAudioState() {
+  if (mediaStream) {
+    mediaStream.getTracks().forEach((t) => t.stop());
+    mediaStream = null;
+  }
+  teardownAudioGraph();
+  mediaRecorder = null;
+  recordedChunks = [];
+}
+
 // Initialize these after DOM loads to avoid null errors
 let recordButton, statusIndicator, statusText, recordingTime, meetingTitle, recordingsList, autoModeToggle;
 let progressContainer = null;
@@ -344,57 +423,93 @@ window.addEventListener('DOMContentLoaded', async () => {
 });
 
 async function startRecording() {
-  // Prevent starting a new recording if auto mode is processing
   if (isAutoModeProcessing) {
     alert('Please wait for auto mode processing to complete before starting a new recording.');
     return;
   }
 
-  // Check if FFmpeg is available
-  const ffmpegCheck = await window.electronAPI.checkFFmpeg();
-  if (!ffmpegCheck.available) {
-    // Show download dialog
-    await showFFmpegDownloadDialog();
+  const title = meetingTitle.value.trim() || 'Untitled_Meeting';
+
+  // Acquire the mic before telling main, so permission prompts don't leave main state dangling.
+  try {
+    mediaStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+        sampleRate: 48000,
+        channelCount: 1,
+      },
+    });
+  } catch (error) {
+    const name = error && error.name ? error.name : '';
+    if (name === 'NotAllowedError' || name === 'SecurityError') {
+      if (confirm('Microphone access is required to record audio.\n\nOpen System Settings to grant permission?')) {
+        await window.electronAPI.openMicrophoneSettings();
+      }
+    } else if (name === 'NotFoundError' || name === 'OverconstrainedError') {
+      if (confirm('No microphone was detected.\n\nOpen System Settings to check input devices?')) {
+        await window.electronAPI.openMicrophoneSettings();
+      }
+    } else {
+      alert('Failed to access microphone: ' + (error && error.message ? error.message : String(error)));
+    }
     return;
   }
 
-  const title = meetingTitle.value.trim() || 'Untitled_Meeting';
+  recordingMimeType = pickRecordingMimeType();
+
+  try {
+    const graph = buildProcessedStream(mediaStream);
+    audioContext = graph.ctx;
+    processedStream = graph.stream;
+    mediaRecorder = recordingMimeType
+      ? new MediaRecorder(processedStream, { mimeType: recordingMimeType, audioBitsPerSecond: 64000 })
+      : new MediaRecorder(processedStream, { audioBitsPerSecond: 64000 });
+    recordedChunks = [];
+    mediaRecorder.ondataavailable = (event) => {
+      if (event.data && event.data.size > 0) recordedChunks.push(event.data);
+    };
+    mediaRecorder.onerror = (event) => {
+      const err = event && event.error ? event.error : event;
+      console.error('MediaRecorder error:', err);
+      cleanupAudioState();
+      resetRecordingUI();
+      window.electronAPI.stopRecording().catch(() => {});
+      alert('Recording failed: ' + (err && err.message ? err.message : 'Unknown error'));
+    };
+    mediaRecorder.start(1000);
+  } catch (error) {
+    cleanupAudioState();
+    alert('Failed to initialize recorder: ' + (error && error.message ? error.message : String(error)));
+    return;
+  }
 
   try {
     const result = await window.electronAPI.startRecording(title);
-    if (result.success) {
-      isRecording = true;
-      recordingStartTime = Date.now();
-
-      recordButton.textContent = 'Stop Recording';
-      recordButton.classList.add('recording');
-      statusIndicator.classList.add('recording');
-      statusText.textContent = 'Recording...';
-      recordingTime.classList.add('active');
-
-      startTimer();
-    } else {
-      // Handle error - check what type of error
-      if (result.error && result.error.includes('FFmpeg not found')) {
-        // FFmpeg check should have already happened above, but just in case
-        await showFFmpegDownloadDialog();
-      } else if (result.error && result.error.includes('Microphone permission denied')) {
-        // Show permission error with button to open settings
-        if (confirm('Microphone access is required to record audio.\n\nWould you like to open System Settings to grant permission?\n\nAfter granting permission, please restart Listener.AI.')) {
-          await window.electronAPI.openMicrophoneSettings();
-        }
-      } else if (result.error && result.error.includes('No audio devices found')) {
-        // This might be due to permissions or no microphone connected
-        if (confirm('No microphone was detected.\n\nThis could be because:\n1. Microphone permissions are denied\n2. No microphone is connected\n3. Audio drivers need updating\n\nWould you like to check System Settings?')) {
-          await window.electronAPI.openMicrophoneSettings();
-        }
-      } else {
-        alert('Failed to start recording: ' + (result.error || 'Unknown error'));
-      }
+    if (!result.success) {
+      if (mediaRecorder && mediaRecorder.state !== 'inactive') mediaRecorder.stop();
+      cleanupAudioState();
+      alert('Failed to start recording: ' + (result.error || 'Unknown error'));
+      return;
     }
   } catch (error) {
+    if (mediaRecorder && mediaRecorder.state !== 'inactive') mediaRecorder.stop();
+    cleanupAudioState();
     alert('Failed to start recording: ' + error.message);
+    return;
   }
+
+  isRecording = true;
+  recordingStartTime = Date.now();
+
+  recordButton.textContent = 'Stop Recording';
+  recordButton.classList.add('recording');
+  statusIndicator.classList.add('recording');
+  statusText.textContent = 'Recording...';
+  recordingTime.classList.add('active');
+
+  startTimer();
 }
 
 function resetRecordingUI() {
@@ -500,13 +615,51 @@ async function handleRecordingStopped(audioPath, durationMs) {
 }
 
 async function stopRecording() {
+  if (!mediaRecorder || mediaRecorder.state === 'inactive') return;
+
   try {
-    const result = await window.electronAPI.stopRecording();
-    if (result.success) {
-      await handleRecordingStopped(result.filePath, result.durationMs);
+    const stopped = new Promise((resolve) => {
+      mediaRecorder.onstop = () => resolve();
+    });
+    mediaRecorder.stop();
+    await stopped;
+
+    const chunks = recordedChunks;
+    const mimeType = mediaRecorder.mimeType || recordingMimeType || 'audio/webm';
+    cleanupAudioState();
+
+    const blob = new Blob(chunks, { type: mimeType });
+    const durationMs = recordingStartTime ? Date.now() - recordingStartTime : 0;
+
+    const stopSignal = await window.electronAPI.stopRecording();
+    if (!stopSignal.success) {
+      console.warn('stop-recording signal returned failure:', stopSignal.error);
+    }
+
+    if (blob.size === 0) {
+      alert('No audio captured.');
+      resetRecordingUI();
+      return;
+    }
+
+    const title = meetingTitle.value.trim() || 'Untitled_Meeting';
+    const saveResult = await window.electronAPI.saveRecording({
+      title,
+      mimeType,
+      durationMs,
+      data: new Uint8Array(await blob.arrayBuffer()),
+    });
+
+    if (saveResult.success) {
+      await handleRecordingStopped(saveResult.filePath, saveResult.durationMs ?? durationMs);
+    } else {
+      alert('Failed to save recording: ' + (saveResult.error || 'Unknown error'));
+      resetRecordingUI();
     }
   } catch (error) {
     alert('Failed to stop recording: ' + error.message);
+    cleanupAudioState();
+    resetRecordingUI();
   }
 }
 
@@ -534,9 +687,11 @@ window.electronAPI.onRecordingStatus((status) => {
 });
 
 if (window.electronAPI.onRecordingAutoStopped) {
-  window.electronAPI.onRecordingAutoStopped(async (data) => {
+  window.electronAPI.onRecordingAutoStopped(async () => {
     showToast('Recording auto-stopped - reached time limit');
-    await handleRecordingStopped(data?.filePath, data?.durationMs);
+    if (isRecording) {
+      await stopRecording();
+    }
   });
 }
 
@@ -1156,6 +1311,9 @@ async function createRecordingItem(recording) {
           Transcribe
         </button>
       `}
+      <button class="action-button reveal-btn" data-path="${recording.path}" title="Reveal in Finder (right-click in Finder to share)">
+        Show
+      </button>
     </div>
   `;
 
@@ -1176,6 +1334,13 @@ async function createRecordingItem(recording) {
     const transcribeBtn = item.querySelector('.transcribe-btn');
     transcribeBtn.addEventListener('click', () => {
       handleTranscribe(recording.path, recording.title);
+    });
+  }
+
+  const revealBtn = item.querySelector('.reveal-btn');
+  if (revealBtn && window.electronAPI.showInFinder) {
+    revealBtn.addEventListener('click', () => {
+      window.electronAPI.showInFinder(recording.path);
     });
   }
 
@@ -1610,7 +1775,7 @@ function setupPasteListener() {
           const file = item.getAsFile();
           if (file && file.name) {
             const ext = file.name.toLowerCase().substring(file.name.lastIndexOf('.'));
-            if (ext === '.mp3' || ext === '.m4a') {
+            if (ext === '.mp3' || ext === '.m4a' || ext === '.webm' || ext === '.ogg' || ext === '.opus' || ext === '.wav') {
               audioFile = file;
               break;
             }
@@ -1632,7 +1797,7 @@ function setupPasteListener() {
     } else {
       // Check if clipboard contains file paths (text)
       const text = e.clipboardData.getData('text');
-      if (text && (text.toLowerCase().endsWith('.mp3') || text.toLowerCase().endsWith('.m4a'))) {
+      if (text && /\.(mp3|m4a|webm|ogg|opus|wav)$/i.test(text.toLowerCase())) {
         showToast('Please copy the actual audio file, not just its path', 'error');
       }
     }

--- a/renderer.js
+++ b/renderer.js
@@ -615,7 +615,15 @@ async function handleRecordingStopped(audioPath, durationMs) {
 }
 
 async function stopRecording() {
-  if (!mediaRecorder || mediaRecorder.state === 'inactive') return;
+  // If the recorder already transitioned to inactive on its own (e.g. USB mic
+  // unplugged, stream ended, Chromium force-stopped encoding), still unwind the
+  // session so the next recording isn't blocked by stuck state.
+  if (!mediaRecorder || mediaRecorder.state === 'inactive') {
+    cleanupAudioState();
+    await window.electronAPI.stopRecording().catch(() => {});
+    resetRecordingUI();
+    return;
+  }
 
   try {
     const stopped = new Promise((resolve) => {

--- a/src/audioFormats.ts
+++ b/src/audioFormats.ts
@@ -1,0 +1,52 @@
+export const SUPPORTED_AUDIO_EXTENSIONS = [
+  '.mp3',
+  '.m4a',
+  '.wav',
+  '.webm',
+  '.ogg',
+  '.opus',
+  '.flac',
+  '.aac',
+  '.wma',
+] as const;
+
+const MIME_FOR_EXTENSION: Record<string, string> = {
+  '.mp3': 'audio/mp3',
+  '.m4a': 'audio/mp4',
+  '.wav': 'audio/wav',
+  '.webm': 'audio/webm',
+  '.ogg': 'audio/ogg',
+  '.opus': 'audio/ogg',
+  '.flac': 'audio/flac',
+  '.aac': 'audio/aac',
+};
+
+const EXTENSION_FOR_MIME: Record<string, string> = {
+  'audio/mp3': 'mp3',
+  'audio/mpeg': 'mp3',
+  'audio/mp4': 'm4a',
+  'audio/x-m4a': 'm4a',
+  'audio/aac': 'm4a',
+  'audio/wav': 'wav',
+  'audio/wave': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/webm': 'webm',
+  'audio/ogg': 'ogg',
+  'audio/opus': 'opus',
+  'audio/flac': 'flac',
+};
+
+export function mimeTypeForExtension(ext: string): string {
+  const normalized = ext.startsWith('.') ? ext.toLowerCase() : `.${ext.toLowerCase()}`;
+  return MIME_FOR_EXTENSION[normalized] ?? 'audio/mp3';
+}
+
+export function extensionForMimeType(mimeType: string): string {
+  const base = mimeType.split(';')[0].trim().toLowerCase();
+  return EXTENSION_FOR_MIME[base] ?? 'webm';
+}
+
+export function isSupportedAudioExtension(ext: string): boolean {
+  const normalized = ext.startsWith('.') ? ext.toLowerCase() : `.${ext.toLowerCase()}`;
+  return (SUPPORTED_AUDIO_EXTENSIONS as readonly string[]).includes(normalized);
+}

--- a/src/audioFormats.ts
+++ b/src/audioFormats.ts
@@ -7,7 +7,6 @@ export const SUPPORTED_AUDIO_EXTENSIONS = [
   '.opus',
   '.flac',
   '.aac',
-  '.wma',
 ] as const;
 
 const MIME_FOR_EXTENSION: Record<string, string> = {

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -2,6 +2,7 @@ import { GoogleGenAI } from '@google/genai';
 import * as fs from 'fs';
 import * as path from 'path';
 import { FFmpegManager } from './services/ffmpegManager';
+import { mimeTypeForExtension } from './audioFormats';
 
 export interface TranscriptionResult {
   transcript: string;
@@ -348,13 +349,7 @@ Return as JSON:
           progressCallback(25, 'Uploading large file to Gemini...');
         }
 
-        const fileExt = path.extname(audioFilePath).toLowerCase();
-        let mimeType = 'audio/mp3';
-        if (fileExt === '.wav') {
-          mimeType = 'audio/wav';
-        } else if (fileExt === '.m4a') {
-          mimeType = 'audio/mp4';
-        }
+        const mimeType = mimeTypeForExtension(path.extname(audioFilePath));
 
         const fileData = fs.readFileSync(audioFilePath);
         const uploadResult = await this.ai.files.upload({
@@ -407,13 +402,7 @@ IMPORTANT:
 
       let result;
       if (fileUri) {
-        const fileExt = path.extname(audioFilePath).toLowerCase();
-        let mimeType = 'audio/mp3';
-        if (fileExt === '.wav') {
-          mimeType = 'audio/wav';
-        } else if (fileExt === '.m4a') {
-          mimeType = 'audio/mp4';
-        }
+        const mimeType = mimeTypeForExtension(path.extname(audioFilePath));
 
         result = await this.ai.models.generateContent({
           model: this.flashModel,
@@ -439,13 +428,7 @@ IMPORTANT:
       } else {
         const audioData = fs.readFileSync(audioFilePath);
         const base64Audio = audioData.toString('base64');
-        const fileExt = path.extname(audioFilePath).toLowerCase();
-        let mimeType = 'audio/mp3';
-        if (fileExt === '.wav') {
-          mimeType = 'audio/wav';
-        } else if (fileExt === '.m4a') {
-          mimeType = 'audio/mp4';
-        }
+        const mimeType = mimeTypeForExtension(path.extname(audioFilePath));
 
         result = await this.ai.models.generateContent({
           model: this.flashModel,
@@ -535,8 +518,7 @@ IMPORTANT:
 
         const audioData = fs.readFileSync(segmentFile);
         const base64Audio = audioData.toString('base64');
-        const fileExt = path.extname(segmentFile).toLowerCase();
-        const mimeType = fileExt === '.mp3' ? 'audio/mp3' : 'audio/wav';
+        const mimeType = mimeTypeForExtension(path.extname(segmentFile));
 
         const result = await this.ai.models.generateContent({
           model: this.flashModel,

--- a/src/main.ts
+++ b/src/main.ts
@@ -528,15 +528,15 @@ ipcMain.handle('start-recording', async (_, meetingTitle: string) => {
         if (!audioRecorder.isRecording()) return;
         notificationService.notifyRecordingAutoStopped(maxMinutes);
         if (mainWindow && !mainWindow.isDestroyed()) {
-          // Renderer owns MediaRecorder — it will stop, save, and reset state via save-recording.
+          // Renderer owns MediaRecorder — it will stop, save, and re-enter stop-recording via IPC.
           mainWindow.webContents.send('recording-auto-stopped', { reason: 'maxDuration', maxMinutes });
-        } else {
-          // Window gone so renderer can't save the file; at least clear main state
-          // so the next recording isn't blocked by a stuck isRecording() flag.
-          audioRecorder.stopRecording();
-          menuBarManager.updateRecordingState(false);
-          meetingAutoStartedRecording = false;
         }
+        // Always reset main-side state so an unresponsive or hung renderer can't leave the
+        // isRecording() flag stuck and block future recordings. stopRecording() is idempotent,
+        // so the renderer's own stop-recording IPC (if it runs) is a safe no-op here.
+        audioRecorder.stopRecording();
+        menuBarManager.updateRecordingState(false);
+        meetingAutoStartedRecording = false;
       }, maxMinutes * 60 * 1000);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { fetchReleaseNotes, fetchAllReleases } from './services/releaseNotesServ
 import { saveTranscription, readTranscription } from './outputService';
 import { searchTranscriptions, ALL_FIELDS, type SearchField } from './searchService';
 import { AgentService, type AgentChatMessage, type AgentRunResult, type AgentScope, type ConfigProposal } from './agentService';
+import { isSupportedAudioExtension, extensionForMimeType } from './audioFormats';
 
 // Global flag to track if app is quitting
 declare global {
@@ -511,47 +512,43 @@ ipcMain.handle('cancel-ffmpeg-download', async () => {
   return { success: true };
 });
 
+// Audio capture runs in the renderer via MediaRecorder; main only tracks state,
+// runs max/reminder timers, updates the menu bar, and writes the final blob to disk.
 ipcMain.handle('start-recording', async (_, meetingTitle: string) => {
   try {
-    const result = await audioRecorder.startRecording(meetingTitle);
-    // Update menu bar icon state
-    if (result.success) {
-      menuBarManager.updateRecordingState(true, meetingTitle);
+    const result = audioRecorder.startRecording(meetingTitle);
+    if (!result.success) return result;
 
-      // Set up recording limit timer
-      const maxMinutes = configService.getMaxRecordingMinutes();
-      if (maxMinutes > 0) {
-        recordingMaxTimer = setTimeout(async () => {
-          clearRecordingTimers();
-          if (audioRecorder.isRecording()) {
-            try {
-              const stopResult = await audioRecorder.stopRecording();
-              menuBarManager.updateRecordingState(false);
-              meetingAutoStartedRecording = false;
-              if (stopResult.success) {
-                notificationService.notifyRecordingAutoStopped(maxMinutes);
-              }
-              if (mainWindow && !mainWindow.isDestroyed()) {
-                mainWindow.webContents.send('recording-auto-stopped', stopResult);
-              }
-            } catch (error) {
-              console.error('Error auto-stopping recording:', error);
-            }
-          }
-        }, maxMinutes * 60 * 1000);
-      }
+    menuBarManager.updateRecordingState(true, meetingTitle);
 
-      // Set up recording reminder interval
-      const reminderMinutes = configService.getRecordingReminderMinutes();
-      if (reminderMinutes > 0) {
-        let elapsed = 0;
-        recordingReminderTimer = setInterval(() => {
-          elapsed += reminderMinutes;
-          if (audioRecorder.isRecording()) {
-            notificationService.notifyRecordingReminder(elapsed);
-          }
-        }, reminderMinutes * 60 * 1000);
-      }
+    const maxMinutes = configService.getMaxRecordingMinutes();
+    if (maxMinutes > 0) {
+      recordingMaxTimer = setTimeout(() => {
+        clearRecordingTimers();
+        if (!audioRecorder.isRecording()) return;
+        notificationService.notifyRecordingAutoStopped(maxMinutes);
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          // Renderer owns MediaRecorder — it will stop, save, and reset state via save-recording.
+          mainWindow.webContents.send('recording-auto-stopped', { reason: 'maxDuration', maxMinutes });
+        } else {
+          // Window gone so renderer can't save the file; at least clear main state
+          // so the next recording isn't blocked by a stuck isRecording() flag.
+          audioRecorder.stopRecording();
+          menuBarManager.updateRecordingState(false);
+          meetingAutoStartedRecording = false;
+        }
+      }, maxMinutes * 60 * 1000);
+    }
+
+    const reminderMinutes = configService.getRecordingReminderMinutes();
+    if (reminderMinutes > 0) {
+      let elapsed = 0;
+      recordingReminderTimer = setInterval(() => {
+        elapsed += reminderMinutes;
+        if (audioRecorder.isRecording()) {
+          notificationService.notifyRecordingReminder(elapsed);
+        }
+      }, reminderMinutes * 60 * 1000);
     }
 
     return result;
@@ -565,18 +562,32 @@ ipcMain.handle('start-recording', async (_, meetingTitle: string) => {
 ipcMain.handle('stop-recording', async () => {
   try {
     clearRecordingTimers();
-    const result = await audioRecorder.stopRecording();
+    const result = audioRecorder.stopRecording();
 
-    // Update menu bar icon state
     menuBarManager.updateRecordingState(false);
     meetingAutoStartedRecording = false;
-    if (result.success) {
-      notificationService.notifyRecordingStopped();
-    }
 
     return result;
   } catch (error) {
     console.error('Error stopping recording:', error);
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+});
+
+// Receives the encoded audio blob from the renderer after MediaRecorder finalizes.
+// The "stopped" notification only fires once the file is actually on disk — otherwise
+// a failed write would still show a success toast.
+ipcMain.handle('save-recording', async (_, payload: { title: string; mimeType: string; durationMs: number; data: ArrayBuffer | Uint8Array }) => {
+  try {
+    const buf = Buffer.from(payload.data as ArrayBuffer);
+    const extension = extensionForMimeType(payload.mimeType);
+    const result = await audioRecorder.saveRecording(payload.title, buf, extension, payload.durationMs);
+    if (result.success) {
+      notificationService.notifyRecordingStopped();
+    }
+    return result;
+  } catch (error) {
+    console.error('Error saving recording:', error);
     return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
 });
@@ -883,6 +894,19 @@ ipcMain.handle('open-recordings-folder', async () => {
   shell.openPath(recordingsPath);
 });
 
+// Reveal a specific recording in Finder/Explorer. This gives the user a
+// one-click path to native OS share tools (right-click -> Share -> AirDrop,
+// Messages, Mail, KakaoTalk, etc.) without us having to integrate each target.
+ipcMain.handle('show-in-finder', (_, filePath: string) => {
+  if (!filePath) return { success: false, error: 'No file path provided' };
+  try {
+    shell.showItemInFolder(filePath);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+});
+
 // Search past transcriptions
 ipcMain.handle('search-transcriptions', async (_, opts: { query: string; fields?: SearchField[]; limit?: number }) => {
   try {
@@ -944,7 +968,7 @@ ipcMain.handle('get-recordings', async () => {
       .filter((file: string) => {
         // Filter out segment files
         if (file.includes('_segment_')) return false;
-        return file.endsWith('.mp3') || file.endsWith('.wav') || file.endsWith('.m4a');
+        return isSupportedAudioExtension(path.extname(file));
       })
       .map((file: string) => {
         const filePath = path.join(recordingsDir, file);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -4,6 +4,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   platform: process.platform,
   startRecording: (meetingTitle: string) => ipcRenderer.invoke('start-recording', meetingTitle),
   stopRecording: () => ipcRenderer.invoke('stop-recording'),
+  saveRecording: (payload: { title: string; mimeType: string; durationMs: number; data: Uint8Array }) =>
+    ipcRenderer.invoke('save-recording', payload),
   onRecordingStatus: (callback: (status: string) => void) => {
     ipcRenderer.on('recording-status', (_, status) => callback(status));
   },
@@ -16,6 +18,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('upload-to-notion', data),
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
   openRecordingsFolder: () => ipcRenderer.invoke('open-recordings-folder'),
+  showInFinder: (filePath: string) => ipcRenderer.invoke('show-in-finder', filePath),
   getRecordings: () => ipcRenderer.invoke('get-recordings'),
   searchTranscriptions: (opts: { query: string; fields?: string[]; limit?: number }) =>
     ipcRenderer.invoke('search-transcriptions', opts),

--- a/src/simpleAudioRecorder.ts
+++ b/src/simpleAudioRecorder.ts
@@ -1,413 +1,82 @@
-import { spawn, ChildProcess, exec, execSync } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 import { app } from 'electron';
-import { promisify } from 'util';
-import { FFmpegManager } from './services/ffmpegManager';
 
-// Use FFmpegManager for FFmpeg path resolution
-const ffmpegManager = new FFmpegManager();
-
-// Helper function to find FFmpeg binary (now delegates to FFmpegManager)
-async function findFFmpegBinary(): Promise<string | null> {
-  return await ffmpegManager.ensureFFmpeg();
-}
-
+// Audio capture runs in the renderer via `navigator.mediaDevices.getUserMedia()`
+// and `MediaRecorder` (Chromium's audio path, which sits on Core Audio HAL directly
+// and bypasses ffmpeg's `AVCaptureAudioDataOutput` that produced periodic ticks).
+// This class only tracks per-session state and writes the final encoded blob to disk.
 export class SimpleAudioRecorder {
-  private recordingProcess: ChildProcess | null = null;
   private outputPath: string | null = null;
   private startTime: number | null = null;
+  private recordingActive = false;
+  private meetingTitle: string | null = null;
 
   constructor() {
-    // Create recordings directory if it doesn't exist
     const recordingsDir = path.join(app.getPath('userData'), 'recordings');
     if (!fs.existsSync(recordingsDir)) {
       fs.mkdirSync(recordingsDir, { recursive: true });
     }
   }
 
-  private async detectAudioDevice(): Promise<string> {
-    try {
-      const ffmpegPath = await this.getFFmpegPath();
-      if (!ffmpegPath) {
-        throw new Error('FFmpeg not found');
-      }
-      const execAsync = promisify(exec);
-      
-      // FFmpeg returns exit code 1 when listing devices, but still outputs the list
-      const command = `"${ffmpegPath}" -f avfoundation -list_devices true -i ""`;
-      
-      const { stdout, stderr } = await execAsync(`${command} 2>&1`).catch(e => {
-        // FFmpeg exits with code 1 when listing devices, which is expected
-        return { stdout: e.stdout || e.stderr || '', stderr: '' };
-      });
-      
-      const output = stdout || stderr;
-      
-      // Parse the output to find audio input devices
-      const lines = output.split('\n');
-      let audioDeviceIndex = '2'; // Default to MacBook Pro Microphone
-      let audioDevices: Array<{index: string, name: string}> = [];
-      
-      let inAudioSection = false;
-      for (const line of lines) {
-        // Check if we're in the audio devices section
-        if (line.includes('AVFoundation audio devices:')) {
-          inAudioSection = true;
-          continue;
-        }
-        
-        // Parse audio devices (format: [AVFoundation indev @ 0x...] [0] Device Name)
-        if (inAudioSection && line.includes('[AVFoundation indev @')) {
-          // Updated regex to handle the actual output format
-          const match = line.match(/\[AVFoundation indev @ [^\]]+\]\s*\[(\d+)\]\s+(.+)/);
-          if (match) {
-            const index = match[1];
-            const name = match[2].trim();
-            audioDevices.push({ index, name });
-          }
-        }
-      }
-      
-      // Check if we found any audio devices
-      if (audioDevices.length === 0) {
-        throw new Error('No audio devices found');
-      }
-      
-      // Try to find the built-in microphone first
-      const builtInMic = audioDevices.find(d => 
-        d.name.toLowerCase().includes('macbook') ||
-        d.name.toLowerCase().includes('built-in') ||
-        d.name.toLowerCase().includes('internal') ||
-        d.name.includes('마이크') || // Korean for "microphone"
-        d.name.includes('Microphone')
-      );
-      
-      if (builtInMic) {
-        audioDeviceIndex = builtInMic.index;
-      } else if (audioDevices.length > 0) {
-        // Skip BlackHole virtual audio device if possible
-        const nonBlackHole = audioDevices.find(d => !d.name.toLowerCase().includes('blackhole'));
-        audioDeviceIndex = nonBlackHole ? nonBlackHole.index : audioDevices[0].index;
-      }
-      
-      return `:${audioDeviceIndex}`;
-    } catch (error) {
-      console.error('Error detecting audio device:', error);
-      throw error; // Re-throw to handle in the caller
-    }
+  private buildFilePath(meetingTitle: string, extension: string): string {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const sanitizedTitle = meetingTitle
+      .replace(/[<>:"/\\|?*]/g, '_')
+      .replace(/\s+/g, '_')
+      .trim();
+    const ext = extension.startsWith('.') ? extension : `.${extension}`;
+    const fileName = `${sanitizedTitle}_${timestamp}${ext}`;
+    return path.join(app.getPath('userData'), 'recordings', fileName);
   }
 
-  async startRecording(meetingTitle: string): Promise<{ success: boolean; filePath?: string; error?: string }> {
-    try {
-      // Check microphone permissions on macOS
-      if (process.platform === 'darwin') {
-        const { systemPreferences } = require('electron');
-        const microphoneAccess = systemPreferences.getMediaAccessStatus('microphone');
-        
-        if (microphoneAccess === 'denied') {
-          return { success: false, error: 'Microphone permission denied' };
-        } else if (microphoneAccess === 'not-determined') {
-          // Request permission
-          const granted = await systemPreferences.askForMediaAccess('microphone');
-          if (!granted) {
-            return { success: false, error: 'Microphone permission denied' };
-          }
-        }
-      }
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-      // Sanitize filename while preserving Korean characters and other Unicode
-      const sanitizedTitle = meetingTitle
-        .replace(/[<>:"/\\|?*]/g, '_')  // Replace only truly problematic characters for filenames
-        .replace(/\s+/g, '_')           // Replace spaces with underscores
-        .trim();
-      const fileName = `${sanitizedTitle}_${timestamp}.mp3`;
-      this.outputPath = path.join(app.getPath('userData'), 'recordings', fileName);
-
-      const ffmpegPath = await this.getFFmpegPath();
-      
-      // Check if FFmpeg exists
-      if (!ffmpegPath) {
-        return { success: false, error: 'FFmpeg not found' };
-      }
-      
-      // Platform-specific audio input configuration
-      let inputFormat: string;
-      let audioDevice: string;
-      
-      if (process.platform === 'darwin') {
-        // macOS
-        inputFormat = 'avfoundation';
-        audioDevice = await this.detectAudioDevice();
-      } else if (process.platform === 'win32') {
-        // Windows
-        inputFormat = 'dshow';
-        audioDevice = await this.detectWindowsAudioDevice();
-      } else {
-        // Linux
-        inputFormat = 'alsa';
-        audioDevice = 'default';
-      }
-      
-      // Optimized ffmpeg command for MP3 output
-      const args = [
-        '-f', inputFormat,
-        '-thread_queue_size', '16384',  // Even larger buffer for smoother processing
-        '-probesize', '32M',           // Larger probe size
-        '-analyzeduration', '10M',      // More time for format analysis
-        '-i', audioDevice,
-        '-acodec', 'libmp3lame',       // MP3 encoder
-        '-b:a', '128k',                // Lower bitrate for faster encoding
-        '-ar', '48000',                // Keep original sample rate
-        '-ac', '1',                    // Mono (matches input)
-        '-threads', '0',               // Use all available CPU threads
-        '-preset', 'ultrafast',        // Fastest encoding preset
-        '-af', 'volume=10.0,alimiter=limit=0.95:attack=5:release=50',  // Volume boost with limiter
-        '-fflags', '+genpts+igndts',  // Better timestamp handling
-        '-flags', '+low_delay',        // Reduce encoding delay
-        '-y',
-        this.outputPath
-      ];
-
-      console.log('Starting recording...');
-
-      this.startTime = Date.now();
-      this.recordingProcess = spawn(ffmpegPath, args);
-      
-      // Track if process started successfully
-      let processStarted = false;
-      let startupError: string | null = null;
-
-      this.recordingProcess.on('error', (error) => {
-        console.error('Recording process error:', error);
-        startupError = error.message;
-        
-        // Show error dialog for spawn errors (usually means FFmpeg not found)
-        if (error.message.includes('ENOENT')) {
-          const { dialog } = require('electron');
-          dialog.showErrorBox(
-            'FFmpeg Not Found',
-            'FFmpeg executable could not be found or executed.\n\n' +
-            'This usually means FFmpeg is not installed or not in the expected location.'
-          );
-        }
-      });
-
-      this.recordingProcess.stderr?.on('data', (data) => {
-        const output = data.toString();
-        console.log('FFmpeg output:', output);
-        
-        // Check for common FFmpeg errors
-        if (output.includes('Permission denied')) {
-          startupError = 'Microphone permission denied';
-        } else if (output.includes('Device or resource busy')) {
-          startupError = 'Microphone is being used by another application';
-        } else if (output.includes('No such device')) {
-          startupError = 'No microphone device found';
-        } else if (output.includes('Unknown input format')) {
-          startupError = 'Audio input format not supported';
-        }
-        
-        // If we see FFmpeg version info, it started successfully
-        if (output.includes('ffmpeg version')) {
-          processStarted = true;
-        }
-      });
-
-      this.recordingProcess.on('close', (code) => {
-        console.log('Recording process closed with code:', code);
-        if (code !== 0 && !processStarted) {
-          startupError = `FFmpeg exited with code ${code}`;
-        }
-      });
-
-      // Wait a bit to see if FFmpeg starts successfully
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
-      // Check if there was a startup error
-      if (startupError) {
-        this.recordingProcess = null;
-        this.startTime = null;
-        return { success: false, error: startupError };
-      }
-
-      // Check if process is still running
-      if (this.recordingProcess.killed || this.recordingProcess.exitCode !== null) {
-        this.recordingProcess = null;
-        this.startTime = null;
-        return { success: false, error: 'FFmpeg process terminated unexpectedly' };
-      }
-
-      return { success: true, filePath: this.outputPath };
-    } catch (error) {
-      console.error('Failed to start recording:', error);
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+  // Called by the main process when the renderer signals recording has begun.
+  // The renderer owns the actual capture; we only reserve state and the clock.
+  startRecording(meetingTitle: string): { success: boolean; error?: string } {
+    if (this.recordingActive) {
+      return { success: false, error: 'Recording already in progress' };
     }
+    this.meetingTitle = meetingTitle;
+    this.startTime = Date.now();
+    this.recordingActive = true;
+    this.outputPath = null;
+    return { success: true };
   }
 
   isRecording(): boolean {
-    return this.recordingProcess !== null;
+    return this.recordingActive;
   }
 
-  async stopRecording(): Promise<{ success: boolean; filePath?: string; durationMs?: number; error?: string }> {
+  // Mark the session as stopped. File write happens separately via saveRecording().
+  // Returns a result compatible with the previous API so tray/auto-stop flows keep working.
+  stopRecording(): { success: boolean; durationMs?: number; filePath?: string } {
+    if (!this.recordingActive) {
+      return { success: false };
+    }
+    const durationMs = this.startTime !== null ? Date.now() - this.startTime : undefined;
+    this.recordingActive = false;
+    return { success: true, durationMs, filePath: this.outputPath ?? undefined };
+  }
+
+  // Persist encoded audio bytes from the renderer to disk. `extension` should match
+  // the container the renderer chose (e.g. 'webm', 'm4a', 'ogg'). Async to avoid
+  // blocking the main thread on multi-MB writes.
+  async saveRecording(
+    meetingTitle: string,
+    data: Buffer,
+    extension: string,
+    durationMs: number
+  ): Promise<{ success: boolean; filePath?: string; durationMs?: number; error?: string }> {
     try {
-      if (this.recordingProcess) {
-        const durationMs = this.startTime !== null ? Date.now() - this.startTime : undefined;
-
-        // Send 'q' to gracefully stop ffmpeg
-        this.recordingProcess.stdin?.write('q');
-
-        // Wait for process to finish
-        await new Promise<void>((resolve) => {
-          this.recordingProcess?.on('close', () => {
-            resolve();
-          });
-
-          // Fallback: force kill after 2 seconds
-          setTimeout(() => {
-            this.recordingProcess?.kill('SIGTERM');
-            resolve();
-          }, 2000);
-        });
-
-        this.recordingProcess = null;
-        this.startTime = null;
-
-        // Check if file exists
-        if (this.outputPath && fs.existsSync(this.outputPath)) {
-          const stats = fs.statSync(this.outputPath);
-          console.log(`Recording saved: ${this.outputPath} (${stats.size} bytes, ${durationMs}ms)`);
-          return { success: true, filePath: this.outputPath, durationMs };
-        } else {
-          return { success: false, error: 'Recording file not found' };
-        }
-      }
-      return { success: false, error: 'No recording in progress' };
+      const outputPath = this.buildFilePath(meetingTitle || this.meetingTitle || 'Untitled_Meeting', extension);
+      await fs.promises.writeFile(outputPath, data);
+      const stats = await fs.promises.stat(outputPath);
+      console.log(`Recording saved: ${outputPath} (${stats.size} bytes, ${durationMs}ms)`);
+      this.outputPath = outputPath;
+      return { success: true, filePath: outputPath, durationMs };
     } catch (error) {
-      console.error('Failed to stop recording:', error);
+      console.error('Failed to save recording:', error);
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   }
-
-  private async detectWindowsAudioDevice(): Promise<string> {
-    try {
-      // Get ffmpeg path
-      const ffmpegPath = await this.getFFmpegPath();
-      if (!ffmpegPath) {
-        throw new Error('FFmpeg not found');
-      }
-      
-      // List DirectShow audio devices on Windows
-      // Note: ffmpeg outputs device list to stderr, not stdout
-      let output = '';
-      try {
-        // Execute ffmpeg with proper encoding for Windows
-        const result = execSync(`"${ffmpegPath}" -list_devices true -f dshow -i dummy 2>&1`, {
-          encoding: 'utf8',
-          windowsHide: true
-        });
-        output = result.toString();
-      } catch (e: any) {
-        // ffmpeg exits with error when listing devices, but output contains the device list
-        output = e.stdout || e.output?.join('') || e.toString();
-      }
-      
-      console.log('Windows audio devices output:', output);
-      
-      // Parse audio devices from the output
-      const lines = output.split('\n');
-      let audioDevices: { name: string, alternativeName?: string }[] = [];
-      let currentDevice: { name: string, alternativeName?: string } | null = null;
-      
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i].trim();
-        
-        // Look for audio device lines
-        // Format: [dshow @ 0x...] "Device Name" (audio)
-        if (line.includes('(audio)') && line.includes('"')) {
-          // Extract device name between quotes
-          const nameMatch = line.match(/"([^"]+)"/);
-          if (nameMatch) {
-            currentDevice = { name: nameMatch[1] };
-          }
-        }
-        
-        // Look for alternative name on the next line
-        // Format: [dshow @ 0x...] Alternative name "@device_cm_{...}"
-        if (currentDevice && line.includes('Alternative name')) {
-          const altMatch = line.match(/Alternative name\s+"([^"]+)"/);
-          if (altMatch) {
-            currentDevice.alternativeName = altMatch[1];
-            audioDevices.push(currentDevice);
-            currentDevice = null;
-          } else {
-            // If no alternative name found, still add the device
-            audioDevices.push(currentDevice);
-            currentDevice = null;
-          }
-        }
-      }
-      
-      // Add the last device if it didn't have an alternative name
-      if (currentDevice) {
-        audioDevices.push(currentDevice);
-      }
-      
-      console.log('Found audio devices:', audioDevices);
-      
-      // Check if we found any audio devices
-      if (audioDevices.length === 0) {
-        throw new Error('No audio devices found');
-      }
-      
-      // Try to find a suitable microphone
-      // Prefer devices with "마이크" (microphone in Korean) or "Microphone" in the name
-      // Also check for corrupted Korean text patterns
-      const preferredDevice = audioDevices.find(device => 
-        device.name.includes('마이크') || 
-        device.name.includes('留덉씠') || // Corrupted Korean for 마이크
-        device.name.toLowerCase().includes('microphone') ||
-        device.name.toLowerCase().includes('mic') ||
-        device.name.includes('(') && device.name.includes(')') // Devices with parentheses often are mics
-      );
-      
-      if (preferredDevice) {
-        // Use alternative name if available, otherwise use the device name
-        if (preferredDevice.alternativeName) {
-          // Don't add quotes around alternative names - ffmpeg handles them internally
-          return `audio=${preferredDevice.alternativeName}`;
-        }
-        // For device names with Korean or special characters, use quotes
-        return `audio="${preferredDevice.name}"`;
-      }
-      
-      // If no preferred device, use the first available audio device
-      if (audioDevices.length > 0) {
-        const device = audioDevices[0];
-        console.log(`Using first available audio device: ${device.name}`);
-        if (device.alternativeName) {
-          // Don't add quotes around alternative names
-          return `audio=${device.alternativeName}`;
-        }
-        return `audio="${device.name}"`;
-      }
-      
-      // This should never be reached due to the check above, but just in case
-      throw new Error('No suitable audio device found');
-    } catch (error) {
-      console.error('Error detecting Windows audio device:', error);
-      // Return a generic microphone reference
-      return 'audio="Microphone"';
-    }
-  }
-
-  private async getFFmpegPath(): Promise<string | null> {
-    const ffmpegPath = await findFFmpegBinary();
-    if (!ffmpegPath) {
-      console.log('WARNING: No FFmpeg found');
-      return null;
-    }
-    return ffmpegPath;
-  }
-
 }

--- a/src/simpleAudioRecorder.ts
+++ b/src/simpleAudioRecorder.ts
@@ -20,7 +20,8 @@ export class SimpleAudioRecorder {
   }
 
   private buildFilePath(meetingTitle: string, extension: string): string {
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const base = this.startTime ? new Date(this.startTime) : new Date();
+    const timestamp = base.toISOString().replace(/[:.]/g, '-');
     const sanitizedTitle = meetingTitle
       .replace(/[<>:"/\\|?*]/g, '_')
       .replace(/\s+/g, '_')


### PR DESCRIPTION
## Summary

ffmpeg's `-f avfoundation` input produced **periodic digital ticks** on macOS during recording. The capture path has moved from ffmpeg (spawned from main) to Chromium's `MediaRecorder` in the renderer, which sits directly on Core Audio HAL and is clean.

## Why

Reproduced the tick noise in:
- Electron app (via `ffmpeg -f avfoundation`)
- Bare CLI `ffmpeg -f avfoundation`

Confirmed **absent** in:
- macOS Voice Memos (uses `AVAudioRecorder`)
- `sox -t coreaudio` (uses Core Audio HAL directly)

Root cause is ffmpeg's `AVCaptureAudioDataOutput` timing, which we can't fix from our side. Voice Isolation was already off (`Standard` mic mode) during reproduction, so it isn't involved.

## What changed

### Capture pipeline
- **Renderer** captures via `navigator.mediaDevices.getUserMedia()` with `echoCancellation: false`, `noiseSuppression: false`, `autoGainControl: false`. Those flags prevent Chromium from routing through `AUVoiceIO`, which is the unit that triggers macOS Voice Isolation.
- Web Audio graph before `MediaRecorder`: `highpass 80Hz → DynamicsCompressor (thr -30, ratio 8, 3ms attack) → Gain ×4 (+12dB makeup) → brick-wall limiter (-1 dBFS, ratio 20)`. Tuned for meeting/conference audio — distant speakers become audible, close-range transients (keyboard, breath) are tamed, and the limiter prevents clipping into the Opus encoder.
- Output: `audio/webm;codecs=opus` at 64 kbps mono. Gemini Files API support verified end-to-end (empirical test covered `.webm`/`.ogg`/`.opus` with `audio/webm`, `audio/ogg`, `audio/opus` MIME combos, all succeeded for Korean transcription).

### Code
- `src/simpleAudioRecorder.ts`: collapsed from ~410 lines to ~80 lines. Now just tracks session state and writes the final blob via `fs.promises.writeFile`. Removed: OS-specific mic detection (~210 lines of AVFoundation/DShow parsing), ffmpeg process management, 500ms startup race check, Korean-locale mojibake workaround (`留덉씠`), cargo-cult ffmpeg flags (`-preset ultrafast`, `-flags +low_delay`, `-probesize 32M`, etc.).
- `src/audioFormats.ts` (new): shared `mimeTypeForExtension` / `extensionForMimeType` / `SUPPORTED_AUDIO_EXTENSIONS` — replaces four duplicated MIME-branch chains in `geminiService.ts` and a hardcoded list in `main.ts`/`renderer.js`.
- `src/main.ts`: `start/stop-recording` handlers are state-only now. New `save-recording` handler receives the encoded blob from renderer and emits the \"stopped\" notification only **after** the file is on disk. Max-duration auto-stop resets state even if the window is gone (previously could leave `isRecording()` stuck).
- `src/preload.ts`: adds `saveRecording(payload)` and `showInFinder(path)`.
- `src/geminiService.ts`: uses `mimeTypeForExtension` helper (was four inline `if/else` blocks that had to be kept in sync).
- `js/fileHandler.js`: drag-drop/dialog import now accepts `mp3/m4a/wav/webm/ogg/opus/flac/aac` (was `mp3/m4a` only). Fixes the regression of being unable to drag a fresh recording back into the app.
- `renderer.js`: all new audio logic (`buildProcessedStream`, `cleanupAudioState`, `startRecording`/`stopRecording` rewrite). Adds Reveal in Finder button on each recording.

### Other
- `CLAUDE.md` refreshed — Audio Recording section rewritten for MediaRecorder, architecture list updated, service responsibilities reflect the new split. The earlier comprehensive rewrite (done before this refactor) is also included in the diff.

## Known limitations (follow-up PR)

- **Renderer crash during recording loses captured chunks**, since chunks live in renderer memory until `stop`. Planned fix: stream chunks to main via IPC during capture and write progressively. Acceptable for v1 — app stability is good and this mirrors a crash scenario in the old path too.
- Device selection UI is not restored (the old path auto-picked built-in mic, preferring non-BlackHole). `getUserMedia` uses the OS default input. Can be added later with `navigator.mediaDevices.enumerateDevices()`.
- System-audio capture (for Zoom-style meeting participant recording) is a deliberate separate-PR item — requires Chromium command-line flags + `getDisplayMedia` + Web Audio mixing.

## Backward compatibility

- Existing `.mp3`/`.m4a` recordings are still listable, transcribable, and transferable. `mimeTypeForExtension` preserves the previous mapping; `isSupportedAudioExtension` is a superset of the old filter.
- CLI (`listener <file>`) unchanged, still accepts the same extensions plus the new ones.
- Meeting detection, display detection, tray menu, global shortcut, and auto mode all route through the same renderer `recordButton.click()` path as before.

## Test plan

- [ ] Start and stop a short recording in the app; confirm it saves to `~/Library/Application Support/listener-ai/recordings/` as `.webm`.
- [ ] Play back via QuickTime/VLC; confirm no periodic ticks and reasonable volume.
- [ ] Transcribe the new recording through auto mode; confirm Gemini returns a correct Korean transcript.
- [ ] Drag an existing `.mp3` into the window; confirm it imports and transcribes.
- [ ] Drag a freshly-recorded `.webm` into the window; confirm it imports.
- [ ] Click Show on a recording row; confirm Finder opens with the file selected, and that macOS right-click → Share lists expected apps (AirDrop/Mail/Messages/KakaoTalk if installed).
- [ ] Set `maxRecordingMinutes` to 1, record past the limit; confirm auto-stop saves the file and UI resets.
- [ ] Record while Zoom or FaceTime is open in the background; confirm no ticks (Chromium capture should be unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)