### PR TITLE
Fix missing static assets in packaged builds + add asar verification CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,9 @@ jobs:
 
       - name: Test
         run: pnpm run test
+
+      - name: Package app (no signing) for asar verification
+        run: pnpm exec electron-builder --linux dir --publish never
+
+      - name: Verify packaged asar contents
+        run: node scripts/verify-asar-contents.js

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "homepage": "https://github.com/asleep-ai/listener-ai#readme",
   "devDependencies": {
+    "@electron/asar": "^4.2.0",
     "@electron/notarize": "^3.0.1",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^24.0.12",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "version:bump": "node scripts/bump-version.js",
     "release": "pnpm run version:bump && pnpm run dist:all",
     "cli": "pnpm run build && node dist/cli.js",
+    "verify:package": "pnpm run build && electron-builder --linux dir --publish never && node scripts/verify-asar-contents.js",
     "prepublishOnly": "tsc",
     "postinstall": "node -e \"require.resolve('electron')\" 2>/dev/null && electron-builder install-app-deps && (cd node_modules/electron && node install.js || cd node_modules/.pnpm/electron*/node_modules/electron && node install.js || true) || true"
   },
@@ -87,22 +88,13 @@
       "index.html",
       "styles.css",
       "renderer.js",
+      "pcmStreamProcessor.js",
+      "js/**/*",
       "package.json",
       "assets/icon.png",
       "!node_modules/ffmpeg-static/**/*",
-      "!scripts/**/*",
-      "!release/**/*",
-      "!src/**/*",
-      "!.git/**/*",
-      "!**/*.ts",
       "!**/*.test.js",
