### PR TITLE
Merge interrupted-recording parts into a single re-transcribed note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,8 +152,45 @@ Env-var fallbacks (read-only when the config key is empty): `GEMINI_API_KEY`, `N
 - `releaseNotesService.ts` — "what's new" modal driver (reads `lastSeenVersion`)
 
 ### Tests
-- Test files: `agentService.test.ts`, `searchService.test.ts`, `meetingDetectorService.test.ts`
 - Run: `pnpm test` (builds with tsc, then executes compiled `.test.js` with `node --test`)
+- Test files live next to source: `src/**/*.test.ts`
+- Existing: `agentService`, `searchService`, `meetingDetectorService`, `simpleAudioRecorder`, `outputService`, `services/audioConcatService`, `cli` (adb-style integration)
+- Shared helpers in `src/test-helpers.ts` (temp dirs, ffmpeg detection, synthetic audio fixtures)
+- Test escape hatches (read-only at process start, never set in production):
+  - `LISTENER_DATA_PATH` — overrides `getDataPath()` so tests run against a temp directory
+  - `LISTENER_TEST_MODE` — `GeminiService.transcribeAudio` returns a canned fixture instead of calling the API
+
+#### Patterns proven in this codebase
+
+- **Test against real external tools when behavior depends on them.** Mocking ffmpeg would have hidden the concat demuxer's silent-corruption bug — exit 0 + 28616s output for 1s+1s mismatched-codec inputs. For deterministic, cheap-to-invoke tools (ffmpeg, ffprobe), shell out instead of mocking.
+- **Test the assumption, not just the code.** When the implementation depends on "tool X errors on bad input", verify it. The original concat fallback assumed `-c copy` would throw on mismatched codecs; it doesn't.
+- **Generate synthetic fixtures with the tool itself.** `ffmpeg -f lavfi -i sine=frequency=440:duration=1` produces a 1-second webm in milliseconds — see `makeOpusWebm` in `test-helpers.ts`. No fixture binaries committed.
+- **No real Gemini calls in tests.** Add a `LISTENER_TEST_MODE` env-var stub before writing CLI/integration tests that exercise `GeminiService`.
+
+#### Conventions
+
+- Per-test temp dirs via `makeTempDir(suffix)` from `test-helpers.ts` (wraps `fs.mkdtempSync` under `os.tmpdir()`). Pair with `rmDir(...)` in `after()`. Never write to the real `getDataPath()`.
+- For `describe({ skip })` based on external-tool availability, detect synchronously at module load (`findFfmpegSync()`); `before()` runs too late because `describe` evaluates options at file-load time.
+- Skip gracefully when external tools are missing: `describe('...', { skip: !ffmpegPath ? 'ffmpeg not installed' : undefined }, ...)`. Tests should pass on a machine without ffmpeg, run for real where it's installed.
+
+#### Test pyramid for new features
+
+1. **Service-layer unit tests** with `node --test` — primary; covers logic and external-tool assumptions
+2. **CLI as adb-style integration test** — see `cli.test.ts`. Drive the compiled CLI as a subprocess with `LISTENER_DATA_PATH` (sandboxed temp) + `LISTENER_TEST_MODE` (Gemini stub). Catches what unit tests can't: argument parsing, IPC/handler wiring, full pipeline flow (resolve refs → readTranscription → concat → transcribe → save). Free, offline, deterministic.
+3. **Interactive verification** — see below. For UX/visual changes or paid-API happy paths, where automation is heavy.
+4. **Playwright Electron** — heaviest; reserve for GUI-only behaviors that can't be reached via CLI.
+
+#### Interactive verification (between unit tests and Playwright)
+
+For UX changes (button visibility, dialog UX, list refresh) or external paid APIs (Gemini), use the live-monitor pattern instead of full Playwright:
+
+1. Launch worktree build in the background (`pnpm start` via `run_in_background`).
+2. Tail stdout — main-process `console.log` lands here (transcription progress, ffmpeg invocations, errors).
+3. Snapshot baseline: file counts in `recordings/` and `transcriptions/` before the user acts.
+4. User drives the GUI; the model reports each observable: file counts, new folder names, log lines, summary.md frontmatter.
+5. Verify the result by reading produced files, not by clicking.
+
+This pattern caught two issues during issue #95 verification: a hard-to-see Merge button (CSS override) and an empty `mergedFrom` edge case dependent on input metadata. Service-layer tests would have missed both.
 
 ## Background Recording Policy
 Recording starts silently — never bring the window to foreground (no `show()`/`focus()`) and never fire a "Recording Started" notification. This applies to all recording triggers: global shortcut, tray click, meeting detection, and display detection. Display detection in particular is designed to be discreet — the user allows recording via the notification without the app becoming visible. Only explicit user actions (dock click, tray menu "Open", notification click for non-recording events) should show the window.
@@ -179,7 +216,7 @@ Recording starts silently — never bring the window to foreground (no `show()`/
 ## npm Distribution
 - Package name: `listener-ai`. Only the CLI portion is published to npm (Electron app ships via GitHub Releases).
 - Electron-only runtime deps (`electron-updater`, `@notionhq/client`) live in `optionalDependencies` — honest semantics for a package serving both Electron and CLI users. `build.files` includes `node_modules/**/*`, so they are still bundled in Electron builds.
-- `package.json.files` whitelists the exact compiled JS shipped to npm: `dist/cli.js`, `dataPath.js`, `configService.js`, `geminiService.js`, `outputService.js`, `searchService.js`, `agentService.js`, `services/ffmpegManager.js`.
+- `package.json.files` whitelists the exact compiled JS shipped to npm: `dist/cli.js`, `dataPath.js`, `configService.js`, `geminiService.js`, `outputService.js`, `searchService.js`, `agentService.js`, `audioFormats.js`, `services/ffmpegManager.js`, `services/audioConcatService.js`. When adding a new module imported by any of these, append it to the whitelist or `npm install -g listener-ai` will fail with `Cannot find module`.
 
 ## Future Enhancements (Optional)
 - Cloud sync of transcriptions, settings, and agent chat history across devices

--- a/index.html
+++ b/index.html
@@ -286,6 +286,27 @@
     </div>
   </div>
 
+  <!-- Merge Recordings Dialog -->
+  <div id="mergeModal" class="modal" style="display: none;">
+    <div class="modal-content merge-modal-content">
+      <div class="modal-header">
+        <h2>Merge Recordings</h2>
+        <span class="close" id="mergeModalClose">&times;</span>
+      </div>
+      <p class="merge-hint">Select 2 or more recordings to combine. Audio is concatenated in the listed order, then re-transcribed end-to-end. Originals are kept.</p>
+      <div class="merge-title-row">
+        <label for="mergeTitleInput">New note title</label>
+        <input type="text" id="mergeTitleInput" placeholder="Merged Meeting" />
+      </div>
+      <ul id="mergeList" class="merge-list" aria-label="Recordings available to merge"></ul>
+      <p id="mergeStatus" class="merge-status"></p>
+      <div class="modal-buttons">
+        <button id="mergeCancelBtn" class="cancel-button">Cancel</button>
+        <button id="mergeConfirmBtn" class="save-button" disabled>Merge &amp; Transcribe</button>
+      </div>
+    </div>
+  </div>
+
   <!-- FFmpeg Download Progress Overlay -->
   <div id="ffmpegDownloadOverlay" class="modal" style="display: none;">
     <div class="ffmpeg-download-card">

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
     "dist/outputService.js",
     "dist/searchService.js",
     "dist/agentService.js",
-    "dist/services/ffmpegManager.js"
+    "dist/audioFormats.js",
+    "dist/services/ffmpegManager.js",
+    "dist/services/audioConcatService.js"
   ],
   "scripts": {
     "start": "pnpm run build && electron .",
     "build": "tsc",
-    "test": "tsc && node --test dist/meetingDetectorService.test.js dist/searchService.test.js dist/agentService.test.js dist/simpleAudioRecorder.test.js",
+    "test": "tsc && node --test dist/meetingDetectorService.test.js dist/searchService.test.js dist/agentService.test.js dist/simpleAudioRecorder.test.js dist/outputService.test.js dist/services/audioConcatService.test.js dist/cli.test.js",
     "dist": "pnpm run build && electron-builder",
     "dist:mac": "pnpm run build && electron-builder --mac",
     "dist:mac-x64": "pnpm run build && electron-builder --mac --x64",

--- a/renderer.js
+++ b/renderer.js
@@ -303,6 +303,17 @@ window.electronAPI.onTranscriptionProgress((progress) => {
   }
 });
 
+// Auto-refresh the list when the recordings directory changes externally
+// (e.g., a `listener` CLI run, or manual file ops). refreshRecordingsList is
+// defined later in this file but the listener only fires after first event.
+if (window.electronAPI.onRecordingsChanged) {
+  window.electronAPI.onRecordingsChanged(() => {
+    if (typeof refreshRecordingsList === 'function') {
+      refreshRecordingsList();
+    }
+  });
+}
+
 // Listen for release notes after an update
 if (window.electronAPI.onShowReleaseNotes) {
   window.electronAPI.onShowReleaseNotes((notes) => {

--- a/renderer.js
+++ b/renderer.js
@@ -1688,22 +1688,28 @@ async function showConfigModal() {
 
 
 // Function to load and display recordings
+// Monotonic token so a slow loadRecordings (per-item async metadata reads)
+// can't overwrite a fresher snapshot's render. Mirrors lastSearchToken.
+let lastLoadRecordingsToken = 0;
 async function loadRecordings() {
+  const myToken = ++lastLoadRecordingsToken;
   try {
     const result = await window.electronAPI.getRecordings();
 
     if (result.success && result.recordings.length > 0) {
-      recordingsList.innerHTML = '';
-
-      // Use Promise.all to handle async createRecordingItem
       const items = await Promise.all(
         result.recordings.map(recording => createRecordingItem(recording))
       );
+      // Drop if a newer load started while we were awaiting metadata.
+      if (myToken !== lastLoadRecordingsToken) return;
+      recordingsList.innerHTML = '';
       items.forEach(item => recordingsList.appendChild(item));
     } else {
+      if (myToken !== lastLoadRecordingsToken) return;
       recordingsList.innerHTML = '<p class="no-recordings">No recordings yet</p>';
     }
   } catch (error) {
+    if (myToken !== lastLoadRecordingsToken) return;
     console.error('Error loading recordings:', error);
     recordingsList.innerHTML = '<p class="no-recordings">Error loading recordings</p>';
   }

--- a/renderer.js
+++ b/renderer.js
@@ -1496,40 +1496,10 @@ async function handleTranscribe(filePath, title) {
     return;
   }
 
-  // Make sure modal elements are loaded
-  if (!transcriptionModal) {
-    transcriptionModal = document.getElementById('transcriptionModal');
-  }
-
-  // Show transcription modal
-  if (transcriptionModal) {
-    transcriptionModal.style.display = 'block';
-    document.getElementById('transcriptionTitle').textContent = `Transcription - ${title}`;
-
-    // Show progress bar
-    if (progressContainer) {
-      progressContainer.style.display = 'block';
-      progressFill.style.width = '0%';
-      progressText.textContent = 'Initializing transcription...';
-    }
-  } else {
-    console.error('Transcription modal not found');
+  if (!prepareTranscriptionModal(`Transcription - ${title}`, 'Initializing transcription...')) {
     return;
   }
 
-  // Reset all tabs to loading state
-  document.getElementById('all').innerHTML = '<p class="loading">Loading...</p>';
-  document.getElementById('summary').innerHTML = '<p class="loading">Loading summary...</p>';
-  document.getElementById('transcript').innerHTML = '<p class="loading">Loading transcription...</p>';
-  resetModalChatFor(null);
-  document.querySelectorAll('.tab-button.dynamic').forEach(el => el.remove());
-  document.querySelectorAll('.tab-pane.dynamic').forEach(el => el.remove());
-  document.querySelectorAll('.tab-button').forEach(b => b.classList.remove('active'));
-  document.querySelectorAll('.tab-pane').forEach(p => p.classList.remove('active'));
-  document.querySelector('[data-tab="all"]').classList.add('active');
-  document.getElementById('all').classList.add('active');
-
-  // Disable the transcribe button
   const button = document.querySelector(`[data-filepath="${filePath}"]`);
   if (button) {
     button.disabled = true;
@@ -1760,6 +1730,9 @@ async function createRecordingItem(recording) {
           Transcribe
         </button>
       `}
