### PR TITLE
Stream MediaRecorder chunks to main via IPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "start": "pnpm run build && electron .",
     "build": "tsc",
-    "test": "tsc && node --test dist/meetingDetectorService.test.js dist/searchService.test.js dist/agentService.test.js",
+    "test": "tsc && node --test dist/meetingDetectorService.test.js dist/searchService.test.js dist/agentService.test.js dist/simpleAudioRecorder.test.js",
     "dist": "pnpm run build && electron-builder",
     "dist:mac": "pnpm run build && electron-builder --mac",
     "dist:mac-x64": "pnpm run build && electron-builder --mac --x64",

--- a/renderer.js
+++ b/renderer.js
@@ -36,11 +36,12 @@ let recordingStartTime = null;
 let timerInterval = null;
 let isAutoModeProcessing = false; // Track if auto mode is processing
 
-// MediaRecorder state (renderer owns audio capture; main only persists the final blob).
-// Constraints disable Chromium's AUVoiceIO path so macOS Voice Isolation can't touch the signal.
+// MediaRecorder state. Chunks are streamed to main via IPC as they arrive so the
+// renderer never accumulates hours of audio; main appends each chunk to a file
+// handle on disk. Constraints disable Chromium's AUVoiceIO path so macOS Voice
+// Isolation can't touch the signal.
 let mediaStream = null;
 let mediaRecorder = null;
-let recordedChunks = [];
 let recordingMimeType = '';
 let audioContext = null;
 let processedStream = null;
@@ -49,6 +50,11 @@ let processedStream = null;
 // connect it to graphHead. MediaRecorder keeps consuming the same destination.
 let sourceNode = null;
 let graphHead = null;