-      "!**/*.map",
-      "!.gitignore",
-      "!.eslintrc",
-      "!README.md",
-      "!CLAUDE.md",
-      "!tsconfig.json",
-      "!build/**/*"
+      "!**/*.map"
     ],
     "asarUnpack": [
       "node_modules/audiotee/bin/**"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,14 +23,10 @@ importers:
       marked:
         specifier: ^15.0.0
         version: 15.0.12
-    optionalDependencies:
-      '@notionhq/client':
-        specifier: ^4.0.0
-        version: 4.0.1
-      electron-updater:
-        specifier: ^6.6.2
-        version: 6.6.2
     devDependencies:
+      '@electron/asar':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@electron/notarize':
         specifier: ^3.0.1
         version: 3.0.1
@@ -55,6 +51,13 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+    optionalDependencies:
+      '@notionhq/client':
+        specifier: ^4.0.0
+        version: 4.0.1
+      electron-updater:
+        specifier: ^6.6.2
+        version: 6.6.2
 
 packages:
 
@@ -68,6 +71,11 @@ packages:
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
     engines: {node: '>=10.12.0'}
+    hasBin: true
+
+  '@electron/asar@4.2.0':
+    resolution: {integrity: sha512-npW1NW5yy8EB9XY/vEw9sUdgmq0sJEhmSBb6bqyFOAw1CSkrhvAvO6QWlW8CdIMo8VN1lkdF345l/MeW0LrY0Q==}
+    engines: {node: '>=22.12.0'}
     hasBin: true
 
   '@electron/fuses@1.8.0':
@@ -398,6 +406,10 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
@@ -689,6 +701,10 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -898,6 +914,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -1079,6 +1099,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
@@ -1457,6 +1481,12 @@ snapshots:
       commander: 5.1.0
       glob: 7.2.3
       minimatch: 3.1.5
+
+  '@electron/asar@4.2.0':
+    dependencies:
+      commander: 13.1.0
+      glob: 13.0.6
+      minimatch: 10.2.4
 
   '@electron/fuses@1.8.0':
     dependencies:
@@ -1925,6 +1955,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@13.1.0: {}
+
   commander@5.1.0: {}
 
   commander@9.5.0:
@@ -2301,6 +2333,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -2530,6 +2568,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.3.5: {}
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -2711,6 +2751,11 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
       minipass: 7.1.3
 
   pe-library@0.4.1: {}

--- a/scripts/verify-asar-contents.js
+++ b/scripts/verify-asar-contents.js
@@ -8,9 +8,9 @@
 // module loaded via `addModule('./foo.js')`) is referenced at runtime but
 // silently omitted from the packaged build.
 
-const { execSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const asar = require('@electron/asar');
 
 function findAsar(root) {
   if (!fs.existsSync(root)) return null;
@@ -33,52 +33,81 @@ if (!asarPath) {
 }
 
 const asarFiles = new Set(
-  execSync(`npx --yes @electron/asar list "${asarPath}"`, { encoding: 'utf8' })
-    .split('\n')
-    .map((s) => s.replace(/^\//, '').trim())
+  asar
+    .listPackage(asarPath)
+    .map((s) => s.replace(/^[\\/]+/, '').replace(/\\/g, '/').trim())
     .filter(Boolean)
 );
 
+// Strip JS line/block comments and HTML comments so commented-out code does
+// not produce false positives. Conservative: only strips `//` comments that
+// start at line beginning (after whitespace) so URLs like `https://...` in
+// string literals are not corrupted.
+function stripJsComments(text) {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+}
+function stripHtmlComments(text) {
+  return text.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+function isExternalRef(ref) {
+  return /^[a-z]+:/i.test(ref) || ref.startsWith('//');
+}
+
 const errors = [];
 
-// Renderer-side: paths are relative to the loading document, which sits at the
-// asar root (index.html, renderer.js are emitted at /).
+// Renderer-side: paths are relative to the loading document, which sits at
+// the asar root (index.html, renderer.js are emitted at /).
 const rendererChecks = [
-  ['renderer.js', /audioWorklet\.addModule\(\s*['"`]([^'"`]+)['"`]/g, 'AudioWorklet.addModule'],
-  ['renderer.js', /(?:fetch|new\s+Worker)\(\s*['"`](\.\/[^'"`]+)['"`]/g, 'fetch / Worker'],
-  ['index.html', /<script[^>]+src=['"]([^'"]+)['"]/g, '<script src>'],
-  ['index.html', /<link[^>]+href=['"]([^'"]+)['"]/g, '<link href>'],
+  ['renderer.js', /audioWorklet\.addModule\(\s*['"`]([^'"`]+)['"`]/g, 'AudioWorklet.addModule', 'js'],
+  ['renderer.js', /(?:fetch|new\s+Worker)\(\s*['"`]([^'"`]+)['"`]/g, 'fetch / Worker', 'js'],
+  ['index.html', /<script[^>]+src=['"]([^'"]+)['"]/g, '<script src>', 'html'],
+  ['index.html', /<link[^>]+href=['"]([^'"]+)['"]/g, '<link href>', 'html'],
 ];
-for (const [file, regex, label] of rendererChecks) {
+for (const [file, regex, label, kind] of rendererChecks) {
   if (!fs.existsSync(file)) continue;
-  const text = fs.readFileSync(file, 'utf8');
+  const raw = fs.readFileSync(file, 'utf8');
+  const text = kind === 'html' ? stripHtmlComments(raw) : stripJsComments(raw);
   for (const match of text.matchAll(regex)) {
     const ref = match[1];
-    if (/^[a-z]+:/i.test(ref) || ref.startsWith('//')) continue;
-    const normalized = ref.replace(/^\.\//, '');
+    if (isExternalRef(ref)) continue;
+    const normalized = path.posix.normalize(ref.replace(/^\.\//, ''));
+    if (normalized.startsWith('..')) {
+      errors.push(`  - ${label} in ${file} references "${ref}" -- escapes asar root`);
+      continue;
+    }
     if (!asarFiles.has(normalized)) {
       errors.push(`  - ${label} in ${file} references "${ref}" -- not in asar`);
     }
   }
 }
 
-// Main-process side: path.join(__dirname, '...') with a literal second arg.
-// __dirname after tsc compilation is the file's location under dist/, so we
-// resolve relative to that. Skips dynamic args (variables, expressions).
+// Main-process side: path.join(__dirname, '...lit'[, '...lit']*) with one or
+// more string-literal args. After tsc, __dirname is the file's location under
+// dist/, so we resolve relative to that. Skips calls with any non-literal arg.
+const MAIN_JOIN_RE =
+  /path\.join\(\s*__dirname\s*((?:,\s*['"`][^'"`]+['"`]\s*)+)\)/g;
+const LITERAL_RE = /['"`]([^'"`]+)['"`]/g;
+
 const mainChecks = [
   ['src/main.ts', 'dist'],
   ['src/preload.ts', 'dist'],
 ];
 for (const [tsFile, compiledDir] of mainChecks) {
   if (!fs.existsSync(tsFile)) continue;
-  const text = fs.readFileSync(tsFile, 'utf8');
-  const re = /path\.join\(\s*__dirname\s*,\s*['"`]([^'"`]+)['"`]\s*\)/g;
-  for (const match of text.matchAll(re)) {
-    const ref = match[1];
-    const resolved = path.posix.normalize(path.posix.join(compiledDir, ref));
-    if (resolved.startsWith('..')) continue; // escapes asar root, not our concern
+  const text = stripJsComments(fs.readFileSync(tsFile, 'utf8'));
+  for (const match of text.matchAll(MAIN_JOIN_RE)) {
+    const literals = [...match[1].matchAll(LITERAL_RE)].map((m) => m[1]);
+    const refDisplay = literals.map((l) => JSON.stringify(l)).join(', ');
+    const resolved = path.posix.normalize(path.posix.join(compiledDir, ...literals));
+    // assets/icon.png and similar live at packaged-app root (outside asar)
+    // when the path joins out of dist/. The verify script's job is only to
+    // confirm asar contents, so we skip references that resolve outside.
+    if (resolved.startsWith('..')) continue;
     if (!asarFiles.has(resolved)) {
-      errors.push(`  - path.join(__dirname, "${ref}") in ${tsFile} -> "${resolved}" -- not in asar`);
+      errors.push(`  - path.join(__dirname, ${refDisplay}) in ${tsFile} -> "${resolved}" -- not in asar`);
     }
   }
 }

--- a/scripts/verify-asar-contents.js
+++ b/scripts/verify-asar-contents.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Verify that every static asset referenced at runtime by renderer.js or
+// index.html is actually present in the packaged app.asar. Run this after
+// `electron-builder --linux dir` (any platform's package step works -- the
+// asar contents are platform-agnostic).
+//
+// Catches the class of bug where a renderer-side file (e.g. an AudioWorklet
+// module loaded via `addModule('./foo.js')`) is referenced at runtime but
+// silently omitted from the packaged build.
+
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function findAsar(root) {
+  if (!fs.existsSync(root)) return null;
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.name === 'app.asar') return full;
+    }
+  }
+  return null;
+}
+
+const asarPath = findAsar('release');
+if (!asarPath) {
+  console.error('No app.asar found under release/. Run `electron-builder --linux dir` first.');
+  process.exit(1);
+}
+
+const asarFiles = new Set(
+  execSync(`npx --yes @electron/asar list "${asarPath}"`, { encoding: 'utf8' })
+    .split('\n')
+    .map((s) => s.replace(/^\//, '').trim())
+    .filter(Boolean)
+);
+
+const errors = [];
+
+// Renderer-side: paths are relative to the loading document, which sits at the
+// asar root (index.html, renderer.js are emitted at /).
+const rendererChecks = [
+  ['renderer.js', /audioWorklet\.addModule\(\s*['"`]([^'"`]+)['"`]/g, 'AudioWorklet.addModule'],
+  ['renderer.js', /(?:fetch|new\s+Worker)\(\s*['"`](\.\/[^'"`]+)['"`]/g, 'fetch / Worker'],
+  ['index.html', /<script[^>]+src=['"]([^'"]+)['"]/g, '<script src>'],
+  ['index.html', /<link[^>]+href=['"]([^'"]+)['"]/g, '<link href>'],
+];
+for (const [file, regex, label] of rendererChecks) {
+  if (!fs.existsSync(file)) continue;
+  const text = fs.readFileSync(file, 'utf8');
+  for (const match of text.matchAll(regex)) {
+    const ref = match[1];
+    if (/^[a-z]+:/i.test(ref) || ref.startsWith('//')) continue;
+    const normalized = ref.replace(/^\.\//, '');
+    if (!asarFiles.has(normalized)) {
+      errors.push(`  - ${label} in ${file} references "${ref}" -- not in asar`);
+    }
+  }
+}
+
+// Main-process side: path.join(__dirname, '...') with a literal second arg.
+// __dirname after tsc compilation is the file's location under dist/, so we
+// resolve relative to that. Skips dynamic args (variables, expressions).
+const mainChecks = [
+  ['src/main.ts', 'dist'],
+  ['src/preload.ts', 'dist'],
+];
+for (const [tsFile, compiledDir] of mainChecks) {
+  if (!fs.existsSync(tsFile)) continue;
+  const text = fs.readFileSync(tsFile, 'utf8');
+  const re = /path\.join\(\s*__dirname\s*,\s*['"`]([^'"`]+)['"`]\s*\)/g;
+  for (const match of text.matchAll(re)) {
+    const ref = match[1];
+    const resolved = path.posix.normalize(path.posix.join(compiledDir, ref));
+    if (resolved.startsWith('..')) continue; // escapes asar root, not our concern
+    if (!asarFiles.has(resolved)) {
+      errors.push(`  - path.join(__dirname, "${ref}") in ${tsFile} -> "${resolved}" -- not in asar`);
+    }
+  }
+}
+
+if (errors.length) {
+  console.error(`Asar at ${asarPath} is missing referenced static assets:`);
+  for (const e of errors) console.error(e);
+  process.exit(1);
+}
+
+console.log(`OK: all referenced static assets are in ${asarPath}`);


### PR DESCRIPTION
## Summary

Two static assets have been silently missing from packaged Listener.AI releases. Both are referenced at runtime (AudioWorklet `addModule()`, HTML `<script src=>`) which TypeScript and the existing CI cannot detect — they were simply absent from `package.json`'s `build.files` whitelist.

| File | Missing since | Broken feature |
|---|---|---|
| `pcmStreamProcessor.js` | v2.2.0 (PR #90) | macOS system audio capture — toast: "System audio capture failed -- recording mic only" |
| `js/fileHandler.js` | **v1.2.0 (2025-08-07)** | **Drag-and-drop file import, file dialog, audio file processing** — `window.fileHandler` is undefined, clicks throw `TypeError` |

The drag-and-drop regression has been in production for ~9 months across v1.2.0 through v2.2.0.

## Root cause

`build.files` is a whitelist. Adding a new root-level file (or directory) requires manual addition. AudioWorklet's `addModule('./...')` is a runtime fetch URL, and `<script src=>` is HTML — neither is a static `import` that tsc/eslint tracks. Dev mode (`pnpm start`) hides the bug because the renderer's working directory contains every project file; only packaged builds (asar) reveal what's missing. PR CI runs `tsc + node --test` — never builds a package, never inspects asar contents.

## Fix

1. **Add the two missing entries** to `build.files`:
   - `pcmStreamProcessor.js`
   - `js/**/*` (covers any future files in `js/`)
   - Cleaned up redundant negative excludes that referenced things never in the whitelist anyway.

2. **`scripts/verify-asar-contents.js`** (new): scans `renderer.js`, `index.html`, `src/main.ts`, `src/preload.ts` for static asset references and asserts each is in the packaged asar. Patterns covered:
   - `audioWorklet.addModule(...)`
   - `fetch('./...')`, `new Worker('./...')`
   - `<script src="...">`, `<link href="...">`
   - `path.join(__dirname, '...literal...')` (main process)

3. **PR CI step**: `electron-builder --linux dir --publish never` (no signing; asar contents are platform-agnostic) then `node scripts/verify-asar-contents.js`. Adds ~60–120s to PR CI on cache hit.

## Verification

| # | Case | Expected | Actual |
|---|---|---|---|
| 1 | Clean build | exit 0 | ✓ exit 0 |
| 2 | Renderer asset removed (`js/fileHandler.js`) | exit 1 + clear message | ✓ |
| 3 | Main-process asset removed (`assets/icon.png`) | exit 1 + resolved path | ✓ |
| 4 | No `release/` dir | exit 1 + helpful hint | ✓ |
| 5 | `set -e` semantic — CI step propagates | non-zero exit | ✓ |

Confirmed asar contents:
- `pcmStreamProcessor.js`, `js/fileHandler.js`, `assets/icon.png`, `dist/preload.js`, `dist/main.js`, etc. — all present
- `.env*`, `.npmrc`, `src/`, `build/`, `CLAUDE.md`, test files, source maps — all absent

## Recommended follow-up

After merge, trigger the **Build and Release** workflow with `version_type=patch` to ship **v2.2.1**. This recovers two user-visible features that have been silently broken (drag-and-drop for ~9 months, system audio for ~3 days).

## Test plan

- [ ] CI passes — `electron-builder --linux dir` + verify both succeed
- [ ] Negative test (locally): remove `pcmStreamProcessor.js` from whitelist → CI fails with the exact missing-asset message
- [ ] After v2.2.1 release: install fresh, drag an audio file onto the window — should import (was broken)
- [ ] After v2.2.1 release on macOS: enable "Record system audio" toggle, start recording — no error toast (was broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)