+      <button class="action-button merge-btn" data-path="${recording.path}" title="Merge this with other recordings into a single note">
+        Merge
+      </button>
       <button class="action-button reveal-btn" data-path="${recording.path}" title="Reveal in Finder (right-click in Finder to share)">
         Show
       </button>
@@ -1803,6 +1776,13 @@ async function createRecordingItem(recording) {
     });
   }
 
+  const mergeBtn = item.querySelector('.merge-btn');
+  if (mergeBtn) {
+    mergeBtn.addEventListener('click', () => {
+      openMergeDialog(recording.path);
+    });
+  }
+
   return item;
 }
 
@@ -1838,6 +1818,235 @@ async function handleExportM4A(srcPath, button) {
       button.disabled = false;
       button.textContent = originalLabel;
     }
+  }
+}
+
+// --- Merge Recordings dialog ----------------------------------------------
+
+// Shared by handleTranscribe and performMerge. Returns false if the modal can't
+// be located (handler should bail).
+function prepareTranscriptionModal(modalTitle, progressMessage, allLoadingText) {
+  if (!transcriptionModal) {
+    transcriptionModal = document.getElementById('transcriptionModal');
+  }
+  if (!transcriptionModal) {
+    console.error('Transcription modal not found');
+    return false;
+  }
+  transcriptionModal.style.display = 'block';
+  document.getElementById('transcriptionTitle').textContent = modalTitle;
+  if (progressContainer) {
+    progressContainer.style.display = 'block';
+    progressFill.style.width = '0%';
+    progressText.textContent = progressMessage;
+  }
+  document.getElementById('all').innerHTML = `<p class="loading">${allLoadingText || 'Loading...'}</p>`;
+  document.getElementById('summary').innerHTML = '<p class="loading">Loading summary...</p>';
+  document.getElementById('transcript').innerHTML = '<p class="loading">Loading transcription...</p>';
+  resetModalChatFor(null);
+  document.querySelectorAll('.tab-button.dynamic').forEach(el => el.remove());
+  document.querySelectorAll('.tab-pane.dynamic').forEach(el => el.remove());
+  document.querySelectorAll('.tab-button').forEach(b => b.classList.remove('active'));
+  document.querySelectorAll('.tab-pane').forEach(p => p.classList.remove('active'));
+  document.querySelector('[data-tab="all"]').classList.add('active');
+  document.getElementById('all').classList.add('active');
+  return true;
+}
+
+async function openMergeDialog(initialFilePath) {
+  const modal = document.getElementById('mergeModal');
+  const list = document.getElementById('mergeList');
+  const status = document.getElementById('mergeStatus');
+  const titleInput = document.getElementById('mergeTitleInput');
+  const confirmBtn = document.getElementById('mergeConfirmBtn');
+  const cancelBtn = document.getElementById('mergeCancelBtn');
+  const closeBtn = document.getElementById('mergeModalClose');
+  if (!modal || !list || !status || !titleInput || !confirmBtn || !cancelBtn || !closeBtn) {
+    console.error('Merge modal elements missing');
+    return;
+  }
+
+  status.textContent = '';
+  status.classList.remove('error');
+  titleInput.value = '';
+  list.innerHTML = '<p class="merge-list-empty">Loading recordings...</p>';
+  modal.style.display = 'block';
+
+  let recordings = [];
+  try {
+    const result = await window.electronAPI.getRecordings();
+    recordings = result && result.success ? result.recordings : [];
+  } catch (err) {
+    list.innerHTML = '<p class="merge-list-empty">Failed to load recordings.</p>';
+    return;
+  }
+
+  if (recordings.length < 2) {
+    list.innerHTML = '<p class="merge-list-empty">Need at least 2 recordings to merge.</p>';
+    confirmBtn.disabled = true;
+    return;
+  }
+
+  // Seed with the clicked recording so the title-prefix heuristic below has
+  // something to work with even before the user picks anything else.
+  const selection = initialFilePath ? [initialFilePath] : [];
+
+  list.innerHTML = '';
+  for (const rec of recordings) {
+    const li = document.createElement('li');
+    li.dataset.path = rec.path;
+    const date = new Date(rec.createdAt);
+    const meta = `${date.toLocaleDateString()} ${date.toLocaleTimeString()} • ${formatFileSize(rec.size)}`;
+    li.innerHTML = `
+      <input type="checkbox" />
+      <div class="merge-list-item-info">
+        <div class="merge-list-item-title"></div>
+        <div class="merge-list-item-meta"></div>
+      </div>
+      <div class="merge-list-order"></div>
+    `;
+    li.querySelector('.merge-list-item-title').textContent = rec.title || 'Untitled';
+    li.querySelector('.merge-list-item-meta').textContent = meta;
+    const checkbox = li.querySelector('input[type="checkbox"]');
+    if (selection.includes(rec.path)) {
+      checkbox.checked = true;
+      li.classList.add('selected');
+    }
+    li.addEventListener('click', (e) => {
+      // Skip when the click hits the checkbox itself -- otherwise the change
+      // event fires twice.
+      if (e.target !== checkbox) {
+        checkbox.checked = !checkbox.checked;
+      }
+      onSelectionChange(rec.path, checkbox.checked, li);
+    });
+    list.appendChild(li);
+  }
+
+  function onSelectionChange(filePath, checked, li) {
+    if (checked) {
+      if (!selection.includes(filePath)) selection.push(filePath);
+      li.classList.add('selected');
+    } else {
+      const idx = selection.indexOf(filePath);
+      if (idx >= 0) selection.splice(idx, 1);
+      li.classList.remove('selected');
+    }
+    updateOrderBadges();
+    updateConfirmState();
+    updateDefaultTitle();
+  }
+
+  function updateOrderBadges() {
+    const items = list.querySelectorAll('li');
+    items.forEach((el) => {
+      const badge = el.querySelector('.merge-list-order');
+      const idx = selection.indexOf(el.dataset.path);
+      badge.textContent = idx >= 0 ? String(idx + 1) : '';
+    });
+  }
+
+  function updateConfirmState() {
+    confirmBtn.disabled = selection.length < 2;
+    if (selection.length === 1) {
+      status.textContent = 'Select at least one more recording.';
+      status.classList.remove('error');
+    } else {
+      status.textContent = '';
+      status.classList.remove('error');
+    }
+  }
+
+  function updateDefaultTitle() {
+    if (titleInput.dataset.userEdited === 'true') return;
+    const titles = selection
+      .map((p) => recordings.find((r) => r.path === p))
+      .filter(Boolean)
+      .map((r) => r.title || '');
+    const prefix = commonTitlePrefix(titles);
+    titleInput.placeholder = prefix || 'Merged Meeting';
+  }
+
+  const onTitleInput = () => {
+    titleInput.dataset.userEdited = titleInput.value.trim() === '' ? '' : 'true';
+  };
+  titleInput.addEventListener('input', onTitleInput);
+
+  updateOrderBadges();
+  updateConfirmState();
+  updateDefaultTitle();
+
+  const cleanup = () => {
+    modal.style.display = 'none';
+    titleInput.dataset.userEdited = '';
+    titleInput.removeEventListener('input', onTitleInput);
+    cancelBtn.removeEventListener('click', onCancel);
+    closeBtn.removeEventListener('click', onCancel);
+    confirmBtn.removeEventListener('click', onConfirm);
+  };
+  const onCancel = () => cleanup();
+  const onConfirm = async () => {
+    if (selection.length < 2) return;
+    const title = titleInput.value.trim() || titleInput.placeholder || 'Merged Meeting';
+    cleanup();
+    await performMerge(selection.slice(), title);
+  };
+  cancelBtn.addEventListener('click', onCancel);
+  closeBtn.addEventListener('click', onCancel);
+  confirmBtn.addEventListener('click', onConfirm);
+}
+
+// Longest shared prefix across titles, trimmed of trailing whitespace and
+// trailing single digits ("Meeting 1" / "Meeting 2" -> "Meeting").
+function commonTitlePrefix(titles) {
+  if (titles.length === 0) return '';
+  if (titles.length === 1) return titles[0];
+  let prefix = titles[0];
+  for (let i = 1; i < titles.length; i++) {
+    const t = titles[i];
+    let j = 0;
+    while (j < prefix.length && j < t.length && prefix[j] === t[j]) j++;
+    prefix = prefix.slice(0, j);
+    if (!prefix) break;
+  }
+  return prefix.replace(/[\s_\-]*\d*\s*$/, '').trim();
+}
+
+async function performMerge(paths, title) {
+  if (!prepareTranscriptionModal(`Merging - ${title}`, 'Preparing merge...', 'Merging audio and re-transcribing...')) {
+    return;
+  }
+
+  try {
+    const result = await window.electronAPI.mergeRecordings({ paths, title });
+    if (!result || !result.success) {
+      const message = (result && result.error) || 'Unknown error';
+      if (result && result.code === 'ffmpeg-missing') {
+        alert('FFmpeg is required to merge recordings. Transcribe a recording first to install it.');
+      } else {
+        alert('Failed to merge recordings: ' + message);
+      }
+      if (progressContainer) progressContainer.style.display = 'none';
+      if (transcriptionModal) transcriptionModal.style.display = 'none';
+      return;
+    }
+
+    if (progressContainer) progressContainer.style.display = 'none';
+    document.getElementById('transcriptionTitle').textContent = `Transcription - ${title}`;
+    currentTranscriptionData = result.data;
+    currentMeetingTitle = title;
+    currentFilePath = result.mergedAudioPath || null;
+    populateTranscriptionUI(result.data);
+
+    await refreshRecordingsList();
+
+    const notionConfig = await window.electronAPI.getConfig();
+    if (notionConfig.notionApiKey && notionConfig.notionDatabaseId && uploadToNotionBtn) {
+      uploadToNotionBtn.style.display = 'flex';
+    }
+  } catch (err) {
+    alert('Error merging recordings: ' + (err && err.message ? err.message : String(err)));
+    if (progressContainer) progressContainer.style.display = 'none';
   }
 }
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,103 @@
+// adb-style integration test: drive the listener CLI as an external process
+// (analogous to `adb shell am start INTENT`), with a sandboxed dataPath and
+// a stubbed GeminiService, then assert on the resulting transcription folder.
+//
+// Catches things service-layer tests can't: CLI argument parsing, ref
+// resolution, the wiring between CLI -> readTranscription -> concat ->
+// transcribe -> saveTranscription, and the mergedFrom round-trip.
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  execFileAsync,
+  findFfmpegSync,
+  makeTempDir,
+  rmDir,
+  makeOpusWebm,
+} from './test-helpers';
+import { saveTranscription } from './outputService';
+
+const ffmpegPath = findFfmpegSync();
+
+let dataPath: string;
+let cliPath: string;
+
+before(() => {
+  dataPath = makeTempDir('cli-merge');
+  // Compiled CLI lives next to this compiled test under dist/.
+  cliPath = path.join(__dirname, 'cli.js');
+});
+
+after(() => rmDir(dataPath));
+
+describe('listener merge (CLI integration)', { skip: !ffmpegPath ? 'ffmpeg not installed' : undefined }, () => {
+  it('merges two transcribed sources end-to-end and writes mergedFrom frontmatter', async () => {
+    const recordingsDir = path.join(dataPath, 'recordings');
+    fs.mkdirSync(recordingsDir, { recursive: true });
+
+    const audioA = await makeOpusWebm(ffmpegPath!, recordingsDir, 'partA.webm', 440);
+    const audioB = await makeOpusWebm(ffmpegPath!, recordingsDir, 'partB.webm', 880);
+
+    const folderA = saveTranscription({
+      title: 'Part One',
+      result: {
+        transcript: 'Part one body.',
+        summary: 'Part one summary.',
+        keyPoints: ['a1'],
+        actionItems: ['a-action'],
+        emoji: 'A',
+        suggestedTitle: 'Part One',
+      },
+      audioFilePath: audioA,
+      dataPath,
+    });
+    const folderB = saveTranscription({
+      title: 'Part Two',
+      result: {
+        transcript: 'Part two body.',
+        summary: 'Part two summary.',
+        keyPoints: ['b1'],
+        actionItems: ['b-action'],
+        emoji: 'B',
+        suggestedTitle: 'Part Two',
+      },
+      audioFilePath: audioB,
+      dataPath,
+    });
+
+    const folderNameA = path.basename(folderA);
+    const folderNameB = path.basename(folderB);
+
+    const env = {
+      ...process.env,
+      LISTENER_DATA_PATH: dataPath,
+      LISTENER_TEST_MODE: '1',
+      GEMINI_API_KEY: 'test-mode-key',
+    };
+
+    const { stdout } = await execFileAsync(
+      'node',
+      [cliPath, 'merge', folderNameA, folderNameB, '--title', 'Combined Meeting'],
+      { env },
+    );
+
+    const resultFolder = stdout.trim();
+    assert.ok(fs.existsSync(resultFolder), `result folder ${resultFolder} should exist`);
+    assert.ok(resultFolder.startsWith(dataPath), `result folder must live inside the test dataPath, got ${resultFolder}`);
+
+    const summary = fs.readFileSync(path.join(resultFolder, 'summary.md'), 'utf-8');
+    assert.match(summary, /title: Stubbed Title/);
+    assert.match(summary, /## Sources/);
+    assert.match(summary, new RegExp(folderNameA.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.match(summary, new RegExp(folderNameB.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+
+    const audioLine = summary.match(/^audioFilePath:\s*(.+)$/m);
+    const mergedAudioPath = audioLine?.[1].trim().replace(/^"|"$/g, '') ?? '';
+    assert.ok(mergedAudioPath.endsWith('.webm'), `merged audio should be webm, got ${mergedAudioPath}`);
+    assert.ok(fs.existsSync(mergedAudioPath), `merged audio file should exist on disk: ${mergedAudioPath}`);
+
+    assert.ok(fs.existsSync(folderA), 'source folder A should be preserved');
+    assert.ok(fs.existsSync(folderB), 'source folder B should be preserved');
+  });
+});

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -71,6 +71,7 @@ describe('listener merge (CLI integration)', { skip: !ffmpegPath ? 'ffmpeg not i
 
     const env = {
       ...process.env,
+      NODE_ENV: 'test',
       LISTENER_DATA_PATH: dataPath,
       LISTENER_TEST_MODE: '1',
       GEMINI_API_KEY: 'test-mode-key',
@@ -87,7 +88,9 @@ describe('listener merge (CLI integration)', { skip: !ffmpegPath ? 'ffmpeg not i
     assert.ok(resultFolder.startsWith(dataPath), `result folder must live inside the test dataPath, got ${resultFolder}`);
 
     const summary = fs.readFileSync(path.join(resultFolder, 'summary.md'), 'utf-8');
-    assert.match(summary, /title: Stubbed Title/);
+    // User-provided --title beats the stub's suggestedTitle.
+    assert.match(summary, /^title: Combined Meeting$/m);
+    assert.match(summary, /suggestedTitle: Stubbed Title/);
     assert.match(summary, /## Sources/);
     assert.match(summary, new RegExp(folderNameA.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     assert.match(summary, new RegExp(folderNameB.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,9 +5,12 @@ import * as path from 'path';
 import { getDataPath } from './dataPath';
 import { ConfigService } from './configService';
 import { GeminiService } from './geminiService';
-import { saveTranscription, listTranscriptions, parseFrontmatter, getTranscriptionsDir } from './outputService';
+import { saveTranscription, listTranscriptions, parseFrontmatter, getTranscriptionsDir, readTranscription, sanitizeForPath, formatTimestamp } from './outputService';
 import { searchTranscriptions, resolveFields, ALL_FIELDS, type SearchField } from './searchService';
 import { AgentService, type AgentScope, type ConfigProposal } from './agentService';
+import { FFmpegManager } from './services/ffmpegManager';
+import { concatAudioFiles } from './services/audioConcatService';
+import { extensionForMimeType } from './audioFormats';
 
 const SUPPORTED_EXTENSIONS = new Set([
   '.mp3', '.m4a', '.wav', '.ogg', '.flac', '.aac', '.wma', '.opus', '.webm',
@@ -22,6 +25,9 @@ function usage(): never {
     '                                           Export transcription\n' +
     '       listener search <query> [--limit <n>] [--transcript] [--field <name>]\n' +
     '                                           Search past transcriptions\n' +
+    '       listener merge <ref1> <ref2> [<ref3>...] [--title <t>]\n' +
+    '                                           Concat the source audio of two or more notes,\n' +
+    '                                           re-transcribe end-to-end, and save as a new note\n' +
     '       listener ask <question> [--ref <ref>]\n' +
     '                                           Ask the AI agent about saved meetings or settings\n' +
     '       listener config list|get|set|path   Manage configuration\n' +
@@ -366,6 +372,99 @@ async function promptYesNo(message: string): Promise<boolean> {
   });
 }
 
+async function handleMerge(args: string[]): Promise<void> {
+  const refs: string[] = [];
+  let title: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--title' && i + 1 < args.length) {
+      title = args[++i];
+      continue;
+    }
+    if (a.startsWith('-')) {
+      process.stderr.write(`Error: Unknown option: ${a}\n`);
+      process.exit(1);
+    }
+    refs.push(a);
+  }
+
+  if (refs.length < 2) {
+    process.stderr.write('Error: merge requires at least 2 refs. Usage: listener merge <ref1> <ref2> [<ref3>...] [--title <t>]\n');
+    process.exit(1);
+  }
+
+  const dataPath = getDataPath();
+  const config = new ConfigService(dataPath);
+  const apiKey = config.getGeminiApiKey();
+  if (!apiKey) {
+    process.stderr.write('Error: Gemini API key not found. Set GEMINI_API_KEY env var or configure via the Listener.AI app.\n');
+    process.exit(1);
+  }
+
+  // Resolve every ref to a folder + audio path before doing any expensive work
+  // so an early failure (missing audio) doesn't waste a partial concat.
+  const sources: Array<{ folderName: string; audioPath: string }> = [];
+  for (const ref of refs) {
+    const folderPath = await resolveRef(ref, dataPath);
+    const data = await readTranscription(folderPath);
+    if (!data || !data.audioFilePath) {
+      process.stderr.write(`Error: ${ref} has no audioFilePath in its frontmatter; cannot include it in a merge.\n`);
+      process.exit(1);
+    }
+    if (!fs.existsSync(data.audioFilePath)) {
+      process.stderr.write(`Error: source audio missing for ${ref}: ${data.audioFilePath}\n`);
+      process.exit(1);
+    }
+    sources.push({ folderName: path.basename(folderPath), audioPath: data.audioFilePath });
+  }
+
+  const ffmpegManager = new FFmpegManager(dataPath);
+  const ffmpegPath = await ffmpegManager.ensureFFmpeg();
+  if (!ffmpegPath) {
+    process.stderr.write('Error: ffmpeg not found. Install ffmpeg or run a transcription in the GUI to download it.\n');
+    process.exit(1);
+  }
+
+  const safeTitle = sanitizeForPath(title?.trim() || 'Merged Meeting') || 'Merged Meeting';
+  const recordingsDir = path.join(dataPath, 'recordings');
+  fs.mkdirSync(recordingsDir, { recursive: true });
+  const mergedAudioPath = path.join(recordingsDir, `${safeTitle}_${formatTimestamp()}.${extensionForMimeType('audio/webm')}`);
+
+  process.stderr.write(`Merging ${sources.length} recordings...\n`);
+  await concatAudioFiles({
+    ffmpegPath,
+    inputPaths: sources.map((s) => s.audioPath),
+    outputPath: mergedAudioPath,
+  });
+  process.stderr.write(`  -> ${mergedAudioPath}\n`);
+
+  const gemini = new GeminiService({
+    apiKey,
+    dataPath,
+    knownWords: config.getKnownWords(),
+    proModel: config.getGeminiModel(),
+    flashModel: config.getGeminiFlashModel(),
+  });
+
+  process.stderr.write('Transcribing merged recording...\n');
+  const result = await gemini.transcribeAudio(mergedAudioPath, (_percent, message) => {
+    process.stderr.write(`  ${message}\n`);
+  }, config.getSummaryPrompt());
+
+  const finalTitle = result.suggestedTitle || (title?.trim() || 'Merged Meeting');
+  const folderPath = saveTranscription({
+    title: finalTitle,
+    result,
+    audioFilePath: mergedAudioPath,
+    dataPath,
+    mergedFrom: sources.map((s) => s.folderName),
+  });
+
+  process.stderr.write('Done.\n');
+  process.stdout.write(`${folderPath}\n`);
+}
+
 async function handleAsk(args: string[]): Promise<void> {
   let question: string | undefined;
   let ref: string | undefined;
@@ -450,6 +549,11 @@ async function main(): Promise<void> {
 
   if (args[0] === 'search') {
     await handleSearch(args.slice(1));
+    return;
+  }
+
+  if (args[0] === 'merge') {
+    await handleMerge(args.slice(1));
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { randomUUID } from 'crypto';
 import { getDataPath } from './dataPath';
 import { ConfigService } from './configService';
 import { GeminiService } from './geminiService';
@@ -429,7 +430,9 @@ async function handleMerge(args: string[]): Promise<void> {
   const safeTitle = sanitizeForPath(title?.trim() || 'Merged Meeting') || 'Merged Meeting';
   const recordingsDir = path.join(dataPath, 'recordings');
   fs.mkdirSync(recordingsDir, { recursive: true });
-  const mergedAudioPath = path.join(recordingsDir, `${safeTitle}_${formatTimestamp()}.${extensionForMimeType('audio/webm')}`);
+  // UUID suffix avoids filename collision when two CLI merges with the same
+  // title start in the same second (formatTimestamp is second-granularity).
+  const mergedAudioPath = path.join(recordingsDir, `${safeTitle}_${formatTimestamp()}_${randomUUID().slice(0, 8)}.${extensionForMimeType('audio/webm')}`);
 
   process.stderr.write(`Merging ${sources.length} recordings...\n`);
   await concatAudioFiles({
@@ -452,7 +455,8 @@ async function handleMerge(args: string[]): Promise<void> {
     process.stderr.write(`  ${message}\n`);
   }, config.getSummaryPrompt());
 
-  const finalTitle = result.suggestedTitle || (title?.trim() || 'Merged Meeting');
+  // User-supplied --title wins; Gemini's suggestion is the fallback.
+  const finalTitle = (title?.trim()) || result.suggestedTitle || 'Merged Meeting';
   const folderPath = saveTranscription({
     title: finalTitle,
     result,

--- a/src/dataPath.ts
+++ b/src/dataPath.ts
@@ -5,6 +5,11 @@ import * as os from 'os';
 const APP_NAME = 'Listener.AI';
 
 export function getDataPath(): string {
+  // Test escape hatch: integration tests set this to a temp dir to avoid
+  // touching the user's real data. Read-only at process start.
+  if (process.env.LISTENER_DATA_PATH) {
+    return process.env.LISTENER_DATA_PATH;
+  }
   switch (process.platform) {
     case 'darwin':
       return path.join(os.homedir(), 'Library', 'Application Support', APP_NAME);

--- a/src/dataPath.ts
+++ b/src/dataPath.ts
@@ -6,8 +6,10 @@ const APP_NAME = 'Listener.AI';
 
 export function getDataPath(): string {
   // Test escape hatch: integration tests set this to a temp dir to avoid
-  // touching the user's real data. Read-only at process start.
-  if (process.env.LISTENER_DATA_PATH) {
+  // touching the user's real data. Gated on NODE_ENV=test so a stray
+  // LISTENER_DATA_PATH in a packaged user's shell rc can't redirect their
+  // config + transcriptions to an attacker-controlled path.
+  if (process.env.LISTENER_DATA_PATH && process.env.NODE_ENV === 'test') {
     return process.env.LISTENER_DATA_PATH;
   }
   switch (process.platform) {

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -57,6 +57,21 @@ export class GeminiService {
   }
 
   async transcribeAudio(audioFilePath: string, progressCallback?: (percent: number, message: string) => void, summaryPrompt?: string): Promise<TranscriptionResult> {
+    // Integration-test escape hatch: avoid the real Gemini call so tests can
+    // exercise the surrounding pipeline (CLI parsing, IPC, ffmpeg, save) for
+    // free and offline. Production runtime never sets this.
+    if (process.env.LISTENER_TEST_MODE) {
+      if (progressCallback) progressCallback(100, 'Stubbed transcription');
+      return {
+        transcript: 'Stubbed transcript.',
+        summary: 'Stubbed summary.',
+        keyPoints: ['stub point'],
+        actionItems: ['stub action'],
+        emoji: '🧪',
+        suggestedTitle: 'Stubbed Title',
+      };
+    }
+
     try {
       // Check file size
       const stats = fs.statSync(audioFilePath);

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -59,8 +59,9 @@ export class GeminiService {
   async transcribeAudio(audioFilePath: string, progressCallback?: (percent: number, message: string) => void, summaryPrompt?: string): Promise<TranscriptionResult> {
     // Integration-test escape hatch: avoid the real Gemini call so tests can
     // exercise the surrounding pipeline (CLI parsing, IPC, ffmpeg, save) for
-    // free and offline. Production runtime never sets this.
-    if (process.env.LISTENER_TEST_MODE) {
+    // free and offline. Gated on NODE_ENV=test so a stray LISTENER_TEST_MODE
+    // in a packaged user's shell rc can't silently stub their transcripts.
+    if (process.env.LISTENER_TEST_MODE && process.env.NODE_ENV === 'test') {
       if (progressCallback) progressCallback(100, 'Stubbed transcription');
       return {
         transcript: 'Stubbed transcript.',

--- a/src/main.ts
+++ b/src/main.ts
@@ -216,6 +216,34 @@ async function checkAndShowReleaseNotes() {
   }
 }
 
+// Watch the recordings directory for external changes (CLI runs, manual file
+// ops) and push a refresh to the renderer so the list stays in sync without
+// requiring a manual reload. Debounced because some operations (a merge
+// concat) write through multiple events in quick succession.
+let recordingsWatcher: fs.FSWatcher | null = null;
+let recordingsWatcherTimer: NodeJS.Timeout | null = null;
+function startRecordingsWatcher(): void {
+  if (recordingsWatcher) return;
+  const dir = path.join(app.getPath('userData'), 'recordings');
+  fs.mkdirSync(dir, { recursive: true });
+  try {
+    recordingsWatcher = fs.watch(dir, () => {
+      if (recordingsWatcherTimer) clearTimeout(recordingsWatcherTimer);
+      recordingsWatcherTimer = setTimeout(() => {
+        recordingsWatcherTimer = null;
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send('recordings-changed');
+        }
+      }, 250);
+    });
+    recordingsWatcher.on('error', (err) => {
+      console.warn('recordings watcher error:', err);
+    });
+  } catch (err) {
+    console.warn('Failed to start recordings watcher:', err);
+  }
+}
+
 function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1000,
@@ -422,6 +450,8 @@ app.whenReady().then(() => {
     notificationService.setMainWindow(mainWindow);
   }
 
+  startRecordingsWatcher();
+
   // Kick off initial + periodic update checks once the renderer can receive IPC.
   autoUpdaterService.checkForUpdates();
   autoUpdaterService.startPeriodicCheck();
@@ -542,6 +572,14 @@ app.on('before-quit', async (event) => {
 // Unregister all shortcuts when app quits
 app.on('will-quit', () => {
   globalShortcut.unregisterAll();
+  if (recordingsWatcher) {
+    recordingsWatcher.close();
+    recordingsWatcher = null;
+  }
+  if (recordingsWatcherTimer) {
+    clearTimeout(recordingsWatcherTimer);
+    recordingsWatcherTimer = null;
+  }
 });
 
 // Helper function to rename audio file with generated title

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,10 +16,11 @@ import { DisplayDetectorService } from './displayDetectorService';
 import { autoUpdaterService } from './services/autoUpdaterService';
 import { notificationService } from './services/notificationService';
 import { fetchReleaseNotes, fetchAllReleases } from './services/releaseNotesService';
-import { saveTranscription, readTranscription } from './outputService';
+import { saveTranscription, readTranscription, sanitizeForPath, formatTimestamp } from './outputService';
+import { concatAudioFiles } from './services/audioConcatService';
 import { searchTranscriptions, ALL_FIELDS, type SearchField } from './searchService';
 import { AgentService, type AgentChatMessage, type AgentRunResult, type AgentScope, type ConfigProposal } from './agentService';
-import { isSupportedAudioExtension } from './audioFormats';
+import { isSupportedAudioExtension, extensionForMimeType } from './audioFormats';
 import { SystemAudioService, SYSTEM_AUDIO_FORMAT } from './services/systemAudioService';
 
 // Enable macOS system-audio loopback capture so getDisplayMedia({audio: 'loopback'})
@@ -696,6 +697,134 @@ ipcMain.handle('export-recording-m4a', async (_, srcPath: string) => {
     const stderr = (error as { stderr?: string } | null)?.stderr;
     const baseMessage = error instanceof Error ? error.message : String(error);
     const message = stderr ? `${baseMessage.split('\n')[0]} — ${stderr.trim()}` : baseMessage;
+    return { success: false, error: message };
+  }
+});
+
+// Merge multiple recordings: concat audio files, then run the standard
+// transcription pipeline on the merged file. Originals are left untouched.
+// Resolves source folder names from per-recording metadata so the merged note's
+// `mergedFrom` frontmatter (and "Sources" body section) can reference them.
+ipcMain.handle('merge-recordings', async (_, opts: { paths: string[]; title?: string }) => {
+  try {
+    const inputPaths = Array.isArray(opts?.paths) ? opts.paths : [];
+    if (inputPaths.length < 2) {
+      return { success: false, error: 'At least 2 recordings are required to merge' };
+    }
+
+    // Containment: every input must resolve inside the recordings directory.
+    const recordingsDir = path.join(app.getPath('userData'), 'recordings');
+    const resolvedRoot = await fs.promises.realpath(recordingsDir).catch(() => recordingsDir);
+    const resolvedInputs: string[] = [];
+    for (const p of inputPaths) {
+      if (typeof p !== 'string' || !p) {
+        return { success: false, error: 'Invalid input path' };
+      }
+      let resolved: string;
+      try {
+        resolved = await fs.promises.realpath(p);
+      } catch {
+        return { success: false, error: `Recording not found: ${path.basename(p)}` };
+      }
+      if (!resolved.startsWith(resolvedRoot + path.sep)) {
+        return { success: false, error: 'Source path is outside the recordings directory' };
+      }
+      resolvedInputs.push(resolved);
+    }
+
+    if (!geminiService) {
+      const apiKey = configService.getGeminiApiKey();
+      if (!apiKey) {
+        return { success: false, error: 'Gemini API key not configured' };
+      }
+      geminiService = createGeminiService()!;
+    }
+
+    const ffmpegPath = await ffmpegManager.ensureFFmpeg();
+    if (!ffmpegPath) {
+      return { success: false, code: 'ffmpeg-missing', error: 'FFmpeg is required to merge recordings.' };
+    }
+
+    const rawTitle = (opts.title && opts.title.trim()) || 'Merged Meeting';
+    const safeTitle = sanitizeForPath(rawTitle) || 'Merged Meeting';
+    // Always emit webm/opus -- matches MediaRecorder native output and survives
+    // the stream-copy fast path when all inputs are also webm.
+    const mergedExt = extensionForMimeType('audio/webm');
+    const mergedAudioPath = path.join(recordingsDir, `${safeTitle}_${formatTimestamp()}.${mergedExt}`);
+
+    if (mainWindow) {
+      mainWindow.webContents.send('transcription-progress', { percent: 5, message: 'Merging audio files...' });
+    }
+
+    await fs.promises.mkdir(recordingsDir, { recursive: true });
+
+    // Run the metadata lookup concurrently with the ffmpeg concat -- they're
+    // independent and concat is the long pole, so the metadata reads are free.
+    // Recordings without a transcription contribute nothing to mergedFrom.
+    const [, metas] = await Promise.all([
+      concatAudioFiles({ ffmpegPath, inputPaths: resolvedInputs, outputPath: mergedAudioPath }),
+      Promise.all(resolvedInputs.map((p) => metadataService.getMetadata(p))),
+    ]);
+    const sourceFolders = metas
+      .filter((m): m is NonNullable<typeof m> => !!m?.transcriptionPath)
+      .map((m) => path.basename(m.transcriptionPath!));
+
+    if (mainWindow) {
+      mainWindow.webContents.send('transcription-progress', { percent: 15, message: 'Transcribing merged recording...' });
+    }
+
+    const progressCallback = (percent: number, message: string) => {
+      if (mainWindow) {
+        // Compress the transcription progress into 15-95% to leave room for the
+        // concat phase at the start and the save phase at the end.
+        const adjusted = 15 + Math.round(percent * 0.8);
+        mainWindow.webContents.send('transcription-progress', { percent: adjusted, message });
+      }
+    };
+
+    const summaryPrompt = configService.getSummaryPrompt();
+    const result = await geminiService.transcribeAudio(mergedAudioPath, progressCallback, summaryPrompt);
+
+    const finalTitle = result.suggestedTitle || rawTitle;
+    let transcriptionPath: string | undefined;
+    try {
+      transcriptionPath = saveTranscription({
+        title: finalTitle,
+        result,
+        audioFilePath: mergedAudioPath,
+        dataPath: app.getPath('userData'),
+        mergedFrom: sourceFolders,
+      });
+    } catch (error) {
+      console.error('Failed to save merged transcription files:', error);
+    }
+
+    try {
+      if (transcriptionPath) {
+        await metadataService.saveMetadata(mergedAudioPath, {
+          title: finalTitle,
+          suggestedTitle: result.suggestedTitle,
+          transcriptionPath,
+          customFields: result.customFields,
+          transcribedAt: new Date().toISOString(),
+        });
+      }
+    } catch (error) {
+      console.error('Failed to save merged metadata:', error);
+    }
+
+    if (mainWindow) {
+      mainWindow.webContents.send('transcription-progress', { percent: 100, message: 'Merge complete' });
+    }
+
+    notificationService.notifyTranscriptionComplete(finalTitle);
+    return { success: true, data: result, mergedAudioPath, transcriptionPath, mergedFrom: sourceFolders };
+  } catch (error) {
+    console.error('Error merging recordings:', error);
+    const stderr = (error as { stderr?: string } | null)?.stderr;
+    const baseMessage = error instanceof Error ? error.message : String(error);
+    const message = stderr ? `${baseMessage.split('\n')[0]} — ${stderr.trim()}` : baseMessage;
+    notificationService.notifyTranscriptionFailed('Merge failed. Check the app for details.');
     return { success: false, error: message };
   }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, shell, dialog, Menu, globalShortcut, systemPreferences, session, desktopCapturer } from 'electron';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { randomUUID } from 'crypto';
 import * as path from 'path';
 import * as fs from 'fs';
 import { SimpleAudioRecorder } from './simpleAudioRecorder';
@@ -222,6 +223,7 @@ async function checkAndShowReleaseNotes() {
 // concat) write through multiple events in quick succession.
 let recordingsWatcher: fs.FSWatcher | null = null;
 let recordingsWatcherTimer: NodeJS.Timeout | null = null;
+let recordingsWatcherRetry: NodeJS.Timeout | null = null;
 function startRecordingsWatcher(): void {
   if (recordingsWatcher) return;
   const dir = path.join(app.getPath('userData'), 'recordings');
@@ -238,6 +240,19 @@ function startRecordingsWatcher(): void {
     });
     recordingsWatcher.on('error', (err) => {
       console.warn('recordings watcher error:', err);
+    });
+    // fs.watch holds an inode handle. If recordings/ is deleted and recreated
+    // externally, the OS fires 'close' and the watcher silently dies on the
+    // dead inode. Re-arm on close so a manual rm -rf doesn't permanently break
+    // live refresh.
+    recordingsWatcher.on('close', () => {
+      recordingsWatcher = null;
+      if (global.isQuitting) return;
+      if (recordingsWatcherRetry) clearTimeout(recordingsWatcherRetry);
+      recordingsWatcherRetry = setTimeout(() => {
+        recordingsWatcherRetry = null;
+        startRecordingsWatcher();
+      }, 1000);
     });
   } catch (err) {
     console.warn('Failed to start recordings watcher:', err);
@@ -580,6 +595,10 @@ app.on('will-quit', () => {
     clearTimeout(recordingsWatcherTimer);
     recordingsWatcherTimer = null;
   }
+  if (recordingsWatcherRetry) {
+    clearTimeout(recordingsWatcherRetry);
+    recordingsWatcherRetry = null;
+  }
 });
 
 // Helper function to rename audio file with generated title
@@ -743,16 +762,33 @@ ipcMain.handle('export-recording-m4a', async (_, srcPath: string) => {
 // transcription pipeline on the merged file. Originals are left untouched.
 // Resolves source folder names from per-recording metadata so the merged note's
 // `mergedFrom` frontmatter (and "Sources" body section) can reference them.
+//
+// Single-flight: a second click while a merge is running returns
+// `{ code: 'merge-busy' }` rather than racing against the in-flight one for
+// the shared geminiService and the merged-output filename slot.
+let mergeInFlight = false;
 ipcMain.handle('merge-recordings', async (_, opts: { paths: string[]; title?: string }) => {
+  if (mergeInFlight) {
+    return { success: false, code: 'merge-busy', error: 'Another merge is already running. Wait for it to finish.' };
+  }
+  mergeInFlight = true;
+  const sendProgress = (percent: number, message: string) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('transcription-progress', { percent, message });
+    }
+  };
   try {
     const inputPaths = Array.isArray(opts?.paths) ? opts.paths : [];
     if (inputPaths.length < 2) {
       return { success: false, error: 'At least 2 recordings are required to merge' };
     }
 
-    // Containment: every input must resolve inside the recordings directory.
+    // Ensure recordings dir exists before realpath so symlink resolution can't
+    // throw on a fresh install. Containment: every input must then resolve
+    // inside that directory.
     const recordingsDir = path.join(app.getPath('userData'), 'recordings');
-    const resolvedRoot = await fs.promises.realpath(recordingsDir).catch(() => recordingsDir);
+    await fs.promises.mkdir(recordingsDir, { recursive: true });
+    const resolvedRoot = await fs.promises.realpath(recordingsDir);
     const resolvedInputs: string[] = [];
     for (const p of inputPaths) {
       if (typeof p !== 'string' || !p) {
@@ -786,45 +822,48 @@ ipcMain.handle('merge-recordings', async (_, opts: { paths: string[]; title?: st
     const rawTitle = (opts.title && opts.title.trim()) || 'Merged Meeting';
     const safeTitle = sanitizeForPath(rawTitle) || 'Merged Meeting';
     // Always emit webm/opus -- matches MediaRecorder native output and survives
-    // the stream-copy fast path when all inputs are also webm.
+    // the stream-copy fast path when all inputs are also webm. UUID suffix
+    // avoids collisions when two merges with the same title start in the same
+    // second (formatTimestamp is second-granularity).
     const mergedExt = extensionForMimeType('audio/webm');
-    const mergedAudioPath = path.join(recordingsDir, `${safeTitle}_${formatTimestamp()}.${mergedExt}`);
+    const mergedAudioPath = path.join(
+      recordingsDir,
+      `${safeTitle}_${formatTimestamp()}_${randomUUID().slice(0, 8)}.${mergedExt}`,
+    );
 
-    if (mainWindow) {
-      mainWindow.webContents.send('transcription-progress', { percent: 5, message: 'Merging audio files...' });
-    }
-
-    await fs.promises.mkdir(recordingsDir, { recursive: true });
+    sendProgress(5, 'Merging audio files...');
 
     // Run the metadata lookup concurrently with the ffmpeg concat -- they're
     // independent and concat is the long pole, so the metadata reads are free.
-    // Recordings without a transcription contribute nothing to mergedFrom.
+    // Recordings without a transcription contribute nothing to mergedFrom; we
+    // also drop entries whose transcription folder no longer exists on disk
+    // so the merged note's Sources section never references stale ghosts.
     const [, metas] = await Promise.all([
       concatAudioFiles({ ffmpegPath, inputPaths: resolvedInputs, outputPath: mergedAudioPath }),
       Promise.all(resolvedInputs.map((p) => metadataService.getMetadata(p))),
     ]);
     const sourceFolders = metas
       .filter((m): m is NonNullable<typeof m> => !!m?.transcriptionPath)
+      .filter((m) => fs.existsSync(m.transcriptionPath!))
       .map((m) => path.basename(m.transcriptionPath!));
 
-    if (mainWindow) {
-      mainWindow.webContents.send('transcription-progress', { percent: 15, message: 'Transcribing merged recording...' });
-    }
+    sendProgress(15, 'Transcribing merged recording...');
 
+    // Compress the transcription progress into 15-95% to leave room for the
+    // concat phase at the start and the save phase at the end.
     const progressCallback = (percent: number, message: string) => {
-      if (mainWindow) {
-        // Compress the transcription progress into 15-95% to leave room for the
-        // concat phase at the start and the save phase at the end.
-        const adjusted = 15 + Math.round(percent * 0.8);
-        mainWindow.webContents.send('transcription-progress', { percent: adjusted, message });
-      }
+      sendProgress(15 + Math.round(percent * 0.8), message);
     };
 
     const summaryPrompt = configService.getSummaryPrompt();
     const result = await geminiService.transcribeAudio(mergedAudioPath, progressCallback, summaryPrompt);
 
-    const finalTitle = result.suggestedTitle || rawTitle;
-    let transcriptionPath: string | undefined;
+    // User-supplied title takes precedence; only fall back to Gemini's
+    // suggestion when the user didn't provide one. Gemini almost always
+    // returns a suggestedTitle, so the previous order silently overrode the
+    // user's --title flag / dialog input.
+    const finalTitle = (opts.title?.trim()) || result.suggestedTitle || rawTitle;
+    let transcriptionPath: string;
     try {
       transcriptionPath = saveTranscription({
         title: finalTitle,
@@ -835,25 +874,26 @@ ipcMain.handle('merge-recordings', async (_, opts: { paths: string[]; title?: st
       });
     } catch (error) {
       console.error('Failed to save merged transcription files:', error);
+      const message = error instanceof Error ? error.message : String(error);
+      notificationService.notifyTranscriptionFailed('Merge failed: could not save the transcription.');
+      return { success: false, error: `Failed to save merged transcription: ${message}` };
     }
 
     try {
-      if (transcriptionPath) {
-        await metadataService.saveMetadata(mergedAudioPath, {
-          title: finalTitle,
-          suggestedTitle: result.suggestedTitle,
-          transcriptionPath,
-          customFields: result.customFields,
-          transcribedAt: new Date().toISOString(),
-        });
-      }
+      await metadataService.saveMetadata(mergedAudioPath, {
+        title: finalTitle,
+        suggestedTitle: result.suggestedTitle,
+        transcriptionPath,
+        customFields: result.customFields,
+        transcribedAt: new Date().toISOString(),
+      });
     } catch (error) {
+      // Metadata write is best-effort -- the transcription folder is the
+      // source of truth. Log and continue rather than fail the merge.
       console.error('Failed to save merged metadata:', error);
     }
 
-    if (mainWindow) {
-      mainWindow.webContents.send('transcription-progress', { percent: 100, message: 'Merge complete' });
-    }
+    sendProgress(100, 'Merge complete');
 
     notificationService.notifyTranscriptionComplete(finalTitle);
     return { success: true, data: result, mergedAudioPath, transcriptionPath, mergedFrom: sourceFolders };
@@ -864,6 +904,8 @@ ipcMain.handle('merge-recordings', async (_, opts: { paths: string[]; title?: st
     const message = stderr ? `${baseMessage.split('\n')[0]} — ${stderr.trim()}` : baseMessage;
     notificationService.notifyTranscriptionFailed('Merge failed. Check the app for details.');
     return { success: false, error: message };
+  } finally {
+    mergeInFlight = false;
   }
 });
 

--- a/src/outputService.test.ts
+++ b/src/outputService.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  saveTranscription,
+  readTranscription,
+  parseFrontmatter,
+  formatSummary,
+  sanitizeForPath,
+} from './outputService';
+import type { TranscriptionResult } from './geminiService';
+import { makeTempDir, rmDir } from './test-helpers';
+
+const tmpDirs: string[] = [];
+
+function makeTmpDataPath(): string {
+  const dir = makeTempDir('output');
+  tmpDirs.push(dir);
+  return dir;
+}
+
+after(() => {
+  for (const dir of tmpDirs) rmDir(dir);
+});
+
+const baseResult: TranscriptionResult = {
+  transcript: 'Speaker A: hello.\nSpeaker B: hi.',
+  summary: 'A short greeting.',
+  keyPoints: ['Greeting exchanged'],
+  actionItems: ['Schedule follow-up'],
+  emoji: '👋',
+  suggestedTitle: 'Greeting Sync',
+};
+
+describe('saveTranscription with mergedFrom', () => {
+  it('round-trips mergedFrom through frontmatter', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Combined Meeting',
+      result: baseResult,
+      audioFilePath: '/tmp/merged.webm',
+      dataPath,
+      mergedFrom: ['Part_One_20260101_120000', 'Part_Two_20260101_130000'],
+    });
+
+    const data = await readTranscription(folderPath);
+    assert.ok(data, 'readTranscription returned null');
+    assert.deepEqual(data!.mergedFrom, [
+      'Part_One_20260101_120000',
+      'Part_Two_20260101_130000',
+    ]);
+    assert.equal(data!.summary, 'A short greeting.');
+    assert.deepEqual(data!.keyPoints, ['Greeting exchanged']);
+  });
+
+  it('omits mergedFrom from frontmatter when absent', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Solo Meeting',
+      result: baseResult,
+      dataPath,
+    });
+
+    const summaryRaw = fs.readFileSync(path.join(folderPath, 'summary.md'), 'utf-8');
+    const { meta } = parseFrontmatter(summaryRaw);
+    assert.equal(meta.mergedFrom, undefined);
+
+    const data = await readTranscription(folderPath);
+    assert.equal(data!.mergedFrom, undefined);
+  });
+
+  it('renders a Sources section in the markdown body when mergedFrom is set', () => {
+    const body = formatSummary(baseResult, 'Combined Meeting', [
+      'Part_One_20260101_120000',
+      'Part_Two_20260101_130000',
+    ]);
+    assert.match(body, /## Sources/);
+    assert.match(body, /Merged from 2 recordings/);
+    assert.match(body, /- Part_One_20260101_120000/);
+    assert.match(body, /- Part_Two_20260101_130000/);
+  });
+
+  it('omits the Sources section when mergedFrom is empty', () => {
+    const body = formatSummary(baseResult, 'Solo Meeting');
+    assert.doesNotMatch(body, /## Sources/);
+  });
+});
+
+describe('sanitizeForPath', () => {
+  it('replaces filesystem-hostile characters', () => {
+    assert.equal(sanitizeForPath('LG : meeting / part 1?'), 'LG _ meeting _ part 1_');
+  });
+
+  it('collapses repeated whitespace', () => {
+    assert.equal(sanitizeForPath('hello    world'), 'hello world');
+  });
+});

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -22,9 +22,18 @@ export function camelToLabel(key: string): string {
   return key.replace(/([A-Z])/g, ' $1').replace(/^./, (s: string) => s.toUpperCase()).trim();
 }
 
-export function formatSummary(result: TranscriptionResult, title: string): string {
+export function formatSummary(result: TranscriptionResult, title: string, mergedFrom?: string[]): string {
   const lines: string[] = [];
   lines.push(`# ${title}\n`);
+
+  if (mergedFrom?.length) {
+    lines.push(`## Sources\n`);
+    lines.push(`Merged from ${mergedFrom.length} recording${mergedFrom.length === 1 ? '' : 's'}:\n`);
+    for (const src of mergedFrom) {
+      lines.push(`- ${src}`);
+    }
+    lines.push('');
+  }
 
   if (result.summary) {
     lines.push(`## Summary\n`);
@@ -85,6 +94,7 @@ interface SummaryFrontmatter {
   audioFilePath?: string;
   transcribedAt: string;
   emoji?: string;
+  mergedFrom?: string[];
 }
 
 function buildFrontmatter(meta: SummaryFrontmatter): string {
@@ -112,6 +122,10 @@ function buildFrontmatter(meta: SummaryFrontmatter): string {
   }
   if (meta.emoji) {
     lines.push(`emoji: ${yamlQuote(meta.emoji)}`);
+  }
+  if (meta.mergedFrom?.length) {
+    lines.push('mergedFrom:');
+    for (const src of meta.mergedFrom) lines.push(`  - ${yamlQuote(src)}`);
   }
   lines.push('---');
   return lines.join('\n');
@@ -197,6 +211,7 @@ export interface SaveTranscriptionOptions {
   audioFilePath?: string;
   outputDir?: string; // override parent dir (for CLI --output)
   dataPath: string;   // app data path (default location)
+  mergedFrom?: string[]; // source folder names when this note was created by merging others
 }
 
 /**
@@ -223,8 +238,9 @@ export function saveTranscription(opts: SaveTranscriptionOptions): string {
     audioFilePath: opts.audioFilePath,
     transcribedAt,
     emoji: opts.result.emoji,
+    mergedFrom: opts.mergedFrom,
   });
-  const summaryBody = formatSummary(opts.result, opts.title);
+  const summaryBody = formatSummary(opts.result, opts.title, opts.mergedFrom);
   fs.writeFileSync(path.join(folderPath, 'summary.md'), `${frontmatter}\n\n${summaryBody}`, 'utf-8');
 
   // transcript.md
@@ -318,6 +334,7 @@ export interface ReadTranscriptionResult {
   audioFilePath?: string;
   transcribedAt?: string;
   emoji?: string;
+  mergedFrom?: string[];
 }
 
 /**
@@ -354,6 +371,7 @@ export async function readTranscription(folderPath: string): Promise<ReadTranscr
       audioFilePath: meta.audioFilePath as string | undefined,
       transcribedAt: meta.transcribedAt as string | undefined,
       emoji: meta.emoji as string | undefined,
+      mergedFrom: meta.mergedFrom as string[] | undefined,
     };
   } catch {
     return null;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -52,6 +52,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   mergeRecordings: (opts: { paths: string[]; title?: string }) =>
     ipcRenderer.invoke('merge-recordings', opts),
 
+  // Pushed by main when the recordings directory changes externally
+  // (CLI run, manual file ops). Renderer should re-fetch the list.
+  onRecordingsChanged: (callback: () => void) => {
+    ipcRenderer.on('recordings-changed', () => callback());
+  },
+
   // System settings
   openMicrophoneSettings: () => ipcRenderer.invoke('open-microphone-settings'),
   openScreenRecordingSettings: () => ipcRenderer.invoke('open-screen-recording-settings'),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -48,6 +48,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Recording export
   exportRecordingM4A: (srcPath: string) => ipcRenderer.invoke('export-recording-m4a', srcPath),
 
+  // Merge multiple recordings into a single re-transcribed note
+  mergeRecordings: (opts: { paths: string[]; title?: string }) =>
+    ipcRenderer.invoke('merge-recordings', opts),
+
   // System settings
   openMicrophoneSettings: () => ipcRenderer.invoke('open-microphone-settings'),
   openScreenRecordingSettings: () => ipcRenderer.invoke('open-screen-recording-settings'),

--- a/src/services/audioConcatService.test.ts
+++ b/src/services/audioConcatService.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { concatAudioFiles } from './audioConcatService';
+import {
+  findFfmpegSync,
+  ffprobeFor,
+  makeTempDir,
+  rmDir,
+  makeOpusWebm,
+  makeMp3,
+  getDurationSeconds,
+} from '../test-helpers';
+
+const ffmpegPath = findFfmpegSync();
+const ffprobePath = ffmpegPath ? ffprobeFor(ffmpegPath) : null;
+
+let workDir: string;
+
+before(() => {
+  workDir = makeTempDir('concat');
+});
+
+after(() => {
+  rmDir(workDir);
+});
+
+describe('concatAudioFiles', { skip: !ffmpegPath ? 'ffmpeg not installed' : undefined }, () => {
+  it('concatenates two same-format webm/opus files via stream-copy fast path', async () => {
+    const a = await makeOpusWebm(ffmpegPath!, workDir, 'a.webm', 440);
+    const b = await makeOpusWebm(ffmpegPath!, workDir, 'b.webm', 880);
+    const out = path.join(workDir, 'merged_copy.webm');
+
+    await concatAudioFiles({ ffmpegPath: ffmpegPath!, inputPaths: [a, b], outputPath: out });
+
+    assert.ok(fs.existsSync(out), 'output file should exist');
+    const duration = await getDurationSeconds(ffprobePath!, out);
+    assert.ok(duration > 1.8 && duration < 2.2, `expected ~2s output, got ${duration}s`);
+  });
+
+  it('falls back to filter path when inputs have mismatched extensions', async () => {
+    const opus = await makeOpusWebm(ffmpegPath!, workDir, 'opus.webm', 440);
+    const mp3 = await makeMp3(ffmpegPath!, workDir, 'lame.mp3', 880);
+    const out = path.join(workDir, 'merged_filter.webm');
+
+    await concatAudioFiles({ ffmpegPath: ffmpegPath!, inputPaths: [opus, mp3], outputPath: out });
+
+    assert.ok(fs.existsSync(out), 'output file should exist');
+    const duration = await getDurationSeconds(ffprobePath!, out);
+    assert.ok(duration > 1.8 && duration < 2.2, `expected ~2s output, got ${duration}s`);
+  });
+
+  it('rejects when fewer than 2 inputs are provided', async () => {
+    const a = await makeOpusWebm(ffmpegPath!, workDir, 'solo.webm', 440);
+    await assert.rejects(
+      () => concatAudioFiles({ ffmpegPath: ffmpegPath!, inputPaths: [a], outputPath: path.join(workDir, 'never.webm') }),
+      /at least 2 input files/i,
+    );
+  });
+
+  it('rejects when an input file is missing', async () => {
+    const a = await makeOpusWebm(ffmpegPath!, workDir, 'exists.webm', 440);
+    const missing = path.join(workDir, 'does-not-exist.webm');
+    await assert.rejects(
+      () => concatAudioFiles({ ffmpegPath: ffmpegPath!, inputPaths: [a, missing], outputPath: path.join(workDir, 'never.webm') }),
+      /Input file not found/,
+    );
+  });
+
+  it('handles input paths that contain a single quote', async () => {
+    // ffmpeg's concat demuxer manifest uses single-quoted paths; a literal "'"
+    // in the filename must round-trip via the "'\\''" escape sequence.
+    const tricky = await makeOpusWebm(ffmpegPath!, workDir, "it's-fine.webm", 440);
+    const plain = await makeOpusWebm(ffmpegPath!, workDir, 'plain.webm', 880);
+    const out = path.join(workDir, 'merged_quote.webm');
+
+    await concatAudioFiles({ ffmpegPath: ffmpegPath!, inputPaths: [tricky, plain], outputPath: out });
+
+    assert.ok(fs.existsSync(out), 'output file should exist');
+    const duration = await getDurationSeconds(ffprobePath!, out);
+    assert.ok(duration > 1.8 && duration < 2.2, `expected ~2s output, got ${duration}s`);
+  });
+
+  it('cleans up the temp manifest file even when ffmpeg fails', async () => {
+    // Count only manifest files (prefix listener-concat-<pid>-) so the workDir
+    // (prefix listener-concat-test-) doesn't pollute the count.
+    const manifestPrefix = `listener-concat-${process.pid}-`;
+    const before = fs.readdirSync(os.tmpdir()).filter((n) => n.startsWith(manifestPrefix)).length;
+    const a = await makeOpusWebm(ffmpegPath!, workDir, 'keep.webm', 440);
+    const missing = path.join(workDir, 'nope.webm');
+    await assert.rejects(() =>
+      concatAudioFiles({ ffmpegPath: ffmpegPath!, inputPaths: [a, missing], outputPath: path.join(workDir, 'never.webm') })
+    );
+    const after = fs.readdirSync(os.tmpdir()).filter((n) => n.startsWith(manifestPrefix)).length;
+    assert.equal(after, before, 'manifest file should be cleaned up after failure');
+  });
+});

--- a/src/services/audioConcatService.ts
+++ b/src/services/audioConcatService.ts
@@ -1,0 +1,91 @@
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export interface ConcatOptions {
+  ffmpegPath: string;
+  inputPaths: string[];
+  outputPath: string;
+}
+
+/**
+ * Concatenate audio files via ffmpeg.
+ *
+ * When every input shares the same extension we attempt the concat *demuxer*
+ * with `-c copy` -- instant, no quality loss, and the typical Listener case
+ * (two parts of an interrupted MediaRecorder session). Otherwise we fall
+ * straight through to the concat *filter*, which decodes each input and
+ * re-encodes the output -- slower but format-agnostic.
+ *
+ * The reason we don't always start with the demuxer: with mismatched codecs
+ * the demuxer returns exit 0 and writes a file with corrupted timestamps
+ * (observed: 1s + 1s inputs produced a 28616s output). Silent corruption is
+ * worse than always-correct + slightly slower.
+ */
+export async function concatAudioFiles(opts: ConcatOptions): Promise<void> {
+  if (opts.inputPaths.length < 2) {
+    throw new Error('concatAudioFiles requires at least 2 input files');
+  }
+
+  for (const p of opts.inputPaths) {
+    if (!fs.existsSync(p)) {
+      throw new Error(`Input file not found: ${p}`);
+    }
+  }
+
+  const firstExt = path.extname(opts.inputPaths[0]).toLowerCase();
+  const allSameExt = opts.inputPaths.every((p) => path.extname(p).toLowerCase() === firstExt);
+
+  if (allSameExt) {
+    const manifestPath = path.join(os.tmpdir(), `listener-concat-${process.pid}-${Date.now()}.txt`);
+    // Single quotes inside paths must be escaped as `'\''` for the concat
+    // demuxer's manifest format.
+    const manifest = opts.inputPaths
+      .map((p) => `file '${p.replace(/'/g, "'\\''")}'`)
+      .join('\n') + '\n';
+    await fs.promises.writeFile(manifestPath, manifest, 'utf-8');
+
+    try {
+      await execFileAsync(opts.ffmpegPath, [
+        '-y', '-loglevel', 'error',
+        '-f', 'concat', '-safe', '0',
+        '-i', manifestPath,
+        '-c', 'copy',
+        opts.outputPath,
+      ]);
+      return;
+    } catch {
+      await fs.promises.unlink(opts.outputPath).catch(() => {});
+      // Fall through to the filter path below.
+    } finally {
+      await fs.promises.unlink(manifestPath).catch(() => {});
+    }
+  }
+
+  // Concat filter: works for any combination of inputs.
+  const filterArgs: string[] = ['-y', '-loglevel', 'error'];
+  for (const p of opts.inputPaths) {
+    filterArgs.push('-i', p);
+  }
+  const filterExpr =
+    opts.inputPaths.map((_, i) => `[${i}:a]`).join('') +
+    `concat=n=${opts.inputPaths.length}:v=0:a=1[out]`;
+  filterArgs.push(
+    '-filter_complex', filterExpr,
+    '-map', '[out]',
+    '-c:a', 'libopus', '-b:a', '64k',
+    opts.outputPath,
+  );
+
+  try {
+    await execFileAsync(opts.ffmpegPath, filterArgs);
+  } catch (err) {
+    const stderr = (err as { stderr?: string })?.stderr ?? '';
+    const base = err instanceof Error ? err.message : String(err);
+    throw new Error(stderr ? `${base.split('\n')[0]} — ${stderr.trim()}` : base);
+  }
+}

--- a/src/services/audioConcatService.ts
+++ b/src/services/audioConcatService.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'child_process';
+import { randomUUID } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -41,7 +42,7 @@ export async function concatAudioFiles(opts: ConcatOptions): Promise<void> {
   const allSameExt = opts.inputPaths.every((p) => path.extname(p).toLowerCase() === firstExt);
 
   if (allSameExt) {
-    const manifestPath = path.join(os.tmpdir(), `listener-concat-${process.pid}-${Date.now()}.txt`);
+    const manifestPath = path.join(os.tmpdir(), `listener-concat-${process.pid}-${randomUUID()}.txt`);
     // Single quotes inside paths must be escaped as `'\''` for the concat
     // demuxer's manifest format.
     const manifest = opts.inputPaths

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,0 +1,110 @@
+// Shared test utilities. Conventions captured here so individual test files
+// stay focused on assertions, not setup boilerplate.
+//
+// - All temp paths live under os.tmpdir() with a prefix that matches a test --
+//   never the real getDataPath().
+// - findFfmpegSync runs at module load so callers can use it in
+//   `describe({ skip })`, where async detection is too late.
+// - Audio fixtures are synthesized via ffmpeg's lavfi source -- no binary
+//   fixtures committed to the repo.
+
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+
+export const execFileAsync = promisify(execFile);
+
+/**
+ * Locate ffmpeg synchronously by checking common install paths. Returns null
+ * when not found so tests can skip gracefully.
+ *
+ * Sync (not async) because `describe('...', { skip: !ffmpegPath, ... })`
+ * evaluates options at file-load time, before any `before()` hook runs.
+ */
+export function findFfmpegSync(): string | null {
+  const candidates = [
+    '/opt/homebrew/opt/ffmpeg@7/bin/ffmpeg',
+    '/opt/homebrew/bin/ffmpeg',
+    '/usr/local/bin/ffmpeg',
+    '/usr/bin/ffmpeg',
+  ];
+  for (const c of candidates) {
+    try {
+      fs.accessSync(c, fs.constants.X_OK);
+      return c;
+    } catch {
+      /* continue */
+    }
+  }
+  return null;
+}
+
+/** Derive the sibling ffprobe path from an ffmpeg path. */
+export function ffprobeFor(ffmpegPath: string): string {
+  return ffmpegPath.replace(/ffmpeg(\.exe)?$/, (_, ext) => `ffprobe${ext ?? ''}`);
+}
+
+/**
+ * Create a unique temp directory with the given suffix prefix. Caller is
+ * responsible for cleanup -- pair with `rm -rf` in `after()`.
+ */
+export function makeTempDir(suffix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `listener-${suffix}-test-`));
+}
+
+/** Recursively delete a directory, ignoring missing-path errors. */
+export function rmDir(dir: string): void {
+  if (dir) fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/**
+ * Synthesize a 1-second (default) opus-in-webm sine-wave file via ffmpeg's
+ * lavfi source. Returns the absolute path of the created file.
+ */
+export async function makeOpusWebm(
+  ffmpegPath: string,
+  workDir: string,
+  name: string,
+  freq: number,
+  duration = 1,
+): Promise<string> {
+  const out = path.join(workDir, name);
+  await execFileAsync(ffmpegPath, [
+    '-y', '-loglevel', 'error',
+    '-f', 'lavfi', '-i', `sine=frequency=${freq}:duration=${duration}:sample_rate=48000`,
+    '-c:a', 'libopus', '-b:a', '64k',
+    out,
+  ]);
+  return out;
+}
+
+/** Same idea as makeOpusWebm but produces an mp3 -- used for mixed-format tests. */
+export async function makeMp3(
+  ffmpegPath: string,
+  workDir: string,
+  name: string,
+  freq: number,
+  duration = 1,
+): Promise<string> {
+  const out = path.join(workDir, name);
+  await execFileAsync(ffmpegPath, [
+    '-y', '-loglevel', 'error',
+    '-f', 'lavfi', '-i', `sine=frequency=${freq}:duration=${duration}`,
+    '-c:a', 'libmp3lame', '-b:a', '64k',
+    out,
+  ]);
+  return out;
+}
+
+/** Read a media file's duration in seconds via ffprobe. */
+export async function getDurationSeconds(ffprobePath: string, p: string): Promise<number> {
+  const { stdout } = await execFileAsync(ffprobePath, [
+    '-v', 'error',
+    '-show_entries', 'format=duration',
+    '-of', 'default=noprint_wrappers=1:nokey=1',
+    p,
+  ]);
+  return parseFloat(stdout.trim());
+}

--- a/styles.css
+++ b/styles.css
@@ -1665,3 +1665,154 @@ h1 {
   min-height: 260px;
   max-height: none;
 }
+
+/* Merge Recordings dialog */
+.merge-modal-content {
+  max-width: 560px;
+  width: 92%;
+  max-height: 85vh;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.merge-modal-content .modal-header {
+  border-bottom: 1px solid #ecf0f1;
+}
+
+.merge-hint {
+  margin: 16px 24px 8px;
+  color: #7f8c8d;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.merge-title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 24px 12px;
+}
+
+.merge-title-row label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #2c3e50;
+  white-space: nowrap;
+}
+
+.merge-title-row input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #d5dbdb;
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+.merge-title-row input:focus {
+  outline: none;
+  border-color: #3498db;
+}
+
+.merge-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 12px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  border-top: 1px solid #ecf0f1;
+  border-bottom: 1px solid #ecf0f1;
+}
+
+.merge-list li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.merge-list li:hover {
+  background-color: #f5f7fa;
+}
+
+.merge-list li.selected {
+  background-color: #ebf5fb;
+}
+
+.merge-list input[type="checkbox"] {
+  margin: 0;
+  flex: 0 0 auto;
+  cursor: pointer;
+}
+
+.merge-list-item-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.merge-list-item-title {
+  font-size: 14px;
+  color: #2c3e50;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.merge-list-item-meta {
+  font-size: 12px;
+  color: #95a5a6;
+  margin-top: 2px;
+}
+
+.merge-list-order {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background-color: #3498db;
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.merge-list li:not(.selected) .merge-list-order {
+  display: none;
+}
+
+.merge-list-empty {
+  padding: 24px 12px;
+  color: #95a5a6;
+  text-align: center;
+  font-size: 13px;
+}
+
+.merge-status {
+  margin: 12px 24px 0;
+  font-size: 13px;
+  color: #7f8c8d;
+  min-height: 18px;
+}
+
+.merge-status.error {
+  color: #e74c3c;
+}
+
+.merge-modal-content .modal-buttons {
+  margin: 0;
+  padding: 14px 24px;
+  border-top: 1px solid #ecf0f1;
+  background-color: #fafbfc;
+}
+
+.merge-modal-content .save-button:disabled {
+  background-color: #bdc3c7;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
Resolves #95.

## Scope at a glance

This PR is **larger than just the merge feature**. Sections below are clearly delineated so reviewers can focus.

| Section | Lines | Status |
|---|---|---|
| **A. Issue #95 core** | ~760 | Required |
| **B. fs.watch live list refresh** | ~55 | Separable; bundled |
| **C. Test infrastructure** | ~250 | Bundled (enables CLI integration tests) |
| **D. Review feedback fixes** | ~100 | Address bot + manual review |

If reviewing in pieces is preferred, sections B + C could be split into follow-up PRs. They're cohesive on their own and the merge feature works without them.

---

## A. Issue #95 core — Merge interrupted-recording parts

When a meeting recording is interrupted and saves two parts as separate notes, users can now select 2+ recordings, concatenate the audio, and re-transcribe end-to-end as a single note. Originals are preserved; merged note frontmatter records `mergedFrom` and the body shows a Sources section.

- ffmpeg concat (demuxer + `-c copy` fast path for same-extension inputs, concat filter fallback for mismatched) → existing `transcribeAudio` pipeline → `saveTranscription` with `mergedFrom: [folder1, folder2]`
- Same-extension up-front check avoids a silent-corruption bug where the demuxer returns exit 0 with garbage timestamps for mismatched-codec inputs (caught by the unit test — `-c copy` doesn't throw, it produces a 28616s output for 1s+1s inputs)
- New CLI subcommand `listener merge <ref1> <ref2> [...] [--title <t>]`
- Side fix: pre-existing npm whitelist bug — `audioFormats.js` was missing from `package.json` `files` even though `geminiService` imports it

Files: `src/services/audioConcatService.ts`, `src/main.ts` (merge IPC handler), `renderer.js` (Merge button + dialog), `index.html`, `styles.css`, `src/outputService.ts` (`mergedFrom` field), `src/cli.ts`, `package.json` (whitelist).

## B. fs.watch live list refresh

Watches `recordings/` so an external `listener` CLI run or manual file op shows up in the GUI list without a manual reload. Independent of #95 — could land separately.

Files: `src/main.ts` (`startRecordingsWatcher`), `src/preload.ts`, `renderer.js`.

## C. Test infrastructure

Three tiers, codified in [CLAUDE.md](CLAUDE.md):

1. **Service-layer unit tests** — `audioConcatService.test.ts`, `outputService.test.ts`. Real ffmpeg with synthetic `lavfi` sine-wave fixtures.
2. **adb-style CLI integration** — `cli.test.ts` spawns the compiled CLI as a subprocess with `LISTENER_DATA_PATH` (sandboxed temp dir) + `LISTENER_TEST_MODE` (Gemini stub) env vars, both gated on `NODE_ENV=test` to keep them out of production binaries.
3. **Interactive verification** — manual smoke test against real Gemini, model monitors stdout + filesystem diffs while user drives. Caught a CSS visibility bug on the Merge button and the empty-`mergedFrom` edge case.

Files: `src/test-helpers.ts`, `src/cli.test.ts`, `src/dataPath.ts` (env-var hook), `src/geminiService.ts` (env-var hook), `CLAUDE.md`.

## D. Review feedback fixes (commit `28223a1`)

Critical:
- Gate `LISTENER_TEST_MODE` / `LISTENER_DATA_PATH` on `NODE_ENV=test` so a stray env var in a packaged user's shell rc can't stub their transcripts or redirect their data path
- Re-arm fs.watch on `'close'` so an external `rm -rf` of the recordings dir doesn't permanently break live refresh
- Token-guard `loadRecordings` against stale snapshot overwrites (per-item async metadata reads racing across triggers)
- Surface `saveTranscription` failures as `{ success: false }` instead of silently logging while telling the renderer "Merge complete"

Major:
- User-provided merge title now wins over Gemini's `suggestedTitle` (CLI `--title` and GUI dialog input were being silently overridden)
- Single-flight mutex on `merge-recordings` so a double-click can't race two concurrent merges through the same `geminiService` and output filename slot
- UUID suffix on merged audio filename + concat manifest path eliminates the second-granularity collision window
- mkdir before realpath; drop `mergedFrom` entries whose transcription folder no longer exists

Plus the two Gemini-bot inline suggestions (manifest UUID, mkdir order).

---

## Test plan

- [x] `pnpm test` passes (59 tests across 13 suites)
- [x] Real Gemini E2E via GUI: clicked Merge, dialog opened, picked second recording, ordering badges shown, confirm triggered concat + transcription, new folder created with summary + key points
- [x] fs.watch verified live: `cp` adds row within 1s; `rm` removes it
- [ ] Reviewer: `gh pr checkout 96` + `pnpm start`, click Merge on any recording row, verify dialog opens and confirmation produces a note
- [ ] Reviewer: optional CLI smoke — `listener merge <ref1> <ref2>` (uses real Gemini)

🤖 Generated with [Claude Code](https://claude.com/claude-code)