+// Serializes chunk forwarding. ondataavailable awaits Blob.arrayBuffer() which is
+// async, so without this chain chunk N+1 could send before chunk N. Stop waits on
+// the chain's tail before invoking stop-recording, guaranteeing every chunk lands
+// on main's IPC queue (and thus the FileHandle write queue) before finalize.
+let chunkSendChain = Promise.resolve();
 
 function pickRecordingMimeType() {
   const candidates = [
@@ -119,7 +125,6 @@ function cleanupAudioState() {
   }
   teardownAudioGraph();
   mediaRecorder = null;
-  recordedChunks = [];
 }
 
 // Falls back to the default device when a preferred deviceId is gone (unplugged).
@@ -580,8 +585,12 @@ async function startRecording() {
 
   recordingMimeType = pickRecordingMimeType();
 
+  // Open the output stream in main BEFORE starting MediaRecorder so the first chunk
+  // has a file handle waiting for it. Build the Web Audio graph up front (without
+  // calling start) — if construction fails we haven't touched main state yet.
+  let graph;
   try {
-    const graph = buildProcessedStream(mediaStream);
+    graph = buildProcessedStream(mediaStream);
     audioContext = graph.ctx;
     processedStream = graph.stream;
     sourceNode = graph.source;
@@ -590,19 +599,6 @@ async function startRecording() {
     mediaRecorder = recordingMimeType
       ? new MediaRecorder(processedStream, { mimeType: recordingMimeType, audioBitsPerSecond: 64000 })
       : new MediaRecorder(processedStream, { audioBitsPerSecond: 64000 });
-    recordedChunks = [];
-    mediaRecorder.ondataavailable = (event) => {
-      if (event.data && event.data.size > 0) recordedChunks.push(event.data);
-    };
-    mediaRecorder.onerror = (event) => {
-      const err = event && event.error ? event.error : event;
-      console.error('MediaRecorder error:', err);
-      cleanupAudioState();
-      resetRecordingUI();
-      window.electronAPI.stopRecording().catch(() => {});
-      alert('Recording failed: ' + (err && err.message ? err.message : 'Unknown error'));
-    };
-    mediaRecorder.start(1000);
   } catch (error) {
     cleanupAudioState();
     alert('Failed to initialize recorder: ' + (error && error.message ? error.message : String(error)));
@@ -610,17 +606,49 @@ async function startRecording() {
   }
 
   try {
-    const result = await window.electronAPI.startRecording(title);
+    const result = await window.electronAPI.startRecording({
+      title,
+      mimeType: mediaRecorder.mimeType || recordingMimeType || 'audio/webm',
+    });
     if (!result.success) {
-      if (mediaRecorder && mediaRecorder.state !== 'inactive') mediaRecorder.stop();
       cleanupAudioState();
       alert('Failed to start recording: ' + (result.error || 'Unknown error'));
       return;
     }
   } catch (error) {
-    if (mediaRecorder && mediaRecorder.state !== 'inactive') mediaRecorder.stop();
     cleanupAudioState();
     alert('Failed to start recording: ' + error.message);
+    return;
+  }
+
+  chunkSendChain = Promise.resolve();
+  mediaRecorder.ondataavailable = (event) => {
+    if (!event.data || event.data.size === 0) return;
+    const blob = event.data;
+    chunkSendChain = chunkSendChain.then(async () => {
+      try {
+        const buf = await blob.arrayBuffer();
+        window.electronAPI.sendRecordingChunk(buf);
+      } catch (err) {
+        console.error('Failed to forward recording chunk:', err);
+      }
+    });
+  };
+  mediaRecorder.onerror = (event) => {
+    const err = event && event.error ? event.error : event;
+    console.error('MediaRecorder error:', err);
+    cleanupAudioState();
+    resetRecordingUI();
+    window.electronAPI.stopRecording().catch(() => {});
+    alert('Recording failed: ' + (err && err.message ? err.message : 'Unknown error'));
+  };
+
+  try {
+    mediaRecorder.start(1000);
+  } catch (error) {
+    await window.electronAPI.abortRecording().catch(() => {});
+    cleanupAudioState();
+    alert('Failed to start recorder: ' + (error && error.message ? error.message : String(error)));
     return;
   }
 
@@ -785,48 +813,41 @@ async function stopRecording() {
   // session so the next recording isn't blocked by stuck state.
   if (!mediaRecorder || mediaRecorder.state === 'inactive') {
     cleanupAudioState();
-    await window.electronAPI.stopRecording().catch(() => {});
+    try {
+      const result = await window.electronAPI.stopRecording();
+      if (result && result.success) {
+        await handleRecordingStopped(result.filePath, result.durationMs);
+        return;
+      }
+    } catch {
+      // fall through to UI reset
+    }
     resetRecordingUI();
     return;
   }
 
   try {
+    // MediaRecorder.stop() flushes the final chunk via ondataavailable before
+    // firing onstop. We then await chunkSendChain so every in-flight arrayBuffer()
+    // conversion lands on main's IPC queue before stop-recording invoke — Electron
+    // multiplexes all IPC over one Mojo pipe, preserving delivery order.
     const stopped = new Promise((resolve) => {
       mediaRecorder.onstop = () => resolve();
     });
     mediaRecorder.stop();
     await stopped;
-
-    const chunks = recordedChunks;
-    const mimeType = mediaRecorder.mimeType || recordingMimeType || 'audio/webm';
+    await chunkSendChain;
     cleanupAudioState();
 
-    const blob = new Blob(chunks, { type: mimeType });
-    const durationMs = recordingStartTime ? Date.now() - recordingStartTime : 0;
+    const result = await window.electronAPI.stopRecording();
 
-    const stopSignal = await window.electronAPI.stopRecording();
-    if (!stopSignal.success) {
-      console.warn('stop-recording signal returned failure:', stopSignal.error);
-    }
-
-    if (blob.size === 0) {
+    if (result.success) {
+      await handleRecordingStopped(result.filePath, result.durationMs);
+    } else if (result.reason === 'empty') {
       alert('No audio captured.');
       resetRecordingUI();
-      return;
-    }
-
-    const title = meetingTitle.value.trim() || 'Untitled_Meeting';
-    const saveResult = await window.electronAPI.saveRecording({
-      title,
-      mimeType,
-      durationMs,
-      data: new Uint8Array(await blob.arrayBuffer()),
-    });
-
-    if (saveResult.success) {
-      await handleRecordingStopped(saveResult.filePath, saveResult.durationMs ?? durationMs);
     } else {
-      alert('Failed to save recording: ' + (saveResult.error || 'Unknown error'));
+      alert('Failed to save recording: ' + (result.error || 'Unknown error'));
       resetRecordingUI();
     }
   } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ import { fetchReleaseNotes, fetchAllReleases } from './services/releaseNotesServ
 import { saveTranscription, readTranscription } from './outputService';
 import { searchTranscriptions, ALL_FIELDS, type SearchField } from './searchService';
 import { AgentService, type AgentChatMessage, type AgentRunResult, type AgentScope, type ConfigProposal } from './agentService';
-import { isSupportedAudioExtension, extensionForMimeType } from './audioFormats';
+import { isSupportedAudioExtension } from './audioFormats';
 
 // Global flag to track if app is quitting
 declare global {
@@ -67,6 +67,23 @@ function rejectAllPendingConfirms(): void {
 }
 let recordingMaxTimer: NodeJS.Timeout | null = null;
 let recordingReminderTimer: NodeJS.Timeout | null = null;
+let recordingAutoStopAbortTimer: NodeJS.Timeout | null = null;
+// The grace timer, the renderer's stop invoke, and the crash/quit finalizers can
+// all call audioRecorder.stopRecording() for the same session (recorder caches the
+// result and replays it). This flag ensures the "stopped" notification fires once.
+let recordingNotificationFired = false;
+function fireStoppedNotificationOnce() {
+  if (recordingNotificationFired) return;
+  recordingNotificationFired = true;
+  notificationService.notifyRecordingStopped();
+}
+// Tracks async finalize work (crash-path stop + remux) so before-quit can await
+// it. Without this, main can exit while the async chain is still running and the
+// partial file ends up without a Duration header.
+let pendingFinalize: Promise<void> = Promise.resolve();
+function trackFinalize(work: Promise<void>): void {
+  pendingFinalize = pendingFinalize.then(() => work).catch(() => {});
+}
 
 function createGeminiService(): GeminiService | null {
   const apiKey = configService.getGeminiApiKey();
@@ -242,8 +259,26 @@ function createWindow() {
   mainWindow.webContents.on('did-start-navigation', (_e, _url, isInPlace, isMainFrame) => {
     if (isMainFrame && !isInPlace) rejectAllPendingConfirms();
   });
-  mainWindow.webContents.on('render-process-gone', () => {
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
     rejectAllPendingConfirms();
+    // Close the recording file handle so the partial file is flushed and left on disk
+    // instead of corrupted or locked open. User keeps whatever audio was streamed so far.
+    if (audioRecorder.isRecording()) {
+      console.warn('Renderer process gone during recording; finalizing partial file:', details.reason);
+      finalizeRecordingSession();
+      trackFinalize((async () => {
+        try {
+          const r = await audioRecorder.stopRecording();
+          if (r.success && r.filePath) {
+            fireStoppedNotificationOnce();
+            console.log(`Partial recording saved: ${r.filePath}`);
+            await remuxRecordingHeader(r.filePath);
+          }
+        } catch (err) {
+          console.error('Failed to finalize partial recording:', err);
+        }
+      })());
+    }
   });
 }
 
@@ -434,11 +469,40 @@ app.on('window-all-closed', () => {
 });
 
 // Handle app quit
-app.on('before-quit', () => {
+app.on('before-quit', async (event) => {
   meetingDetector.stop();
   displayDetector.stop();
   autoUpdaterService.stopPeriodicCheck();
   global.isQuitting = true;
+
+  // Flush and close any open recording handle so the partial file survives the quit.
+  if (audioRecorder.isRecording()) {
+    event.preventDefault();
+    console.warn('Quit requested during recording; finalizing partial file before exit');
+    finalizeRecordingSession();
+    try {
+      const r = await audioRecorder.stopRecording();
+      if (r.success && r.filePath) {
+        console.log(`Partial recording saved on quit: ${r.filePath}`);
+        await remuxRecordingHeader(r.filePath);
+      }
+    } catch (err) {
+      console.error('Failed to finalize recording on quit:', err);
+    }
+    app.quit();
+    return;
+  }
+
+  // Wait for any async finalize started by render-process-gone to complete so
+  // the remux isn't killed mid-spawn when the app exits.
+  try {
+    await Promise.race([
+      pendingFinalize,
+      new Promise<void>((resolve) => setTimeout(resolve, 5000)),
+    ]);
+  } catch {
+    // swallow — we're quitting
+  }
 });
 
 // Unregister all shortcuts when app quits
@@ -486,6 +550,17 @@ function clearRecordingTimers() {
     clearInterval(recordingReminderTimer);
     recordingReminderTimer = null;
   }
+  if (recordingAutoStopAbortTimer) {
+    clearTimeout(recordingAutoStopAbortTimer);
+    recordingAutoStopAbortTimer = null;
+  }
+}
+
+// Shared session teardown for stop, abort, crash, and quit paths.
+function finalizeRecordingSession() {
+  clearRecordingTimers();
+  menuBarManager.updateRecordingState(false);
+  meetingAutoStartedRecording = false;
 }
 
 // IPC handlers for recording functionality
@@ -592,31 +667,39 @@ ipcMain.handle('export-recording-m4a', async (_, srcPath: string) => {
   }
 });
 
-// Audio capture runs in the renderer via MediaRecorder; main only tracks state,
-// runs max/reminder timers, updates the menu bar, and writes the final blob to disk.
-ipcMain.handle('start-recording', async (_, meetingTitle: string) => {
+// Audio capture runs in the renderer via MediaRecorder; chunks stream over IPC as
+// they're encoded so the renderer never accumulates hours of audio in memory. Main
+// opens a FileHandle on start, appends each chunk on arrival, and closes on stop.
+// A renderer crash mid-session leaves a truncated-but-valid WebM/Opus file on disk.
+ipcMain.handle('start-recording', async (_, payload: { title: string; mimeType: string }) => {
   try {
-    const result = audioRecorder.startRecording(meetingTitle);
+    const meetingTitle = payload?.title ?? 'Untitled_Meeting';
+    const mimeType = payload?.mimeType ?? 'audio/webm';
+    const result = await audioRecorder.startRecording(meetingTitle, mimeType);
     if (!result.success) return result;
 
+    recordingNotificationFired = false;
     menuBarManager.updateRecordingState(true, meetingTitle);
 
     const maxMinutes = configService.getMaxRecordingMinutes();
     if (maxMinutes > 0) {
       recordingMaxTimer = setTimeout(() => {
-        clearRecordingTimers();
         if (!audioRecorder.isRecording()) return;
         notificationService.notifyRecordingAutoStopped(maxMinutes);
         if (mainWindow && !mainWindow.isDestroyed()) {
-          // Renderer owns MediaRecorder — it will stop, save, and re-enter stop-recording via IPC.
           mainWindow.webContents.send('recording-auto-stopped', { reason: 'maxDuration', maxMinutes });
         }
-        // Always reset main-side state so an unresponsive or hung renderer can't leave the
-        // isRecording() flag stuck and block future recordings. stopRecording() is idempotent,
-        // so the renderer's own stop-recording IPC (if it runs) is a safe no-op here.
-        audioRecorder.stopRecording();
-        menuBarManager.updateRecordingState(false);
-        meetingAutoStartedRecording = false;
+        // Grace window: if the renderer is hung and never calls stop-recording,
+        // force-finalize so main state unblocks and the partial file is saved.
+        recordingAutoStopAbortTimer = setTimeout(() => {
+          recordingAutoStopAbortTimer = null;
+          if (!audioRecorder.isRecording()) return;
+          console.warn('Renderer did not stop after auto-stop signal; finalizing partial file');
+          finalizeRecordingSession();
+          audioRecorder.stopRecording().then((r) => {
+            if (r.success) fireStoppedNotificationOnce();
+          }).catch((err) => console.error('Force-stop failed:', err));
+        }, 10_000);
       }, maxMinutes * 60 * 1000);
     }
 
@@ -639,14 +722,32 @@ ipcMain.handle('start-recording', async (_, meetingTitle: string) => {
   }
 });
 
+// Fire-and-forget chunk append. IPC preserves order per channel, so sequential
+// appendChunk calls land on disk in the order MediaRecorder emitted them.
+ipcMain.on('recording-chunk', (_event, data: ArrayBuffer | Uint8Array) => {
+  if (!data) return;
+  try {
+    audioRecorder.appendChunk(Buffer.from(data as ArrayBuffer));
+  } catch (error) {
+    console.error('Invalid chunk payload:', error);
+  }
+});
+
 ipcMain.handle('stop-recording', async () => {
   try {
-    clearRecordingTimers();
-    const result = audioRecorder.stopRecording();
-
-    menuBarManager.updateRecordingState(false);
-    meetingAutoStartedRecording = false;
-
+    finalizeRecordingSession();
+    const result = await audioRecorder.stopRecording();
+    if (result.success) {
+      fireStoppedNotificationOnce();
+      if (result.filePath) {
+        // MediaRecorder writes no Duration element to the WebM header, so players
+        // like Chrome/QuickTime show "0:00" until they scan the whole file. An
+        // ffmpeg `-c copy` remux adds Duration + Cues in ~1s without re-encoding.
+        // Silently skip if ffmpeg isn't available — file still plays, transcription
+        // pipeline is unaffected.
+        await remuxRecordingHeader(result.filePath);
+      }
+    }
     return result;
   } catch (error) {
     console.error('Error stopping recording:', error);
@@ -654,20 +755,33 @@ ipcMain.handle('stop-recording', async () => {
   }
 });
 
-// Receives the encoded audio blob from the renderer after MediaRecorder finalizes.
-// The "stopped" notification only fires once the file is actually on disk — otherwise
-// a failed write would still show a success toast.
-ipcMain.handle('save-recording', async (_, payload: { title: string; mimeType: string; durationMs: number; data: ArrayBuffer | Uint8Array }) => {
+async function remuxRecordingHeader(filePath: string): Promise<void> {
   try {
-    const buf = Buffer.from(payload.data as ArrayBuffer);
-    const extension = extensionForMimeType(payload.mimeType);
-    const result = await audioRecorder.saveRecording(payload.title, buf, extension, payload.durationMs);
-    if (result.success) {
-      notificationService.notifyRecordingStopped();
-    }
-    return result;
+    const ffmpegPath = await ffmpegManager.ensureFFmpeg();
+    if (!ffmpegPath) return;
+    const dir = path.dirname(filePath);
+    const tmpPath = path.join(dir, `.remux-${path.basename(filePath)}`);
+    const { spawn } = await import('child_process');
+    await new Promise<void>((resolve, reject) => {
+      const proc = spawn(ffmpegPath, ['-y', '-i', filePath, '-c', 'copy', tmpPath], { stdio: 'ignore' });
+      proc.on('error', reject);
+      proc.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`ffmpeg exit ${code}`))));
+    });
+    await fs.promises.rename(tmpPath, filePath);
   } catch (error) {
-    console.error('Error saving recording:', error);
+    console.warn('Header remux skipped:', error instanceof Error ? error.message : error);
+  }
+}
+
+// Explicit cancel path: discard the in-progress file (used when renderer fails to
+// construct MediaRecorder after main already opened the stream).
+ipcMain.handle('abort-recording', async () => {
+  try {
+    finalizeRecordingSession();
+    await audioRecorder.abortRecording();
+    return { success: true };
+  } catch (error) {
+    console.error('Error aborting recording:', error);
     return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
 });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -2,10 +2,11 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   platform: process.platform,
-  startRecording: (meetingTitle: string) => ipcRenderer.invoke('start-recording', meetingTitle),
+  startRecording: (payload: { title: string; mimeType: string }) =>
+    ipcRenderer.invoke('start-recording', payload),
+  sendRecordingChunk: (data: ArrayBuffer) => ipcRenderer.send('recording-chunk', data),
   stopRecording: () => ipcRenderer.invoke('stop-recording'),
-  saveRecording: (payload: { title: string; mimeType: string; durationMs: number; data: Uint8Array }) =>
-    ipcRenderer.invoke('save-recording', payload),
+  abortRecording: () => ipcRenderer.invoke('abort-recording'),
   onRecordingStatus: (callback: (status: string) => void) => {
     ipcRenderer.on('recording-status', (_, status) => callback(status));
   },

--- a/src/simpleAudioRecorder.test.ts
+++ b/src/simpleAudioRecorder.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SimpleAudioRecorder } from './simpleAudioRecorder';
+
+let tmpDir: string;
+let recorder: SimpleAudioRecorder;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'recorder-test-'));
+  recorder = new SimpleAudioRecorder(tmpDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('SimpleAudioRecorder', () => {
+  it('writes appended chunks to disk and reports accurate byte count', async () => {
+    const start = await recorder.startRecording('Test Meeting', 'audio/webm');
+    assert.equal(start.success, true);
+
+    recorder.appendChunk(Buffer.from([1, 2, 3, 4]));
+    recorder.appendChunk(Buffer.from([5, 6, 7, 8]));
+    recorder.appendChunk(Buffer.from([9, 10]));
+
+    const stop = await recorder.stopRecording();
+    assert.equal(stop.success, true, `expected success, got ${stop.error ?? stop.reason}`);
+    assert.equal(stop.bytesWritten, 10);
+    assert.ok(stop.filePath);
+
+    // Regression guard: the counter must include writes that landed during the
+    // stop's `await writeChain`. Snapshotting too early would return 0.
+    const onDisk = fs.readFileSync(stop.filePath!);
+    assert.equal(onDisk.length, 10);
+    assert.deepEqual(Array.from(onDisk), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it('returns reason="empty" and deletes the file when no chunks were appended', async () => {
+    const start = await recorder.startRecording('Empty', 'audio/webm');
+    assert.equal(start.success, true);
+    const filePath = start.filePath!;
+    assert.ok(fs.existsSync(filePath));
+
+    const stop = await recorder.stopRecording();
+    assert.equal(stop.success, false);
+    assert.equal(stop.reason, 'empty');
+    assert.equal(fs.existsSync(filePath), false);
+  });
+
+  it('replays the finalized result on a second stopRecording call (grace-timer race)', async () => {
+    await recorder.startRecording('Race', 'audio/webm');
+    recorder.appendChunk(Buffer.from([0xff, 0xee]));
+
+    const first = await recorder.stopRecording();
+    assert.equal(first.success, true);
+    assert.equal(first.bytesWritten, 2);
+
+    // A late caller (e.g. renderer's IPC stop after grace timer already finalized)
+    // must see the saved path, not a spurious "No recording in progress" error.
+    const second = await recorder.stopRecording();
+    assert.equal(second.success, true);
+    assert.equal(second.filePath, first.filePath);
+    assert.equal(second.bytesWritten, first.bytesWritten);
+  });
+
+  it('rejects concurrent startRecording calls (race guard)', async () => {
+    const [first, second] = await Promise.all([
+      recorder.startRecording('A', 'audio/webm'),
+      recorder.startRecording('B', 'audio/webm'),
+    ]);
+    // Exactly one must succeed; the other hits the recordingActive guard.
+    const successes = [first, second].filter((r) => r.success).length;
+    assert.equal(successes, 1);
+  });
+
+  it('discards the in-progress file on abort', async () => {
+    const start = await recorder.startRecording('Abort', 'audio/webm');
+    recorder.appendChunk(Buffer.from([1, 2, 3]));
+    await recorder.abortRecording();
+    assert.equal(fs.existsSync(start.filePath!), false);
+    assert.equal(recorder.isRecording(), false);
+  });
+
+  it('uses the mime type to pick an extension', async () => {
+    const ogg = await recorder.startRecording('Oggy', 'audio/ogg;codecs=opus');
+    assert.ok(ogg.filePath!.endsWith('.ogg'));
+    await recorder.abortRecording();
+
+    const webm = await recorder.startRecording('Webby', 'audio/webm;codecs=opus');
+    assert.ok(webm.filePath!.endsWith('.webm'));
+    await recorder.abortRecording();
+  });
+});

--- a/src/simpleAudioRecorder.ts
+++ b/src/simpleAudioRecorder.ts
@@ -1,21 +1,50 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { app } from 'electron';
+import { extensionForMimeType } from './audioFormats';
 
-// Audio capture runs in the renderer via `navigator.mediaDevices.getUserMedia()`
-// and `MediaRecorder` (Chromium's audio path, which sits on Core Audio HAL directly
-// and bypasses ffmpeg's `AVCaptureAudioDataOutput` that produced periodic ticks).
-// This class only tracks per-session state and writes the final encoded blob to disk.
+// Lazy-load electron so unit tests (which inject recordingsDir) don't trigger a
+// module-load failure outside the Electron runtime.
+function defaultRecordingsDir(): string {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { app } = require('electron') as typeof import('electron');
+  return path.join(app.getPath('userData'), 'recordings');
+}
+
+// Audio capture runs in the renderer via `navigator.mediaDevices.getUserMedia()` and
+// `MediaRecorder` (Chromium's audio path sits on Core Audio HAL directly and bypasses
+// ffmpeg's `AVCaptureAudioDataOutput` that produced periodic ticks). The renderer
+// streams encoded chunks to main as they arrive, and main appends them to a file
+// handle. If the renderer crashes mid-session we still have a valid (truncated)
+// WebM/Opus file on disk — the container tolerates truncation and ffmpeg can recover.
+export type StopReason = 'empty';
+
+export interface StopResult {
+  success: boolean;
+  filePath?: string;
+  durationMs?: number;
+  bytesWritten?: number;
+  error?: string;
+  reason?: StopReason;
+}
+
 export class SimpleAudioRecorder {
+  private recordingsDir: string;
   private outputPath: string | null = null;
+  private fileHandle: fs.promises.FileHandle | null = null;
+  private writeChain: Promise<void> = Promise.resolve();
+  private bytesWritten = 0;
+  private appendError: Error | null = null;
   private startTime: number | null = null;
   private recordingActive = false;
-  private meetingTitle: string | null = null;
+  // Finalized result from the most recent stop/abort. Returned to a late caller
+  // (e.g. renderer's stop invoke that races the 10s grace-window force-stop) so
+  // it doesn't see a spurious "No recording in progress" error.
+  private lastResult: StopResult | null = null;
 
-  constructor() {
-    const recordingsDir = path.join(app.getPath('userData'), 'recordings');
-    if (!fs.existsSync(recordingsDir)) {
-      fs.mkdirSync(recordingsDir, { recursive: true });
+  constructor(recordingsDir?: string) {
+    this.recordingsDir = recordingsDir ?? defaultRecordingsDir();
+    if (!fs.existsSync(this.recordingsDir)) {
+      fs.mkdirSync(this.recordingsDir, { recursive: true });
     }
   }
 
@@ -28,56 +57,157 @@ export class SimpleAudioRecorder {
       .trim();
     const ext = extension.startsWith('.') ? extension : `.${extension}`;
     const fileName = `${sanitizedTitle}_${timestamp}${ext}`;
-    return path.join(app.getPath('userData'), 'recordings', fileName);
+    return path.join(this.recordingsDir, fileName);
   }
 
-  // Called by the main process when the renderer signals recording has begun.
-  // The renderer owns the actual capture; we only reserve state and the clock.
-  startRecording(meetingTitle: string): { success: boolean; error?: string } {
+  async startRecording(
+    meetingTitle: string,
+    mimeType: string
+  ): Promise<{ success: boolean; filePath?: string; error?: string }> {
     if (this.recordingActive) {
       return { success: false, error: 'Recording already in progress' };
     }
-    this.meetingTitle = meetingTitle;
-    this.startTime = Date.now();
+    // Flip the active flag synchronously so concurrent starts can't both pass the
+    // guard while we're awaiting fs.promises.open.
     this.recordingActive = true;
-    this.outputPath = null;
-    return { success: true };
+    this.startTime = Date.now();
+    this.lastResult = null;
+    this.appendError = null;
+    try {
+      const extension = extensionForMimeType(mimeType);
+      const outputPath = this.buildFilePath(meetingTitle || 'Untitled_Meeting', extension);
+      this.fileHandle = await fs.promises.open(outputPath, 'w');
+      this.outputPath = outputPath;
+      this.bytesWritten = 0;
+      this.writeChain = Promise.resolve();
+      return { success: true, filePath: outputPath };
+    } catch (error) {
+      this.recordingActive = false;
+      this.startTime = null;
+      this.outputPath = null;
+      this.fileHandle = null;
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
   }
 
   isRecording(): boolean {
     return this.recordingActive;
   }
 
-  // Mark the session as stopped. File write happens separately via saveRecording().
-  // Returns a result compatible with the previous API so tray/auto-stop flows keep working.
-  stopRecording(): { success: boolean; durationMs?: number; filePath?: string } {
-    if (!this.recordingActive) {
-      return { success: false };
-    }
-    const durationMs = this.startTime !== null ? Date.now() - this.startTime : undefined;
-    this.recordingActive = false;
-    return { success: true, durationMs, filePath: this.outputPath ?? undefined };
+  // Writes are serialized through `writeChain` so chunks stay in arrival order
+  // even if multiple appendChunk calls overlap. Errors are latched into
+  // `appendError` so stopRecording surfaces disk-full/EIO instead of returning
+  // success on a truncated file.
+  appendChunk(data: Buffer): void {
+    if (!this.recordingActive || !this.fileHandle) return;
+    const handle = this.fileHandle;
+    this.writeChain = this.writeChain.then(async () => {
+      if (this.appendError) return;
+      try {
+        // Loop in case write() performs a short write (rare on local fs but
+        // FileHandle.write makes no contiguous-write guarantee).
+        let offset = 0;
+        while (offset < data.length) {
+          const { bytesWritten } = await handle.write(data, offset, data.length - offset);
+          if (bytesWritten <= 0) throw new Error('Zero-byte write');
+          offset += bytesWritten;
+          this.bytesWritten += bytesWritten;
+        }
+      } catch (error) {
+        this.appendError = error instanceof Error ? error : new Error(String(error));
+        console.error('Failed to append recording chunk:', this.appendError);
+      }
+    });
   }
 
-  // Persist encoded audio bytes from the renderer to disk. `extension` should match
-  // the container the renderer chose (e.g. 'webm', 'm4a', 'ogg'). Async to avoid
-  // blocking the main thread on multi-MB writes.
-  async saveRecording(
-    meetingTitle: string,
-    data: Buffer,
-    extension: string,
-    durationMs: number
-  ): Promise<{ success: boolean; filePath?: string; durationMs?: number; error?: string }> {
-    try {
-      const outputPath = this.buildFilePath(meetingTitle || this.meetingTitle || 'Untitled_Meeting', extension);
-      await fs.promises.writeFile(outputPath, data);
-      const stats = await fs.promises.stat(outputPath);
-      console.log(`Recording saved: ${outputPath} (${stats.size} bytes, ${durationMs}ms)`);
-      this.outputPath = outputPath;
-      return { success: true, filePath: outputPath, durationMs };
-    } catch (error) {
-      console.error('Failed to save recording:', error);
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+  // Flush pending writes, close the handle, return the finalized path. Must await
+  // `writeChain` BEFORE snapshotting bytesWritten — chunks queued just before stop
+  // only increment the counter when their write resolves inside the chain.
+  async stopRecording(): Promise<StopResult> {
+    if (!this.recordingActive) {
+      // Grace-timer or crash-path may have finalized already — return that result
+      // so the late caller sees the saved file instead of a spurious error.
+      if (this.lastResult) return this.lastResult;
+      return { success: false, error: 'No recording in progress' };
     }
+    this.recordingActive = false;
+    const durationMs = this.startTime !== null ? Date.now() - this.startTime : undefined;
+    const outputPath = this.outputPath;
+    const handle = this.fileHandle;
+    this.fileHandle = null;
+    try {
+      await this.writeChain;
+      if (handle) await handle.close();
+    } catch (error) {
+      console.error('Failed to close recording file:', error);
+    }
+
+    const bytes = this.bytesWritten;
+    const writeError = this.appendError;
+
+    if (!outputPath) {
+      const result: StopResult = { success: false, error: 'No output path was set' };
+      this.lastResult = result;
+      return result;
+    }
+
+    if (writeError) {
+      // Keep the partial file around for debugging / recovery.
+      const result: StopResult = {
+        success: false,
+        error: writeError.message,
+        filePath: outputPath,
+        durationMs,
+        bytesWritten: bytes,
+      };
+      this.lastResult = result;
+      return result;
+    }
+
+    if (bytes === 0) {
+      try {
+        await fs.promises.unlink(outputPath);
+      } catch (error) {
+        console.warn('Failed to remove empty recording file:', error);
+      }
+      this.outputPath = null;
+      const result: StopResult = { success: false, reason: 'empty', durationMs };
+      this.lastResult = result;
+      return result;
+    }
+
+    console.log(`Recording saved: ${outputPath} (${bytes} bytes, ${durationMs ?? 'unknown'}ms)`);
+    const result: StopResult = { success: true, filePath: outputPath, durationMs, bytesWritten: bytes };
+    this.lastResult = result;
+    return result;
+  }
+
+  // Close and delete the in-progress file. Used when the renderer fails to
+  // construct MediaRecorder after main already opened the stream.
+  async abortRecording(): Promise<void> {
+    if (!this.recordingActive && !this.fileHandle) return;
+    this.recordingActive = false;
+    const handle = this.fileHandle;
+    const outputPath = this.outputPath;
+    this.fileHandle = null;
+    try {
+      await this.writeChain;
+    } catch {
+      // aborting — swallow
+    }
+    try {
+      if (handle) await handle.close();
+    } catch (error) {
+      console.warn('Failed to close recording file during abort:', error);
+    }
+    if (outputPath) {
+      try {
+        await fs.promises.unlink(outputPath);
+      } catch {
+        // file may already be gone
+      }
+    }
+    this.outputPath = null;
+    this.lastResult = null;
   }
 }


### PR DESCRIPTION
## Summary
- Renderer forwards each 1s Opus/WebM chunk to main over IPC instead of accumulating them in memory. Main holds the FileHandle and appends on arrival, so recording length no longer bounds renderer memory and a renderer crash / mid-session quit leaves a truncated-but-valid WebM on disk (container tolerates truncation).
- ffmpeg `-c copy` remux runs on every saved recording so Chrome and QuickTime show the correct duration immediately. Skips silently when ffmpeg isn't available.
- Adds render-process-gone and before-quit finalize paths, a 10s grace-window force-stop for hung-renderer recovery after max-duration auto-stop, and tracks pending finalize work so before-quit awaits async stop+remux instead of exiting mid-spawn.
- Fixes a stale `bytesWritten` snapshot that would have deleted short recordings, serializes renderer chunk forwarding so the final chunk can't race ahead of stop, caches the last stopRecording result so a late stop invoke (grace-timer race) returns the saved path instead of a spurious error, and surfaces write errors through the stop result.

## Test plan
- [x] `pnpm test` — 46/46 pass (6 new cases in `simpleAudioRecorder.test.ts` covering chunk accounting, empty-file deletion, grace-timer replay, concurrent-start race, abort cleanup, and mime→ext mapping).
- [x] Short recordings (2s / 6s / 31s) saved with correct duration in the WebM header (verified with ffprobe).
- [x] Crash path: `location.href = 'chrome://crash'` during recording + Cmd+Q → partial file survives with duration remuxed in.
- [ ] Long recording (2h+) memory flat — not measured directly; renderer holds at most one ~8KB chunk so the design rules it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)