### PR TITLE
Add PR CI and sync pnpm-lock.yaml with audiotee

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm run test

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,19 +14,15 @@ importers:
       '@google/genai':
         specifier: ^1.13.0
         version: 1.13.0(encoding@0.1.13)
+      audiotee:
+        specifier: ^0.0.7
+        version: 0.0.7
       fs-extra:
         specifier: ^11.2.0
         version: 11.3.0
       marked:
         specifier: ^15.0.0
         version: 15.0.12
-    optionalDependencies:
-      '@notionhq/client':
-        specifier: ^4.0.0
-        version: 4.0.1
-      electron-updater:
-        specifier: ^6.6.2
-        version: 6.6.2
     devDependencies:
       '@electron/notarize':
         specifier: ^3.0.1
@@ -52,6 +48,13 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+    optionalDependencies:
+      '@notionhq/client':
+        specifier: ^4.0.0
+        version: 4.0.1
+      electron-updater:
+        specifier: ^6.6.2
+        version: 6.6.2
 
 packages:
 
@@ -268,6 +271,10 @@ packages:
   at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
+
+  audiotee@0.0.7:
+    resolution: {integrity: sha512-+sk3pOKmAvD+Yx2pjXgcfgV1YbT28IKoAMefN4KCAofak+L+xF2PyWO+wheP2ahpSplVuFaVTBVKekcKUl/Bcg==}
+    engines: {node: '>=20'}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1759,6 +1766,8 @@ snapshots:
   asynckit@0.4.0: {}
 
   at-least-node@1.0.0: {}
+
+  audiotee@0.0.7: {}
 
   balanced-match@1.0.2: {}
 


### PR DESCRIPTION
## Summary
- Regenerate `pnpm-lock.yaml` to include `audiotee@0.0.7`, which PR #90 added to `package.json` without updating the lockfile. This broke the `Build and Release` workflow at the `pnpm install --frozen-lockfile` step ([failed run](https://github.com/asleep-ai/listener-ai/actions/runs/24880813334)).
- Add a lightweight `CI` workflow that runs on every pull request and on push to `main`: install with `--frozen-lockfile`, `pnpm run build` (tsc), and `pnpm run test` (node --test). This would have caught the lockfile drift before #90 merged.

## Why only install/build/test (not a full electron-builder)
- The existing `release.yml` already handles full packaging, code signing, and notarization. Running it on every PR would be slow and requires signing secrets.
- The three added steps are sufficient to catch the class of bug that broke main (lockfile drift, type errors, unit-test regressions) in under a minute.

## Test plan
- [ ] CI workflow runs green on this PR.
- [ ] `pnpm install --frozen-lockfile` succeeds locally.
- [ ] Manual `Build and Release` re-run (workflow_dispatch) succeeds after merge.