### PR TITLE
Add Slack meeting summary sharing (BYOW MVP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "test": "tsc && node --test dist/meetingDetectorService.test.js dist/searchService.test.js dist/agentService.test.js dist/simpleAudioRecorder.test.js dist/outputService.test.js dist/services/audioConcatService.test.js dist/cli.test.js",
+    "test": "tsc && node --test dist/meetingDetectorService.test.js dist/searchService.test.js dist/agentService.test.js dist/simpleAudioRecorder.test.js dist/outputService.test.js dist/slackService.test.js dist/services/audioConcatService.test.js dist/cli.test.js",
     "dist": "pnpm run build && electron-builder",
     "dist:mac": "pnpm run build && electron-builder --mac",
     "dist:mac-x64": "pnpm run build && electron-builder --mac --x64",

--- a/renderer/audio/recorder.ts
+++ b/renderer/audio/recorder.ts
@@ -209,32 +209,60 @@ export async function processAutoMode(
         console.log('Auto mode: File renamed to:', finalAudioPath);
       }
 
-      if (config.notionApiKey && config.notionDatabaseId) {
-        console.log('Auto mode: Uploading to Notion...');
+      const finalTitle =
+        (recordingTitle === '' || recordingTitle === 'Untitled_Meeting') &&
+        transcriptionResult.data.suggestedTitle
+          ? transcriptionResult.data.suggestedTitle
+          : recordingTitle || transcriptionResult.data.suggestedTitle || 'Untitled Meeting';
 
-        const finalTitle =
-          (recordingTitle === '' || recordingTitle === 'Untitled_Meeting') &&
-          transcriptionResult.data.suggestedTitle
-            ? transcriptionResult.data.suggestedTitle
-            : recordingTitle || transcriptionResult.data.suggestedTitle || 'Untitled Meeting';
+      let notionUrl: string | undefined;
+      let notionError: string | undefined;
+      let notionConfigured = false;
+
+      if (config.notionApiKey && config.notionDatabaseId) {
+        notionConfigured = true;
+        console.log('Auto mode: Uploading to Notion...');
 
         const uploadResult = await window.electronAPI.uploadToNotion({
           title: finalTitle,
           transcriptionData: transcriptionResult.data,
           audioFilePath: finalAudioPath,
+          transcriptionPath: transcriptionResult.transcriptionPath,
         });
 
         if (uploadResult.success) {
+          notionUrl = uploadResult.url;
           statusText.textContent = 'Auto mode: Successfully uploaded to Notion!';
           if (uploadResult.url) {
             window.electronAPI.openExternal(uploadResult.url);
           }
         } else {
+          notionError = uploadResult.error || 'Unknown error';
           statusText.textContent = 'Auto mode: Failed to upload to Notion';
           console.error('Auto mode: Notion upload failed:', uploadResult.error);
         }
-      } else {
-        statusText.textContent = 'Auto mode: Transcription complete (Notion not configured)';
+      }
+
+      if (config.slackWebhookUrl && config.slackAutoShare) {
+        console.log('Auto mode: Sending to Slack...');
+        const slackResult = await window.electronAPI.sendToSlack({
+          title: finalTitle,
+          transcriptionData: transcriptionResult.data,
+          transcriptionPath: transcriptionResult.transcriptionPath,
+          notionUrl,
+          notionError,
+        });
+        if (slackResult.success) {
+          statusText.textContent = notionConfigured
+            ? 'Auto mode: Sent to Notion and Slack.'
+            : 'Auto mode: Sent to Slack.';
+        } else {
+          statusText.textContent = 'Auto mode: Failed to send to Slack';
+          console.error('Auto mode: Slack send failed:', slackResult.error);
+        }
+      } else if (!notionConfigured) {
+        statusText.textContent =
+          'Auto mode: Transcription complete (Notion/Slack not configured)';
       }
 
       await refreshRecordingsList();

--- a/renderer/audio/recorder.ts
+++ b/renderer/audio/recorder.ts
@@ -223,6 +223,7 @@ export async function processAutoMode(
       let notionUrl: string | undefined;
       let notionError: string | undefined;
       let notionConfigured = false;
+      let notionSucceeded = false;
 
       if (config.notionApiKey && config.notionDatabaseId) {
         notionConfigured = true;
@@ -236,6 +237,7 @@ export async function processAutoMode(
         });
 
         if (uploadResult.success) {
+          notionSucceeded = true;
           notionUrl = uploadResult.url;
           statusText.textContent = 'Auto mode: Successfully uploaded to Notion!';
           if (uploadResult.url) {
@@ -258,9 +260,13 @@ export async function processAutoMode(
           notionError,
         });
         if (slackResult.success) {
-          statusText.textContent = notionConfigured
-            ? 'Auto mode: Sent to Notion and Slack.'
-            : 'Auto mode: Sent to Slack.';
+          if (notionSucceeded) {
+            statusText.textContent = 'Auto mode: Sent to Notion and Slack.';
+          } else if (notionConfigured) {
+            statusText.textContent = 'Auto mode: Sent to Slack (Notion failed).';
+          } else {
+            statusText.textContent = 'Auto mode: Sent to Slack.';
+          }
         } else {
           statusText.textContent = 'Auto mode: Failed to send to Slack';
           console.error('Auto mode: Slack send failed:', slackResult.error);

--- a/renderer/audio/recorder.ts
+++ b/renderer/audio/recorder.ts
@@ -167,6 +167,12 @@ export function resetRecordingUI(): void {
   recordingTime.classList.remove('active');
 }
 
+function pickMeetingTitle(recordingTitle: string, suggestedTitle?: string): string {
+  const isPlaceholder = recordingTitle === '' || recordingTitle === 'Untitled_Meeting';
+  if (isPlaceholder && suggestedTitle) return suggestedTitle;
+  return recordingTitle || suggestedTitle || 'Untitled Meeting';
+}
+
 export async function processAutoMode(
   audioPath: string | undefined,
   recordingTitle: string,
@@ -209,11 +215,10 @@ export async function processAutoMode(
         console.log('Auto mode: File renamed to:', finalAudioPath);
       }
 
-      const finalTitle =
-        (recordingTitle === '' || recordingTitle === 'Untitled_Meeting') &&
-        transcriptionResult.data.suggestedTitle
-          ? transcriptionResult.data.suggestedTitle
-          : recordingTitle || transcriptionResult.data.suggestedTitle || 'Untitled Meeting';
+      const finalTitle = pickMeetingTitle(
+        recordingTitle,
+        transcriptionResult.data.suggestedTitle,
+      );
 
       let notionUrl: string | undefined;
       let notionError: string | undefined;

--- a/renderer/audio/recorder.ts
+++ b/renderer/audio/recorder.ts
@@ -62,7 +62,7 @@ export async function startRecording(): Promise<void> {
   // Open the output stream in main BEFORE starting MediaRecorder so the first chunk
   // has a file handle waiting for it. Build the Web Audio graph up front (without
   // calling start) — if construction fails we haven't touched main state yet.
-  let graph;
+  let graph: Awaited<ReturnType<typeof buildProcessedStream>>;
   try {
     const addSystemAudio = useSystemAudio
       ? async (ctx: AudioContext) => {
@@ -215,10 +215,7 @@ export async function processAutoMode(
         console.log('Auto mode: File renamed to:', finalAudioPath);
       }
 
-      const finalTitle = pickMeetingTitle(
-        recordingTitle,
-        transcriptionResult.data.suggestedTitle,
-      );
+      const finalTitle = pickMeetingTitle(recordingTitle, transcriptionResult.data.suggestedTitle);
 
       let notionUrl: string | undefined;
       let notionError: string | undefined;
@@ -272,8 +269,7 @@ export async function processAutoMode(
           console.error('Auto mode: Slack send failed:', slackResult.error);
         }
       } else if (!notionConfigured) {
-        statusText.textContent =
-          'Auto mode: Transcription complete (Notion/Slack not configured)';
+        statusText.textContent = 'Auto mode: Transcription complete (Notion/Slack not configured)';
       }
 
       await refreshRecordingsList();

--- a/renderer/dev-shim.html
+++ b/renderer/dev-shim.html
@@ -25,7 +25,16 @@
           : { success: true, data: null };
         if (prop === 'searchTranscriptions' || prop === 'listReleases') return asyncList;
         if (prop === 'checkConfig') return async () => ({ hasConfig: true, hasGeminiKey: true, hasNotionConfig: true, autoMode: false, missing: [] });
-        if (prop === 'getConfig') return async () => ({ globalShortcut: 'CommandOrControl+Shift+R' });
+        if (prop === 'getConfig') return async () => ({
+          globalShortcut: 'CommandOrControl+Shift+R',
+          notionApiKey: 'secret_dev_token',
+          notionDatabaseId: 'dev_db_id',
+          slackWebhookUrl: 'https://hooks.slack.com/services/T0/B0/devShimWebhook',
+          slackAutoShare: true,
+        });
+        if (prop === 'testSlackWebhook') return async () => ({ success: true, sentAt: new Date().toISOString() });
+        if (prop === 'sendToSlack') return async () => ({ success: true, sentAt: new Date().toISOString() });
+        if (prop === 'uploadToNotion') return async () => ({ success: true, url: 'https://www.notion.so/dev-page' });
         if (prop === 'getAudioInputDevices') return asyncList;
         return asyncEmpty;
       }

--- a/renderer/electronAPI.d.ts
+++ b/renderer/electronAPI.d.ts
@@ -28,6 +28,14 @@ export type ConfigPayload = {
   summaryPrompt?: string;
   recordSystemAudio?: boolean;
   audioDeviceId?: string;
+  slackWebhookUrl?: string;
+  slackAutoShare?: boolean;
+};
+
+export type SlackSendApiResult = {
+  success: boolean;
+  error?: string;
+  sentAt?: string;
 };
 
 export type SystemAudioStartResult =
@@ -62,14 +70,27 @@ export type ElectronAPI = {
   }>;
   saveConfig: (config: ConfigPayload) => Promise<{ success: boolean; error?: string }>;
   getConfig: () => Promise<Record<string, unknown>>;
-  transcribeAudio: (
-    filePath: string,
-  ) => Promise<{ success: boolean; data?: any; newFilePath?: string; error?: string }>;
+  transcribeAudio: (filePath: string) => Promise<{
+    success: boolean;
+    data?: any;
+    newFilePath?: string;
+    transcriptionPath?: string;
+    error?: string;
+  }>;
   uploadToNotion: (data: {
     title: string;
     transcriptionData: any;
     audioFilePath?: string;
+    transcriptionPath?: string;
   }) => Promise<{ success: boolean; url?: string; error?: string }>;
+  sendToSlack: (data: {
+    title: string;
+    transcriptionData: any;
+    transcriptionPath?: string;
+    notionUrl?: string;
+    notionError?: string;
+  }) => Promise<SlackSendApiResult>;
+  testSlackWebhook: (webhookUrl?: string) => Promise<SlackSendApiResult>;
   openExternal: (url: string) => Promise<void>;
   openRecordingsFolder: () => Promise<void>;
   showInFinder: (filePath: string) => Promise<void>;

--- a/renderer/electronAPI.d.ts
+++ b/renderer/electronAPI.d.ts
@@ -32,11 +32,9 @@ export type ConfigPayload = {
   slackAutoShare?: boolean;
 };
 
-export type SlackSendApiResult = {
-  success: boolean;
-  error?: string;
-  sentAt?: string;
-};
+export type SlackSendApiResult =
+  | { success: true; sentAt: string }
+  | { success: false; error: string };
 
 export type SystemAudioStartResult =
   | { success: true; format: { sampleRate: number; channelCount: number; bytesPerSample: number } }

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -169,6 +169,35 @@
           <small>Copy from your database URL: notion.so/[workspace]/[database-id]?v=...</small>
         </div>
         <div class="form-group">
+          <label for="slackWebhookUrl">Slack Incoming Webhook URL:</label>
+          <input type="password" id="slackWebhookUrl" placeholder="https://hooks.slack.com/services/...">
+          <div class="slack-webhook-row">
+            <button type="button" id="openSlackAppCreator" class="reset-prompt-button">Get Webhook URL</button>
+            <button type="button" id="testSlackWebhook" class="reset-prompt-button">Send Test Message</button>
+            <span id="slackWebhookStatus" class="slack-webhook-status"></span>
+          </div>
+          <details class="slack-help">
+            <summary>How do I get this URL?</summary>
+            <ol class="slack-help-steps">
+              <li>Click <strong>Get Webhook URL</strong> above (opens api.slack.com/apps).</li>
+              <li><strong>Create New App</strong> &rarr; <strong>From scratch</strong>. Name it anything (e.g. "Listener AI") and pick your workspace.</li>
+              <li>Sidebar &rarr; <strong>Features &rarr; Incoming Webhooks</strong>. Toggle <strong>Activate Incoming Webhooks</strong> on.</li>
+              <li>Scroll down &rarr; <strong>Add New Webhook to Workspace</strong>, pick the channel, and Allow.</li>
+              <li>Copy the URL (starts with <code>https://hooks.slack.com/services/</code>) and paste it above.</li>
+              <li>Click <strong>Send Test Message</strong> to confirm.</li>
+            </ol>
+            <small>If your workspace blocks app installs, ask an admin to do steps 1&ndash;4 for you.</small>
+          </details>
+          <small>Stored locally; never logged.</small>
+        </div>
+        <div class="form-group">
+          <label class="inline-label">
+            <input type="checkbox" id="slackAutoShare">
+            Automatically share completed meetings to Slack
+          </label>
+          <small>When auto mode is on, post the summary + Notion link to the configured webhook after each meeting.</small>
+        </div>
+        <div class="form-group">
           <label for="globalShortcut">Global Shortcut:</label>
           <input type="text" id="globalShortcut" placeholder="Press shortcut keys" readonly>
           <small>Click the input and press your desired shortcut combination</small>
@@ -227,9 +256,14 @@
             <button class="tab-button" data-tab="transcript">Transcript</button>
             <button class="tab-button" data-tab="ask">💬 Ask</button>
           </div>
-          <button id="uploadToNotion" class="notion-button" style="display: none;">
-            <span class="notion-icon">📝</span> Upload to Notion
-          </button>
+          <div class="transcription-actions">
+            <button id="uploadToNotion" class="notion-button" style="display: none;">
+              <span class="notion-icon">📝</span> Upload to Notion
+            </button>
+            <button id="sendToSlack" class="slack-button" style="display: none;">
+              <span class="slack-icon">💬</span> <span id="slackButtonLabel">Send to Slack</span>
+            </button>
+          </div>
         </div>
         <div class="transcription-body">
           <div class="tab-content">

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -1181,6 +1181,109 @@ h1 {
   font-size: 18px;
 }
 
+.transcription-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.slack-button {
+  background-color: #4a154b;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: background-color 0.3s;
+}
+
+.slack-button:hover {
+  background-color: #611f64;
+}
+
+.slack-button:disabled {
+  background-color: #95a5a6;
+  cursor: not-allowed;
+}
+
+.slack-button.is-resend {
+  background-color: #2f7a64;
+}
+
+.slack-button.is-resend:hover {
+  background-color: #36927a;
+}
+
+.slack-icon {
+  font-size: 16px;
+}
+
+.slack-webhook-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.slack-webhook-status {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.slack-webhook-status.is-success {
+  color: #2f7a64;
+}
+
+.slack-webhook-status.is-error {
+  color: #c0392b;
+}
+
+.slack-help {
+  margin-top: 8px;
+  font-size: 13px;
+  color: #475569;
+}
+
+.slack-help summary {
+  cursor: pointer;
+  color: #2563eb;
+  user-select: none;
+}
+
+.slack-help summary:hover {
+  text-decoration: underline;
+}
+
+.slack-help-steps {
+  margin: 8px 0 4px 20px;
+  padding: 0;
+  line-height: 1.6;
+}
+
+.slack-help-steps li {
+  margin-bottom: 4px;
+}
+
+.slack-help-steps code {
+  background: #f1f5f9;
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.inline-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+}
+
 .recording-meta {
   font-size: 12px;
   color: #94a3b8;

--- a/renderer/ui/config-modal.ts
+++ b/renderer/ui/config-modal.ts
@@ -192,7 +192,7 @@ export function setupConfigModal(): void {
           slackWebhookStatus.textContent = 'Test message sent. Check the channel.';
           slackWebhookStatus.className = 'slack-webhook-status is-success';
         } else {
-          slackWebhookStatus.textContent = result.error || 'Test failed.';
+          slackWebhookStatus.textContent = result.error;
           slackWebhookStatus.className = 'slack-webhook-status is-error';
         }
       } finally {

--- a/renderer/ui/config-modal.ts
+++ b/renderer/ui/config-modal.ts
@@ -13,6 +13,10 @@ let geminiModelInput: HTMLInputElement | null = null;
 let geminiFlashModelInput: HTMLInputElement | null = null;
 let notionApiKeyInput: HTMLInputElement | null = null;
 let notionDatabaseIdInput: HTMLInputElement | null = null;
+let slackWebhookUrlInput: HTMLInputElement | null = null;
+let slackAutoShareInput: HTMLInputElement | null = null;
+let testSlackWebhookBtn: HTMLButtonElement | null = null;
+let slackWebhookStatus: HTMLElement | null = null;
 let globalShortcutInput: HTMLInputElement | null = null;
 let knownWordsInput: HTMLTextAreaElement | null = null;
 
@@ -46,6 +50,8 @@ export async function showConfigModal(): Promise<void> {
     geminiFlashModel?: string;
     notionApiKey?: string;
     notionDatabaseId?: string;
+    slackWebhookUrl?: string;
+    slackAutoShare?: boolean;
     globalShortcut?: string;
     knownWords?: string[];
     maxRecordingMinutes?: number | string;
@@ -69,6 +75,16 @@ export async function showConfigModal(): Promise<void> {
   }
   if (notionDatabaseIdInput && config.notionDatabaseId) {
     notionDatabaseIdInput.value = config.notionDatabaseId;
+  }
+  if (slackWebhookUrlInput) {
+    slackWebhookUrlInput.value = config.slackWebhookUrl || '';
+  }
+  if (slackAutoShareInput) {
+    slackAutoShareInput.checked = !!config.slackAutoShare;
+  }
+  if (slackWebhookStatus) {
+    slackWebhookStatus.textContent = '';
+    slackWebhookStatus.className = 'slack-webhook-status';
   }
   if (globalShortcutInput && config.globalShortcut) {
     globalShortcutInput.value = config.globalShortcut;
@@ -142,8 +158,48 @@ export function setupConfigModal(): void {
   geminiFlashModelInput = document.getElementById('geminiFlashModel') as HTMLInputElement | null;
   notionApiKeyInput = document.getElementById('notionApiKey') as HTMLInputElement | null;
   notionDatabaseIdInput = document.getElementById('notionDatabaseId') as HTMLInputElement | null;
+  slackWebhookUrlInput = document.getElementById('slackWebhookUrl') as HTMLInputElement | null;
+  slackAutoShareInput = document.getElementById('slackAutoShare') as HTMLInputElement | null;
+  testSlackWebhookBtn = document.getElementById('testSlackWebhook') as HTMLButtonElement | null;
+  slackWebhookStatus = document.getElementById('slackWebhookStatus');
   globalShortcutInput = document.getElementById('globalShortcut') as HTMLInputElement | null;
   knownWordsInput = document.getElementById('knownWords') as HTMLTextAreaElement | null;
+
+  const openSlackAppCreatorBtn = document.getElementById(
+    'openSlackAppCreator',
+  ) as HTMLButtonElement | null;
+  if (openSlackAppCreatorBtn) {
+    openSlackAppCreatorBtn.addEventListener('click', () => {
+      window.electronAPI.openExternal('https://api.slack.com/apps?new_app=1');
+    });
+  }
+
+  if (testSlackWebhookBtn) {
+    testSlackWebhookBtn.addEventListener('click', async () => {
+      if (!slackWebhookUrlInput || !slackWebhookStatus) return;
+      const url = slackWebhookUrlInput.value.trim();
+      if (!url) {
+        slackWebhookStatus.textContent = 'Enter a webhook URL first.';
+        slackWebhookStatus.className = 'slack-webhook-status is-error';
+        return;
+      }
+      slackWebhookStatus.textContent = 'Sending test message…';
+      slackWebhookStatus.className = 'slack-webhook-status';
+      testSlackWebhookBtn!.disabled = true;
+      try {
+        const result = await window.electronAPI.testSlackWebhook(url);
+        if (result.success) {
+          slackWebhookStatus.textContent = 'Test message sent. Check the channel.';
+          slackWebhookStatus.className = 'slack-webhook-status is-success';
+        } else {
+          slackWebhookStatus.textContent = result.error || 'Test failed.';
+          slackWebhookStatus.className = 'slack-webhook-status is-error';
+        }
+      } finally {
+        testSlackWebhookBtn!.disabled = false;
+      }
+    });
+  }
 
   if (saveConfigBtn) {
     saveConfigBtn.addEventListener('click', async () => {
@@ -152,6 +208,8 @@ export function setupConfigModal(): void {
       const geminiFlashModel = geminiFlashModelInput ? geminiFlashModelInput.value.trim() : '';
       const notionKey = notionApiKeyInput?.value.trim() ?? '';
       const notionDb = notionDatabaseIdInput?.value.trim() ?? '';
+      const slackWebhookUrl = slackWebhookUrlInput?.value.trim() ?? '';
+      const slackAutoShare = !!slackAutoShareInput?.checked;
       const globalShortcut = globalShortcutInput?.value.trim() ?? '';
       const knownWords = knownWordsInput
         ? knownWordsInput.value
@@ -196,6 +254,8 @@ export function setupConfigModal(): void {
           geminiFlashModel: geminiFlashModel,
           notionApiKey: notionKey,
           notionDatabaseId: notionDb,
+          slackWebhookUrl: slackWebhookUrl,
+          slackAutoShare: slackAutoShare,
           globalShortcut: globalShortcut,
           knownWords: knownWords,
           summaryPrompt: summaryPrompt || DEFAULT_SUMMARY_PROMPT,

--- a/renderer/ui/recordings-list.ts
+++ b/renderer/ui/recordings-list.ts
@@ -35,6 +35,7 @@ type MergeRecordingsResult = {
   code?: string;
   data?: Record<string, unknown>;
   mergedAudioPath?: string;
+  transcriptionPath?: string;
 };
 
 // Monotonic token so a slow loadRecordings (per-item async metadata reads)
@@ -426,6 +427,7 @@ async function performMerge(paths: string[], title: string): Promise<void> {
       transcriptionData: (result.data || {}) as never,
       title,
       filePath: result.mergedAudioPath || null,
+      transcriptionPath: result.transcriptionPath ?? null,
     });
     populateTranscriptionUI((result.data || {}) as never);
 
@@ -433,8 +435,7 @@ async function performMerge(paths: string[], title: string): Promise<void> {
 
     const cfg = await window.electronAPI.getConfig();
     if (uploadToNotionBtn) {
-      uploadToNotionBtn.style.display =
-        cfg.notionApiKey && cfg.notionDatabaseId ? 'flex' : 'none';
+      uploadToNotionBtn.style.display = cfg.notionApiKey && cfg.notionDatabaseId ? 'flex' : 'none';
     }
     const sendToSlackBtn = document.getElementById('sendToSlack') as HTMLElement | null;
     if (sendToSlackBtn) {

--- a/renderer/ui/recordings-list.ts
+++ b/renderer/ui/recordings-list.ts
@@ -431,12 +431,12 @@ async function performMerge(paths: string[], title: string): Promise<void> {
 
     await refreshRecordingsList();
 
-    const notionConfig = await window.electronAPI.getConfig();
-    if (notionConfig.notionApiKey && notionConfig.notionDatabaseId && uploadToNotionBtn) {
+    const cfg = await window.electronAPI.getConfig();
+    if (cfg.notionApiKey && cfg.notionDatabaseId && uploadToNotionBtn) {
       uploadToNotionBtn.style.display = 'flex';
     }
     const sendToSlackBtn = document.getElementById('sendToSlack') as HTMLElement | null;
-    if (notionConfig.slackWebhookUrl && sendToSlackBtn) {
+    if (cfg.slackWebhookUrl && sendToSlackBtn) {
       sendToSlackBtn.style.display = 'flex';
     }
   } catch (err) {

--- a/renderer/ui/recordings-list.ts
+++ b/renderer/ui/recordings-list.ts
@@ -432,12 +432,13 @@ async function performMerge(paths: string[], title: string): Promise<void> {
     await refreshRecordingsList();
 
     const cfg = await window.electronAPI.getConfig();
-    if (cfg.notionApiKey && cfg.notionDatabaseId && uploadToNotionBtn) {
-      uploadToNotionBtn.style.display = 'flex';
+    if (uploadToNotionBtn) {
+      uploadToNotionBtn.style.display =
+        cfg.notionApiKey && cfg.notionDatabaseId ? 'flex' : 'none';
     }
     const sendToSlackBtn = document.getElementById('sendToSlack') as HTMLElement | null;
-    if (cfg.slackWebhookUrl && sendToSlackBtn) {
-      sendToSlackBtn.style.display = 'flex';
+    if (sendToSlackBtn) {
+      sendToSlackBtn.style.display = cfg.slackWebhookUrl ? 'flex' : 'none';
     }
   } catch (err) {
     alert(

--- a/renderer/ui/recordings-list.ts
+++ b/renderer/ui/recordings-list.ts
@@ -435,6 +435,10 @@ async function performMerge(paths: string[], title: string): Promise<void> {
     if (notionConfig.notionApiKey && notionConfig.notionDatabaseId && uploadToNotionBtn) {
       uploadToNotionBtn.style.display = 'flex';
     }
+    const sendToSlackBtn = document.getElementById('sendToSlack') as HTMLElement | null;
+    if (notionConfig.slackWebhookUrl && sendToSlackBtn) {
+      sendToSlackBtn.style.display = 'flex';
+    }
   } catch (err) {
     alert(
       `Error merging recordings: ${err && (err as Error).message ? (err as Error).message : String(err)}`,

--- a/renderer/ui/transcription-modal.ts
+++ b/renderer/ui/transcription-modal.ts
@@ -43,6 +43,13 @@ function refreshSlackButtonLabel(): void {
   }
 }
 
+function refreshNotionButtonLabel(): void {
+  if (!uploadToNotionBtn) return;
+  uploadToNotionBtn.innerHTML = currentNotionUrl
+    ? '<span class="notion-icon">📝</span> View in Notion'
+    : '<span class="notion-icon">📝</span> Upload to Notion';
+}
+
 function ensureTranscriptionModal(): HTMLElement | null {
   if (!transcriptionModal) {
     transcriptionModal = document.getElementById('transcriptionModal');
@@ -129,6 +136,7 @@ export function showSavedTranscript(
     currentNotionUrl = (metadata as { notionPageUrl?: string }).notionPageUrl ?? null;
     currentSlackSentAt = (metadata as { slackSentAt?: string }).slackSentAt ?? null;
     refreshSlackButtonLabel();
+    refreshNotionButtonLabel();
 
     // Prefer an explicit folderName; fall back to the one get-metadata attaches.
     resetModalChatFor(folderName || metadata?.folderName || null);
@@ -220,6 +228,7 @@ export async function handleTranscribe(filePath: string, title: string): Promise
       currentNotionUrl = null;
       currentSlackSentAt = null;
       refreshSlackButtonLabel();
+      refreshNotionButtonLabel();
 
       populateTranscriptionUI(result.data);
 
@@ -345,14 +354,19 @@ export function setupTranscriptionModal(): void {
     });
   }
 
-  // Handle upload to Notion
+  // Handle upload to Notion (or open existing page if already uploaded)
   if (uploadToNotionBtn) {
     uploadToNotionBtn.addEventListener('click', async () => {
+      if (currentNotionUrl) {
+        window.electronAPI.openExternal(currentNotionUrl);
+        return;
+      }
+
       if (!currentTranscriptionData || !currentMeetingTitle) {
         alert('No transcription data available');
         return;
       }
-      if (!uploadToNotionBtn) return;
+      if (!uploadToNotionBtn || uploadToNotionBtn.disabled) return;
 
       uploadToNotionBtn.disabled = true;
       uploadToNotionBtn.textContent = 'Uploading...';
@@ -368,12 +382,9 @@ export function setupTranscriptionModal(): void {
         if (result.success) {
           if (result.url) {
             currentNotionUrl = result.url;
-          }
-          alert('Successfully uploaded to Notion!');
-          if (result.url) {
-            // Open the Notion page in browser
             window.electronAPI.openExternal(result.url);
           }
+          alert('Successfully uploaded to Notion!');
         } else {
           alert(`Failed to upload to Notion: ${result.error}`);
         }
@@ -381,10 +392,8 @@ export function setupTranscriptionModal(): void {
         const message = error instanceof Error ? error.message : String(error);
         alert(`Error uploading to Notion: ${message}`);
       } finally {
-        if (uploadToNotionBtn) {
-          uploadToNotionBtn.disabled = false;
-          uploadToNotionBtn.innerHTML = '<span class="notion-icon">📝</span> Upload to Notion';
-        }
+        if (uploadToNotionBtn) uploadToNotionBtn.disabled = false;
+        refreshNotionButtonLabel();
       }
     });
   }
@@ -449,4 +458,5 @@ export function _setCurrentTranscription(data: {
   currentNotionUrl = null;
   currentSlackSentAt = null;
   refreshSlackButtonLabel();
+  refreshNotionButtonLabel();
 }

--- a/renderer/ui/transcription-modal.ts
+++ b/renderer/ui/transcription-modal.ts
@@ -135,7 +135,6 @@ export function showSavedTranscript(
 
     populateTranscriptionUI(currentTranscriptionData);
 
-    // Show upload to Notion / Slack buttons if configured
     window.electronAPI.getConfig().then((config) => {
       if (config.notionApiKey && config.notionDatabaseId) {
         if (uploadToNotionBtn) uploadToNotionBtn.style.display = 'flex';
@@ -227,7 +226,6 @@ export async function handleTranscribe(filePath: string, title: string): Promise
       // state appear without requiring a manual reload.
       await refreshRecordingsList();
 
-      // Show upload to Notion / Slack buttons if configured
       const cfg = await window.electronAPI.getConfig();
       if (cfg.notionApiKey && cfg.notionDatabaseId) {
         if (uploadToNotionBtn) uploadToNotionBtn.style.display = 'flex';
@@ -395,15 +393,19 @@ export function setupTranscriptionModal(): void {
         alert('No transcription data available');
         return;
       }
-      if (!sendToSlackBtn) return;
+      if (!sendToSlackBtn || sendToSlackBtn.disabled) return;
+
+      // Disable before confirm() to block double-clicks during the prompt.
+      sendToSlackBtn.disabled = true;
 
       if (currentSlackSentAt) {
         const when = new Date(currentSlackSentAt).toLocaleString();
-        if (!confirm(`Already sent to Slack on ${when}. Send again?`)) return;
+        if (!confirm(`Already sent to Slack on ${when}. Send again?`)) {
+          sendToSlackBtn.disabled = false;
+          return;
+        }
       }
 
-      sendToSlackBtn.disabled = true;
-      const originalLabel = slackButtonLabel?.textContent || 'Send to Slack';
       if (slackButtonLabel) slackButtonLabel.textContent = 'Sending…';
 
       try {
@@ -415,7 +417,7 @@ export function setupTranscriptionModal(): void {
         });
 
         if (result.success) {
-          currentSlackSentAt = result.sentAt || new Date().toISOString();
+          currentSlackSentAt = result.sentAt ?? new Date().toISOString();
           showToast('Sent to Slack');
         } else {
           alert(`Failed to send to Slack: ${result.error}`);
@@ -424,10 +426,7 @@ export function setupTranscriptionModal(): void {
         const message = error instanceof Error ? error.message : String(error);
         alert(`Error sending to Slack: ${message}`);
       } finally {
-        if (sendToSlackBtn) {
-          sendToSlackBtn.disabled = false;
-        }
-        if (slackButtonLabel) slackButtonLabel.textContent = originalLabel;
+        if (sendToSlackBtn) sendToSlackBtn.disabled = false;
         refreshSlackButtonLabel();
       }
     });

--- a/renderer/ui/transcription-modal.ts
+++ b/renderer/ui/transcription-modal.ts
@@ -22,10 +22,26 @@ import { refreshRecordingsList } from './recordings-list';
 let currentTranscriptionData: TranscriptionData | null = null;
 let currentMeetingTitle = '';
 let currentFilePath: string | null | undefined = '';
+let currentTranscriptionPath: string | null = null;
+let currentNotionUrl: string | null = null;
+let currentSlackSentAt: string | null = null;
 
 let transcriptionModal: HTMLElement | null = null;
 let closeTranscriptionBtn: Element | null = null;
 let uploadToNotionBtn: HTMLButtonElement | null = null;
+let sendToSlackBtn: HTMLButtonElement | null = null;
+let slackButtonLabel: HTMLElement | null = null;
+
+function refreshSlackButtonLabel(): void {
+  if (!slackButtonLabel || !sendToSlackBtn) return;
+  if (currentSlackSentAt) {
+    slackButtonLabel.textContent = 'Resend to Slack';
+    sendToSlackBtn.classList.add('is-resend');
+  } else {
+    slackButtonLabel.textContent = 'Send to Slack';
+    sendToSlackBtn.classList.remove('is-resend');
+  }
+}
 
 function ensureTranscriptionModal(): HTMLElement | null {
   if (!transcriptionModal) {
@@ -108,16 +124,24 @@ export function showSavedTranscript(
     };
     currentMeetingTitle = title;
     currentFilePath = filePath;
+    currentTranscriptionPath =
+      (metadata as { transcriptionPath?: string }).transcriptionPath ?? null;
+    currentNotionUrl = (metadata as { notionPageUrl?: string }).notionPageUrl ?? null;
+    currentSlackSentAt = (metadata as { slackSentAt?: string }).slackSentAt ?? null;
+    refreshSlackButtonLabel();
 
     // Prefer an explicit folderName; fall back to the one get-metadata attaches.
     resetModalChatFor(folderName || metadata?.folderName || null);
 
     populateTranscriptionUI(currentTranscriptionData);
 
-    // Show upload to Notion button if configured
+    // Show upload to Notion / Slack buttons if configured
     window.electronAPI.getConfig().then((config) => {
       if (config.notionApiKey && config.notionDatabaseId) {
         if (uploadToNotionBtn) uploadToNotionBtn.style.display = 'flex';
+      }
+      if (config.slackWebhookUrl) {
+        if (sendToSlackBtn) sendToSlackBtn.style.display = 'flex';
       }
     });
   }
@@ -191,6 +215,11 @@ export async function handleTranscribe(filePath: string, title: string): Promise
       currentTranscriptionData = result.data;
       currentMeetingTitle = title;
       currentFilePath = filePath;
+      currentTranscriptionPath =
+        (result as { transcriptionPath?: string }).transcriptionPath ?? null;
+      currentNotionUrl = null;
+      currentSlackSentAt = null;
+      refreshSlackButtonLabel();
 
       populateTranscriptionUI(result.data);
 
@@ -198,10 +227,13 @@ export async function handleTranscribe(filePath: string, title: string): Promise
       // state appear without requiring a manual reload.
       await refreshRecordingsList();
 
-      // Show upload to Notion button if configured
-      const notionConfig = await window.electronAPI.getConfig();
-      if (notionConfig.notionApiKey && notionConfig.notionDatabaseId) {
+      // Show upload to Notion / Slack buttons if configured
+      const cfg = await window.electronAPI.getConfig();
+      if (cfg.notionApiKey && cfg.notionDatabaseId) {
         if (uploadToNotionBtn) uploadToNotionBtn.style.display = 'flex';
+      }
+      if (cfg.slackWebhookUrl) {
+        if (sendToSlackBtn) sendToSlackBtn.style.display = 'flex';
       }
     } else {
       alert(`Failed to transcribe audio: ${result.error}`);
@@ -290,6 +322,8 @@ export function setupTranscriptionModal(): void {
   transcriptionModal = document.getElementById('transcriptionModal');
   closeTranscriptionBtn = document.querySelector('#transcriptionModal .close');
   uploadToNotionBtn = document.getElementById('uploadToNotion') as HTMLButtonElement | null;
+  sendToSlackBtn = document.getElementById('sendToSlack') as HTMLButtonElement | null;
+  slackButtonLabel = document.getElementById('slackButtonLabel');
 
   if (closeTranscriptionBtn) {
     closeTranscriptionBtn.addEventListener('click', () => {
@@ -328,9 +362,13 @@ export function setupTranscriptionModal(): void {
           title: currentMeetingTitle,
           transcriptionData: currentTranscriptionData,
           audioFilePath: currentFilePath || undefined,
+          transcriptionPath: currentTranscriptionPath || undefined,
         });
 
         if (result.success) {
+          if (result.url) {
+            currentNotionUrl = result.url;
+          }
           alert('Successfully uploaded to Notion!');
           if (result.url) {
             // Open the Notion page in browser
@@ -347,6 +385,50 @@ export function setupTranscriptionModal(): void {
           uploadToNotionBtn.disabled = false;
           uploadToNotionBtn.innerHTML = '<span class="notion-icon">📝</span> Upload to Notion';
         }
+      }
+    });
+  }
+
+  if (sendToSlackBtn) {
+    sendToSlackBtn.addEventListener('click', async () => {
+      if (!currentTranscriptionData || !currentMeetingTitle) {
+        alert('No transcription data available');
+        return;
+      }
+      if (!sendToSlackBtn) return;
+
+      if (currentSlackSentAt) {
+        const when = new Date(currentSlackSentAt).toLocaleString();
+        if (!confirm(`Already sent to Slack on ${when}. Send again?`)) return;
+      }
+
+      sendToSlackBtn.disabled = true;
+      const originalLabel = slackButtonLabel?.textContent || 'Send to Slack';
+      if (slackButtonLabel) slackButtonLabel.textContent = 'Sending…';
+
+      try {
+        const result = await window.electronAPI.sendToSlack({
+          title: currentMeetingTitle,
+          transcriptionData: currentTranscriptionData,
+          transcriptionPath: currentTranscriptionPath || undefined,
+          notionUrl: currentNotionUrl || undefined,
+        });
+
+        if (result.success) {
+          currentSlackSentAt = result.sentAt || new Date().toISOString();
+          showToast('Sent to Slack');
+        } else {
+          alert(`Failed to send to Slack: ${result.error}`);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        alert(`Error sending to Slack: ${message}`);
+      } finally {
+        if (sendToSlackBtn) {
+          sendToSlackBtn.disabled = false;
+        }
+        if (slackButtonLabel) slackButtonLabel.textContent = originalLabel;
+        refreshSlackButtonLabel();
       }
     });
   }

--- a/renderer/ui/transcription-modal.ts
+++ b/renderer/ui/transcription-modal.ts
@@ -136,11 +136,12 @@ export function showSavedTranscript(
     populateTranscriptionUI(currentTranscriptionData);
 
     window.electronAPI.getConfig().then((config) => {
-      if (config.notionApiKey && config.notionDatabaseId) {
-        if (uploadToNotionBtn) uploadToNotionBtn.style.display = 'flex';
+      if (uploadToNotionBtn) {
+        uploadToNotionBtn.style.display =
+          config.notionApiKey && config.notionDatabaseId ? 'flex' : 'none';
       }
-      if (config.slackWebhookUrl) {
-        if (sendToSlackBtn) sendToSlackBtn.style.display = 'flex';
+      if (sendToSlackBtn) {
+        sendToSlackBtn.style.display = config.slackWebhookUrl ? 'flex' : 'none';
       }
     });
   }
@@ -227,11 +228,12 @@ export async function handleTranscribe(filePath: string, title: string): Promise
       await refreshRecordingsList();
 
       const cfg = await window.electronAPI.getConfig();
-      if (cfg.notionApiKey && cfg.notionDatabaseId) {
-        if (uploadToNotionBtn) uploadToNotionBtn.style.display = 'flex';
+      if (uploadToNotionBtn) {
+        uploadToNotionBtn.style.display =
+          cfg.notionApiKey && cfg.notionDatabaseId ? 'flex' : 'none';
       }
-      if (cfg.slackWebhookUrl) {
-        if (sendToSlackBtn) sendToSlackBtn.style.display = 'flex';
+      if (sendToSlackBtn) {
+        sendToSlackBtn.style.display = cfg.slackWebhookUrl ? 'flex' : 'none';
       }
     } else {
       alert(`Failed to transcribe audio: ${result.error}`);
@@ -417,7 +419,7 @@ export function setupTranscriptionModal(): void {
         });
 
         if (result.success) {
-          currentSlackSentAt = result.sentAt ?? new Date().toISOString();
+          currentSlackSentAt = result.sentAt;
           showToast('Sent to Slack');
         } else {
           alert(`Failed to send to Slack: ${result.error}`);
@@ -438,8 +440,13 @@ export function _setCurrentTranscription(data: {
   transcriptionData: TranscriptionData | null;
   title: string;
   filePath: string | null | undefined;
+  transcriptionPath?: string | null;
 }): void {
   currentTranscriptionData = data.transcriptionData;
   currentMeetingTitle = data.title;
   currentFilePath = data.filePath;
+  currentTranscriptionPath = data.transcriptionPath ?? null;
+  currentNotionUrl = null;
+  currentSlackSentAt = null;
+  refreshSlackButtonLabel();
 }

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -19,6 +19,8 @@ export interface AppConfig {
   recordSystemAudio?: boolean;
   audioDeviceId?: string;
   lastSeenVersion?: string;
+  slackWebhookUrl?: string;
+  slackAutoShare?: boolean;
 }
 
 export const DEFAULT_SUMMARY_PROMPT = `Based on this meeting transcript, provide:
@@ -237,6 +239,24 @@ export class ConfigService {
     this.saveConfig();
   }
 
+  getSlackWebhookUrl(): string | undefined {
+    return this.config.slackWebhookUrl || process.env.SLACK_WEBHOOK_URL;
+  }
+
+  setSlackWebhookUrl(url: string): void {
+    this.config.slackWebhookUrl = url;
+    this.saveConfig();
+  }
+
+  getSlackAutoShare(): boolean {
+    return this.config.slackAutoShare || false;
+  }
+
+  setSlackAutoShare(enabled: boolean): void {
+    this.config.slackAutoShare = enabled;
+    this.saveConfig();
+  }
+
   updateConfig(partial: Partial<AppConfig>): void {
     for (const [key, value] of Object.entries(partial)) {
       if (value !== undefined) {
@@ -265,6 +285,8 @@ export class ConfigService {
       recordSystemAudio: this.getRecordSystemAudio(),
       audioDeviceId: this.getAudioDeviceId(),
       lastSeenVersion: this.getLastSeenVersion(),
+      slackWebhookUrl: this.getSlackWebhookUrl(),
+      slackAutoShare: this.getSlackAutoShare(),
     };
   }
 }

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -452,7 +452,7 @@ IMPORTANT:
 - Keep the transcription in the original spoken language
 - Return ONLY the transcription text, no JSON formatting`;
 
-      let result;
+      let result: Awaited<ReturnType<typeof this.ai.models.generateContent>>;
       if (fileUri) {
         const mimeType = mimeTypeForExtension(path.extname(audioFilePath));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,6 @@ import {
   saveTranscription,
   updateTranscriptionStatus,
 } from './outputService';
-import { isLikelySlackWebhookUrl, SLACK_WEBHOOK_PREFIX, SlackService } from './slackService';
 import { ALL_FIELDS, type SearchField, searchTranscriptions } from './searchService';
 import { concatAudioFiles } from './services/audioConcatService';
 import { autoUpdaterService } from './services/autoUpdaterService';
@@ -48,6 +47,7 @@ import { notificationService } from './services/notificationService';
 import { fetchAllReleases, fetchReleaseNotes } from './services/releaseNotesService';
 import { SYSTEM_AUDIO_FORMAT, SystemAudioService } from './services/systemAudioService';
 import { SimpleAudioRecorder } from './simpleAudioRecorder';
+import { SLACK_WEBHOOK_PREFIX, SlackService, isLikelySlackWebhookUrl } from './slackService';
 
 // Enable macOS system-audio loopback capture so getDisplayMedia({audio: 'loopback'})
 // can pull Zoom/Meet participant audio alongside the mic.
@@ -1459,9 +1459,20 @@ ipcMain.handle(
         return { success: false, error: 'Slack webhook URL is not configured' };
       }
 
+      // For a historical resend, use the original meeting time from frontmatter
+      // so the Slack message shows when the meeting actually happened, not now.
+      let meetingDate = new Date();
+      if (isContainedTranscriptionPath(data.transcriptionPath)) {
+        const stored = await readTranscription(data.transcriptionPath).catch(() => null);
+        if (stored?.transcribedAt) {
+          const parsed = new Date(stored.transcribedAt);
+          if (!Number.isNaN(parsed.getTime())) meetingDate = parsed;
+        }
+      }
+
       const result = await service.sendMeetingSummary({
         title: data.title,
-        date: new Date(),
+        date: meetingDate,
         result: data.transcriptionData,
         notionUrl: data.notionUrl,
         notionError: data.notionError,
@@ -1469,8 +1480,10 @@ ipcMain.handle(
 
       if (isContainedTranscriptionPath(data.transcriptionPath)) {
         try {
+          // Preserve the previous successful slackSentAt on a failed resend;
+          // only the error field reflects the new failure.
           await updateTranscriptionStatus(data.transcriptionPath, {
-            slackSentAt: result.success ? result.sentAt : null,
+            ...(result.success ? { slackSentAt: result.sentAt } : {}),
             slackError: result.success ? null : result.error,
           });
         } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ import {
   saveTranscription,
   updateTranscriptionStatus,
 } from './outputService';
-import { isLikelySlackWebhookUrl, SlackService } from './slackService';
+import { isLikelySlackWebhookUrl, SLACK_WEBHOOK_PREFIX, SlackService } from './slackService';
 import { ALL_FIELDS, type SearchField, searchTranscriptions } from './searchService';
 import { concatAudioFiles } from './services/audioConcatService';
 import { autoUpdaterService } from './services/autoUpdaterService';
@@ -1408,8 +1408,6 @@ ipcMain.handle(
         data.audioFilePath,
       );
 
-      // Persist the Notion URL to the transcription folder so a later Slack
-      // resend (or any other follow-up) can include the link without re-uploading.
       if (result.success && result.url && data.transcriptionPath) {
         try {
           await updateTranscriptionStatus(data.transcriptionPath, {
@@ -1461,8 +1459,8 @@ ipcMain.handle(
       if (data.transcriptionPath) {
         try {
           await updateTranscriptionStatus(data.transcriptionPath, {
-            slackSentAt: result.success ? (result.sentAt ?? new Date().toISOString()) : null,
-            slackError: result.success ? null : (result.error ?? 'Unknown error'),
+            slackSentAt: result.success ? result.sentAt : null,
+            slackError: result.success ? null : result.error,
           });
         } catch (error) {
           console.error('Failed to persist Slack status to transcription:', error);
@@ -1487,7 +1485,7 @@ ipcMain.handle('test-slack-webhook', async (_, webhookUrl?: string) => {
     if (!isLikelySlackWebhookUrl(url)) {
       return {
         success: false,
-        error: 'URL must start with https://hooks.slack.com/services/',
+        error: `URL must start with ${SLACK_WEBHOOK_PREFIX}`,
       };
     }
     const service = new SlackService({ webhookUrl: url });

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,9 @@ import {
   readTranscription,
   sanitizeForPath,
   saveTranscription,
+  updateTranscriptionStatus,
 } from './outputService';
+import { isLikelySlackWebhookUrl, SlackService } from './slackService';
 import { ALL_FIELDS, type SearchField, searchTranscriptions } from './searchService';
 import { concatAudioFiles } from './services/audioConcatService';
 import { autoUpdaterService } from './services/autoUpdaterService';
@@ -77,6 +79,7 @@ const displayDetector = new DisplayDetectorService();
 let meetingAutoStartedRecording = false;
 let geminiService: GeminiService | null = null;
 let notionService: NotionService | null = null;
+let slackService: SlackService | null = null;
 let agentService: AgentService | null = null;
 
 function getAgentService(): AgentService | null {
@@ -1153,6 +1156,17 @@ function applyConfigSideEffects(changed: Partial<AppConfig>): void {
       notionService = new NotionService({ apiKey, databaseId });
     }
   }
+  if (changed.slackWebhookUrl !== undefined) {
+    slackService = null; // re-init lazily on next send
+  }
+}
+
+function getSlackService(): SlackService | null {
+  if (slackService) return slackService;
+  const url = configService.getSlackWebhookUrl();
+  if (!url || !isLikelySlackWebhookUrl(url)) return null;
+  slackService = new SlackService({ webhookUrl: url });
+  return slackService;
 }
 
 // Tell the renderer the config has changed out-of-band so it can re-read and
@@ -1341,10 +1355,10 @@ ipcMain.handle('transcribe-audio', async (_, filePath: string) => {
         await metadataService.saveMetadata(newFilePath, existingMetadata);
       }
 
-      return { success: true, data: result, newFilePath };
+      return { success: true, data: result, newFilePath, transcriptionPath };
     }
 
-    return { success: true, data: result };
+    return { success: true, data: result, transcriptionPath };
   } catch (error) {
     console.error('Error transcribing audio:', error);
     notificationService.notifyTranscriptionFailed(
@@ -1357,7 +1371,15 @@ ipcMain.handle('transcribe-audio', async (_, filePath: string) => {
 // Notion upload handler
 ipcMain.handle(
   'upload-to-notion',
-  async (_, data: { title: string; transcriptionData: any; audioFilePath?: string }) => {
+  async (
+    _,
+    data: {
+      title: string;
+      transcriptionData: any;
+      audioFilePath?: string;
+      transcriptionPath?: string;
+    },
+  ) => {
     try {
       console.log('Uploading to Notion:', data.title);
 
@@ -1386,6 +1408,18 @@ ipcMain.handle(
         data.audioFilePath,
       );
 
+      // Persist the Notion URL to the transcription folder so a later Slack
+      // resend (or any other follow-up) can include the link without re-uploading.
+      if (result.success && result.url && data.transcriptionPath) {
+        try {
+          await updateTranscriptionStatus(data.transcriptionPath, {
+            notionPageUrl: result.url,
+          });
+        } catch (error) {
+          console.error('Failed to persist Notion URL to transcription:', error);
+        }
+      }
+
       notificationService.notifyUploadComplete(data.title);
       return result;
     } catch (error) {
@@ -1395,6 +1429,74 @@ ipcMain.handle(
     }
   },
 );
+
+ipcMain.handle(
+  'send-to-slack',
+  async (
+    _,
+    data: {
+      title: string;
+      transcriptionData: any;
+      transcriptionPath?: string;
+      notionUrl?: string;
+      notionError?: string;
+    },
+  ) => {
+    try {
+      console.log('Sending to Slack:', data.title);
+
+      const service = getSlackService();
+      if (!service) {
+        return { success: false, error: 'Slack webhook URL is not configured' };
+      }
+
+      const result = await service.sendMeetingSummary({
+        title: data.title,
+        date: new Date(),
+        result: data.transcriptionData,
+        notionUrl: data.notionUrl,
+        notionError: data.notionError,
+      });
+
+      if (data.transcriptionPath) {
+        try {
+          await updateTranscriptionStatus(data.transcriptionPath, {
+            slackSentAt: result.success ? (result.sentAt ?? new Date().toISOString()) : null,
+            slackError: result.success ? null : (result.error ?? 'Unknown error'),
+          });
+        } catch (error) {
+          console.error('Failed to persist Slack status to transcription:', error);
+        }
+      }
+
+      return result;
+    } catch (error) {
+      console.error('Error sending to Slack:', error);
+      const message = error instanceof Error ? error.message : String(error);
+      return { success: false, error: message };
+    }
+  },
+);
+
+ipcMain.handle('test-slack-webhook', async (_, webhookUrl?: string) => {
+  try {
+    const url = (webhookUrl ?? configService.getSlackWebhookUrl() ?? '').trim();
+    if (!url) {
+      return { success: false, error: 'Slack webhook URL is not provided' };
+    }
+    if (!isLikelySlackWebhookUrl(url)) {
+      return {
+        success: false,
+        error: 'URL must start with https://hooks.slack.com/services/',
+      };
+    }
+    const service = new SlackService({ webhookUrl: url });
+    return await service.sendTestMessage();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { success: false, error: message };
+  }
+});
 
 // Open external URL
 ipcMain.handle('open-external', async (_, url: string) => {
@@ -1422,6 +1524,9 @@ ipcMain.handle('get-metadata', async (_, filePath: string) => {
             actionItems: transcription.actionItems,
             customFields: transcription.customFields ?? metadata.customFields,
             emoji: transcription.emoji,
+            notionPageUrl: transcription.notionPageUrl,
+            slackSentAt: transcription.slackSentAt,
+            slackError: transcription.slackError,
           },
         };
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ import { MenuBarManager } from './menuBarManager';
 import { NotionService } from './notionService';
 import {
   formatTimestamp,
+  getTranscriptionsDir,
   readTranscription,
   sanitizeForPath,
   saveTranscription,
@@ -1169,6 +1170,16 @@ function getSlackService(): SlackService | null {
   return slackService;
 }
 
+// Defense in depth: a renderer-supplied transcriptionPath could otherwise be
+// any path on disk and let an XSS-compromised renderer overwrite arbitrary
+// summary.md files via updateTranscriptionStatus.
+function isContainedTranscriptionPath(folderPath: string | undefined): folderPath is string {
+  if (!folderPath) return false;
+  const root = getTranscriptionsDir(app.getPath('userData'));
+  const resolved = path.resolve(folderPath);
+  return resolved === root || resolved.startsWith(root + path.sep);
+}
+
 // Tell the renderer the config has changed out-of-band so it can re-read and
 // re-render its UI state (toggle checkboxes etc.). Used by the agent flow.
 function broadcastConfigChanged(): void {
@@ -1408,7 +1419,7 @@ ipcMain.handle(
         data.audioFilePath,
       );
 
-      if (result.success && result.url && data.transcriptionPath) {
+      if (result.success && result.url && isContainedTranscriptionPath(data.transcriptionPath)) {
         try {
           await updateTranscriptionStatus(data.transcriptionPath, {
             notionPageUrl: result.url,
@@ -1456,7 +1467,7 @@ ipcMain.handle(
         notionError: data.notionError,
       });
 
-      if (data.transcriptionPath) {
+      if (isContainedTranscriptionPath(data.transcriptionPath)) {
         try {
           await updateTranscriptionStatus(data.transcriptionPath, {
             slackSentAt: result.success ? result.sentAt : null,

--- a/src/outputService.test.ts
+++ b/src/outputService.test.ts
@@ -9,6 +9,7 @@ import {
   readTranscription,
   sanitizeForPath,
   saveTranscription,
+  updateTranscriptionStatus,
 } from './outputService';
 import { makeTempDir, rmDir } from './test-helpers';
 
@@ -81,6 +82,55 @@ describe('saveTranscription with mergedFrom', () => {
   it('omits the Sources section when mergedFrom is empty', () => {
     const body = formatSummary(baseResult, 'Solo Meeting');
     assert.doesNotMatch(body, /## Sources/);
+  });
+});
+
+describe('updateTranscriptionStatus', () => {
+  it('writes Notion URL and Slack send timestamp without losing the markdown body', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Status Test',
+      result: baseResult,
+      dataPath,
+    });
+
+    const before = fs.readFileSync(path.join(folderPath, 'summary.md'), 'utf-8');
+    const bodyBefore = before.split('\n---').slice(1).join('\n---');
+
+    await updateTranscriptionStatus(folderPath, {
+      notionPageUrl: 'https://www.notion.so/abc123',
+      slackSentAt: '2026-04-30T09:30:00Z',
+    });
+
+    const after = fs.readFileSync(path.join(folderPath, 'summary.md'), 'utf-8');
+    const bodyAfter = after.split('\n---').slice(1).join('\n---');
+    assert.equal(bodyAfter, bodyBefore, 'body should be preserved verbatim');
+
+    const data = await readTranscription(folderPath);
+    assert.equal(data!.notionPageUrl, 'https://www.notion.so/abc123');
+    assert.equal(data!.slackSentAt, '2026-04-30T09:30:00Z');
+    assert.equal(data!.slackError, undefined);
+  });
+
+  it('clears a field when passed null', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Status Test 2',
+      result: baseResult,
+      dataPath,
+    });
+
+    await updateTranscriptionStatus(folderPath, {
+      slackSentAt: '2026-04-30T09:30:00Z',
+      slackError: 'temporary failure',
+    });
+    let data = await readTranscription(folderPath);
+    assert.equal(data!.slackError, 'temporary failure');
+
+    await updateTranscriptionStatus(folderPath, { slackError: null });
+    data = await readTranscription(folderPath);
+    assert.equal(data!.slackError, undefined);
+    assert.equal(data!.slackSentAt, '2026-04-30T09:30:00Z');
   });
 });
 

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -165,16 +165,16 @@ function yamlQuote(value: string): string {
 
 export function parseFrontmatter(content: string): { meta: Record<string, unknown>; body: string } {
   // Normalize line endings
-  content = content.replace(/\r\n/g, '\n');
-  if (!content.startsWith('---\n')) {
-    return { meta: {}, body: content };
+  const normalized = content.replace(/\r\n/g, '\n');
+  if (!normalized.startsWith('---\n')) {
+    return { meta: {}, body: normalized };
   }
-  const end = content.indexOf('\n---', 4);
+  const end = normalized.indexOf('\n---', 4);
   if (end === -1) {
-    return { meta: {}, body: content };
+    return { meta: {}, body: normalized };
   }
-  const yamlBlock = content.slice(4, end);
-  const body = content.slice(end + 4).trimStart();
+  const yamlBlock = normalized.slice(4, end);
+  const body = normalized.slice(end + 4).trimStart();
 
   const meta: Record<string, unknown> = {};
   let currentArrayKey: string | null = null;
@@ -454,21 +454,16 @@ export async function updateTranscriptionStatus(
     }
   }
 
+  // Spread first so any unknown frontmatter keys (added by future writers, or
+  // by hand-edits) survive the round-trip; named fields override with proper
+  // typing and defaults.
   const merged: SummaryFrontmatter = {
+    ...(meta as unknown as Partial<SummaryFrontmatter>),
     title: (meta.title as string) || path.basename(folderPath),
-    suggestedTitle: meta.suggestedTitle as string | undefined,
     summary: (meta.summary as string) || '',
     transcript: (meta.transcript as string) || '',
-    keyPoints: meta.keyPoints as string[] | undefined,
-    actionItems: meta.actionItems as string[] | undefined,
-    customFields,
-    audioFilePath: meta.audioFilePath as string | undefined,
     transcribedAt: (meta.transcribedAt as string) || new Date().toISOString(),
-    emoji: meta.emoji as string | undefined,
-    mergedFrom: meta.mergedFrom as string[] | undefined,
-    notionPageUrl: meta.notionPageUrl as string | undefined,
-    slackSentAt: meta.slackSentAt as string | undefined,
-    slackError: meta.slackError as string | undefined,
+    customFields,
   };
 
   applyStatusUpdate(merged, 'notionPageUrl', updates.notionPageUrl);

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -107,6 +107,9 @@ interface SummaryFrontmatter {
   transcribedAt: string;
   emoji?: string;
   mergedFrom?: string[];
+  notionPageUrl?: string;
+  slackSentAt?: string;
+  slackError?: string;
 }
 
 function buildFrontmatter(meta: SummaryFrontmatter): string {
@@ -138,6 +141,15 @@ function buildFrontmatter(meta: SummaryFrontmatter): string {
   if (meta.mergedFrom?.length) {
     lines.push('mergedFrom:');
     for (const src of meta.mergedFrom) lines.push(`  - ${yamlQuote(src)}`);
+  }
+  if (meta.notionPageUrl) {
+    lines.push(`notionPageUrl: ${yamlQuote(meta.notionPageUrl)}`);
+  }
+  if (meta.slackSentAt) {
+    lines.push(`slackSentAt: ${yamlQuote(meta.slackSentAt)}`);
+  }
+  if (meta.slackError) {
+    lines.push(`slackError: ${yamlQuote(meta.slackError)}`);
   }
   lines.push('---');
   return lines.join('\n');
@@ -359,6 +371,9 @@ export interface ReadTranscriptionResult {
   transcribedAt?: string;
   emoji?: string;
   mergedFrom?: string[];
+  notionPageUrl?: string;
+  slackSentAt?: string;
+  slackError?: string;
 }
 
 /**
@@ -399,8 +414,80 @@ export async function readTranscription(
       transcribedAt: meta.transcribedAt as string | undefined,
       emoji: meta.emoji as string | undefined,
       mergedFrom: meta.mergedFrom as string[] | undefined,
+      notionPageUrl: meta.notionPageUrl as string | undefined,
+      slackSentAt: meta.slackSentAt as string | undefined,
+      slackError: meta.slackError as string | undefined,
     };
   } catch {
     return null;
   }
+}
+
+export interface TranscriptionStatusUpdate {
+  notionPageUrl?: string | null;
+  slackSentAt?: string | null;
+  slackError?: string | null;
+}
+
+/**
+ * Update tracking fields (Notion URL, Slack send status) in summary.md frontmatter
+ * without rewriting the markdown body. Pass `null` to clear a field, `undefined` to leave unchanged.
+ */
+export async function updateTranscriptionStatus(
+  folderPath: string,
+  updates: TranscriptionStatusUpdate,
+): Promise<void> {
+  const summaryPath = path.join(folderPath, 'summary.md');
+  const content = await fs.promises.readFile(summaryPath, 'utf-8');
+  const { meta, body } = parseFrontmatter(content);
+
+  // Recover customFields shape (parseFrontmatter returns it as a JSON string)
+  let customFields: Record<string, unknown> | undefined;
+  if (meta.customFields) {
+    try {
+      customFields =
+        typeof meta.customFields === 'string'
+          ? JSON.parse(meta.customFields as string)
+          : (meta.customFields as Record<string, unknown>);
+    } catch {
+      customFields = undefined;
+    }
+  }
+
+  const merged: SummaryFrontmatter = {
+    title: (meta.title as string) || path.basename(folderPath),
+    suggestedTitle: meta.suggestedTitle as string | undefined,
+    summary: (meta.summary as string) || '',
+    transcript: (meta.transcript as string) || '',
+    keyPoints: meta.keyPoints as string[] | undefined,
+    actionItems: meta.actionItems as string[] | undefined,
+    customFields,
+    audioFilePath: meta.audioFilePath as string | undefined,
+    transcribedAt: (meta.transcribedAt as string) || new Date().toISOString(),
+    emoji: meta.emoji as string | undefined,
+    mergedFrom: meta.mergedFrom as string[] | undefined,
+    notionPageUrl: meta.notionPageUrl as string | undefined,
+    slackSentAt: meta.slackSentAt as string | undefined,
+    slackError: meta.slackError as string | undefined,
+  };
+
+  applyStatusUpdate(merged, 'notionPageUrl', updates.notionPageUrl);
+  applyStatusUpdate(merged, 'slackSentAt', updates.slackSentAt);
+  applyStatusUpdate(merged, 'slackError', updates.slackError);
+
+  const frontmatter = buildFrontmatter(merged);
+  await fs.promises.writeFile(summaryPath, `${frontmatter}\n\n${body}`, 'utf-8');
+}
+
+function applyStatusUpdate(
+  meta: SummaryFrontmatter,
+  key: 'notionPageUrl' | 'slackSentAt' | 'slackError',
+  value: string | null | undefined,
+): void {
+  if (value === undefined) return;
+  if (value === null || value === '') {
+    delete meta[key];
+    return;
+  }
+  meta[key] = value;
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -23,11 +23,26 @@ contextBridge.exposeInMainWorld('electronAPI', {
     summaryPrompt?: string;
     recordSystemAudio?: boolean;
     audioDeviceId?: string;
+    slackWebhookUrl?: string;
+    slackAutoShare?: boolean;
   }) => ipcRenderer.invoke('save-config', config),
   getConfig: () => ipcRenderer.invoke('get-config'),
   transcribeAudio: (filePath: string) => ipcRenderer.invoke('transcribe-audio', filePath),
-  uploadToNotion: (data: { title: string; transcriptionData: any; audioFilePath?: string }) =>
-    ipcRenderer.invoke('upload-to-notion', data),
+  uploadToNotion: (data: {
+    title: string;
+    transcriptionData: any;
+    audioFilePath?: string;
+    transcriptionPath?: string;
+  }) => ipcRenderer.invoke('upload-to-notion', data),
+  sendToSlack: (data: {
+    title: string;
+    transcriptionData: any;
+    transcriptionPath?: string;
+    notionUrl?: string;
+    notionError?: string;
+  }) => ipcRenderer.invoke('send-to-slack', data),
+  testSlackWebhook: (webhookUrl?: string) =>
+    ipcRenderer.invoke('test-slack-webhook', webhookUrl),
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
   openRecordingsFolder: () => ipcRenderer.invoke('open-recordings-folder'),
   showInFinder: (filePath: string) => ipcRenderer.invoke('show-in-finder', filePath),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -41,8 +41,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     notionUrl?: string;
     notionError?: string;
   }) => ipcRenderer.invoke('send-to-slack', data),
-  testSlackWebhook: (webhookUrl?: string) =>
-    ipcRenderer.invoke('test-slack-webhook', webhookUrl),
+  testSlackWebhook: (webhookUrl?: string) => ipcRenderer.invoke('test-slack-webhook', webhookUrl),
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
   openRecordingsFolder: () => ipcRenderer.invoke('open-recordings-folder'),
   showInFinder: (filePath: string) => ipcRenderer.invoke('show-in-finder', filePath),

--- a/src/slackService.test.ts
+++ b/src/slackService.test.ts
@@ -1,11 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import type { TranscriptionResult } from './geminiService';
-import {
-  buildMeetingSummaryPayload,
-  isLikelySlackWebhookUrl,
-  SlackService,
-} from './slackService';
+import { SlackService, buildMeetingSummaryPayload, isLikelySlackWebhookUrl } from './slackService';
 
 const sampleResult: TranscriptionResult = {
   transcript: 'A long transcript that should not be sent to Slack.',
@@ -19,10 +15,7 @@ const sampleResult: TranscriptionResult = {
 
 describe('isLikelySlackWebhookUrl', () => {
   it('accepts valid hooks.slack.com URLs', () => {
-    assert.equal(
-      isLikelySlackWebhookUrl('https://hooks.slack.com/services/T0/B0/abc'),
-      true,
-    );
+    assert.equal(isLikelySlackWebhookUrl('https://hooks.slack.com/services/T0/B0/abc'), true);
   });
 
   it('rejects unrelated hosts and schemes', () => {
@@ -54,8 +47,9 @@ describe('buildMeetingSummaryPayload', () => {
       date: new Date(),
       result: sampleResult,
     });
-    const sectionBlock = (payload.blocks as Array<{ type: string; text?: { text?: string } }>)
-      .find((b) => b.type === 'section');
+    const sectionBlock = (payload.blocks as Array<{ type: string; text?: { text?: string } }>).find(
+      (b) => b.type === 'section',
+    );
     const text = sectionBlock?.text?.text ?? '';
     assert.equal(text.split('\n').length, 3);
   });
@@ -66,8 +60,9 @@ describe('buildMeetingSummaryPayload', () => {
       date: new Date(),
       result: sampleResult,
     });
-    const keyPointsBlock = (payload.blocks as Array<{ type: string; text?: { text?: string } }>)
-      .find((b) => String(b.text?.text ?? '').startsWith('*Key points*'));
+    const keyPointsBlock = (
+      payload.blocks as Array<{ type: string; text?: { text?: string } }>
+    ).find((b) => String(b.text?.text ?? '').startsWith('*Key points*'));
     assert.ok(keyPointsBlock, 'key points block should exist');
     const lines = String(keyPointsBlock?.text?.text ?? '').split('\n');
     // Expect: header line + 3 bullets

--- a/src/slackService.test.ts
+++ b/src/slackService.test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import type { TranscriptionResult } from './geminiService';
+import {
+  buildMeetingSummaryPayload,
+  isLikelySlackWebhookUrl,
+  SlackService,
+} from './slackService';
+
+const sampleResult: TranscriptionResult = {
+  transcript: 'A long transcript that should not be sent to Slack.',
+  summary:
+    'Line one of the meeting summary in Korean.\nLine two with another point.\nLine three closing.',
+  keyPoints: ['First decision', 'Second decision', 'Third decision', 'Fourth (should be dropped)'],
+  actionItems: ['Action 1', 'Action 2'],
+  emoji: '📝',
+  suggestedTitle: 'Roadmap Review',
+};
+
+describe('isLikelySlackWebhookUrl', () => {
+  it('accepts valid hooks.slack.com URLs', () => {
+    assert.equal(
+      isLikelySlackWebhookUrl('https://hooks.slack.com/services/T0/B0/abc'),
+      true,
+    );
+  });
+
+  it('rejects unrelated hosts and schemes', () => {
+    assert.equal(isLikelySlackWebhookUrl('http://hooks.slack.com/services/abc'), false);
+    assert.equal(isLikelySlackWebhookUrl('https://example.com/hook'), false);
+    assert.equal(isLikelySlackWebhookUrl(''), false);
+  });
+});
+
+describe('buildMeetingSummaryPayload', () => {
+  it('includes header with emoji and date context', () => {
+    const date = new Date('2026-04-30T09:30:00Z');
+    const payload = buildMeetingSummaryPayload({
+      title: 'Roadmap Review',
+      date,
+      result: sampleResult,
+    });
+
+    const blocks = payload.blocks as Array<{ type: string; text?: { text?: string } }>;
+    assert.equal(blocks[0]?.type, 'header');
+    assert.match(String(blocks[0]?.text?.text ?? ''), /Roadmap Review/);
+    assert.equal(blocks[1]?.type, 'context');
+    assert.match(payload.text, /Roadmap Review/);
+  });
+
+  it('clamps the summary preview to three lines', () => {
+    const payload = buildMeetingSummaryPayload({
+      title: 'Roadmap Review',
+      date: new Date(),
+      result: sampleResult,
+    });
+    const sectionBlock = (payload.blocks as Array<{ type: string; text?: { text?: string } }>)
+      .find((b) => b.type === 'section');
+    const text = sectionBlock?.text?.text ?? '';
+    assert.equal(text.split('\n').length, 3);
+  });
+
+  it('truncates key points to the first three entries', () => {
+    const payload = buildMeetingSummaryPayload({
+      title: 'Roadmap Review',
+      date: new Date(),
+      result: sampleResult,
+    });
+    const keyPointsBlock = (payload.blocks as Array<{ type: string; text?: { text?: string } }>)
+      .find((b) => String(b.text?.text ?? '').startsWith('*Key points*'));
+    assert.ok(keyPointsBlock, 'key points block should exist');
+    const lines = String(keyPointsBlock?.text?.text ?? '').split('\n');
+    // Expect: header line + 3 bullets
+    assert.equal(lines.length, 4);
+    assert.ok(!lines.join('\n').includes('Fourth'));
+  });
+
+  it('emits a Notion button when notionUrl is provided', () => {
+    const payload = buildMeetingSummaryPayload({
+      title: 'Roadmap Review',
+      date: new Date(),
+      result: sampleResult,
+      notionUrl: 'https://www.notion.so/page-id',
+    });
+    const blocks = payload.blocks as Array<{
+      type: string;
+      elements?: Array<{ type: string; url?: string }>;
+    }>;
+    const actions = blocks.find((b) => b.type === 'actions');
+    assert.ok(actions, 'actions block should be present');
+    assert.equal(actions?.elements?.[0]?.url, 'https://www.notion.so/page-id');
+  });
+
+  it('emits a Notion-failure context block when notionError is provided without URL', () => {
+    const payload = buildMeetingSummaryPayload({
+      title: 'Roadmap Review',
+      date: new Date(),
+      result: sampleResult,
+      notionError: 'invalid_grant',
+    });
+    const blocks = payload.blocks as Array<{
+      type: string;
+      elements?: Array<{ text?: string }>;
+    }>;
+    const contextBlocks = blocks.filter((b) => b.type === 'context');
+    const failureContext = contextBlocks.find((b) =>
+      String(b.elements?.[0]?.text ?? '').includes('Notion sync failed'),
+    );
+    assert.ok(failureContext, 'failure context block should be present');
+  });
+});
+
+describe('SlackService', () => {
+  const originalFetch = globalThis.fetch;
+  let lastRequest: { url: string; init?: RequestInit } | null = null;
+
+  beforeEach(() => {
+    lastRequest = null;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('rejects construction with a non-Slack URL', () => {
+    assert.throws(
+      () => new SlackService({ webhookUrl: 'https://example.com/hook' }),
+      /must start with/,
+    );
+  });
+
+  it('returns sentAt on a 200 response', async () => {
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      lastRequest = { url, init };
+      return new Response('ok', { status: 200 });
+    }) as typeof fetch;
+
+    const service = new SlackService({
+      webhookUrl: 'https://hooks.slack.com/services/T0/B0/abc',
+    });
+    const result = await service.sendMeetingSummary({
+      title: 'Roadmap',
+      date: new Date(),
+      result: sampleResult,
+      notionUrl: 'https://www.notion.so/x',
+    });
+
+    assert.equal(result.success, true);
+    assert.ok(result.sentAt, 'sentAt should be set on success');
+    assert.equal(lastRequest?.url, 'https://hooks.slack.com/services/T0/B0/abc');
+    assert.equal(lastRequest?.init?.method, 'POST');
+  });
+
+  it('returns success: false with status code on a non-OK response', async () => {
+    globalThis.fetch = (async () =>
+      new Response('invalid_payload', { status: 400 })) as typeof fetch;
+
+    const service = new SlackService({
+      webhookUrl: 'https://hooks.slack.com/services/T0/B0/abc',
+    });
+    const result = await service.sendMeetingSummary({
+      title: 'Roadmap',
+      date: new Date(),
+      result: sampleResult,
+    });
+
+    assert.equal(result.success, false);
+    assert.match(String(result.error ?? ''), /400/);
+    assert.match(String(result.error ?? ''), /invalid_payload/);
+  });
+
+  it('captures fetch errors', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('network down');
+    }) as typeof fetch;
+
+    const service = new SlackService({
+      webhookUrl: 'https://hooks.slack.com/services/T0/B0/abc',
+    });
+    const result = await service.sendTestMessage();
+
+    assert.equal(result.success, false);
+    assert.equal(result.error, 'network down');
+  });
+});

--- a/src/slackService.ts
+++ b/src/slackService.ts
@@ -28,6 +28,7 @@ const KEY_POINTS_PREVIEW = 3;
 const NOTION_ERROR_PREVIEW_MAX_CHARS = 200;
 const FALLBACK_TEXT_MAX_CHARS = 1000;
 const ERROR_BODY_PREVIEW_MAX_CHARS = 200;
+const REQUEST_TIMEOUT_MS = 15_000;
 
 export function isLikelySlackWebhookUrl(url: string): boolean {
   return SLACK_HOST_PATTERN.test(url.trim());
@@ -70,6 +71,7 @@ export class SlackService {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
 
       if (!response.ok) {
@@ -83,6 +85,9 @@ export class SlackService {
 
       return { success: true, sentAt: new Date().toISOString() };
     } catch (error) {
+      if (error instanceof Error && error.name === 'TimeoutError') {
+        return { success: false, error: `Slack request timed out after ${REQUEST_TIMEOUT_MS}ms` };
+      }
       const message = error instanceof Error ? error.message : String(error);
       return { success: false, error: message };
     }

--- a/src/slackService.ts
+++ b/src/slackService.ts
@@ -12,16 +12,22 @@ export interface SlackSendOptions {
   notionError?: string;
 }
 
-export interface SlackSendResult {
-  success: boolean;
-  error?: string;
-  sentAt?: string;
-}
+export type SlackSendResult =
+  | { success: true; sentAt: string }
+  | { success: false; error: string };
 
-const SLACK_HOST_PATTERN = /^https:\/\/hooks\.slack\.com\/services\//;
+export const SLACK_WEBHOOK_PREFIX = 'https://hooks.slack.com/services/';
+
+const SLACK_HOST_PATTERN = new RegExp(
+  `^${SLACK_WEBHOOK_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+);
+const HEADER_MAX_CHARS = 150;
 const SUMMARY_PREVIEW_MAX_CHARS = 600;
 const SUMMARY_PREVIEW_MAX_LINES = 3;
 const KEY_POINTS_PREVIEW = 3;
+const NOTION_ERROR_PREVIEW_MAX_CHARS = 200;
+const FALLBACK_TEXT_MAX_CHARS = 1000;
+const ERROR_BODY_PREVIEW_MAX_CHARS = 200;
 
 export function isLikelySlackWebhookUrl(url: string): boolean {
   return SLACK_HOST_PATTERN.test(url.trim());
@@ -32,9 +38,7 @@ export class SlackService {
 
   constructor(config: SlackConfig) {
     if (!isLikelySlackWebhookUrl(config.webhookUrl)) {
-      throw new Error(
-        'Slack webhook URL must start with https://hooks.slack.com/services/',
-      );
+      throw new Error(`Slack webhook URL must start with ${SLACK_WEBHOOK_PREFIX}`);
     }
     this.webhookUrl = config.webhookUrl.trim();
   }
@@ -70,7 +74,7 @@ export class SlackService {
 
       if (!response.ok) {
         const body = await response.text().catch(() => '');
-        const trimmed = body.slice(0, 200);
+        const trimmed = body.slice(0, ERROR_BODY_PREVIEW_MAX_CHARS);
         return {
           success: false,
           error: `Slack responded ${response.status}${trimmed ? `: ${trimmed}` : ''}`,
@@ -91,7 +95,7 @@ export function buildMeetingSummaryPayload(options: SlackSendOptions): {
 } {
   const { title, date, result, notionUrl, notionError } = options;
   const emoji = (result.emoji || '📝').trim();
-  const headerText = truncate(`${emoji} ${title}`, 150);
+  const headerText = truncate(`${emoji} ${title}`, HEADER_MAX_CHARS);
   const dateLabel = formatDate(date);
   const summaryPreview = clampLines(
     result.summary || '',
@@ -119,7 +123,7 @@ export function buildMeetingSummaryPayload(options: SlackSendOptions): {
 
   const keyPoints = (result.keyPoints || [])
     .slice(0, KEY_POINTS_PREVIEW)
-    .map((p) => `• ${escapeMrkdwn(p)}`)
+    .map((p) => `• ${escapeSlackText(p)}`)
     .join('\n');
   if (keyPoints) {
     blocks.push({
@@ -145,7 +149,7 @@ export function buildMeetingSummaryPayload(options: SlackSendOptions): {
       elements: [
         {
           type: 'mrkdwn',
-          text: `:warning: Notion sync failed: ${escapeMrkdwn(truncate(notionError, 200))}`,
+          text: `:warning: Notion sync failed: ${escapeSlackText(truncate(notionError, NOTION_ERROR_PREVIEW_MAX_CHARS))}`,
         },
       ],
     });
@@ -154,7 +158,7 @@ export function buildMeetingSummaryPayload(options: SlackSendOptions): {
   const fallbackParts = [`${emoji} ${title}`, dateLabel];
   if (summaryPreview) fallbackParts.push(summaryPreview);
   if (notionUrl) fallbackParts.push(notionUrl);
-  const text = truncate(fallbackParts.join(' — '), 1000);
+  const text = truncate(fallbackParts.join(' — '), FALLBACK_TEXT_MAX_CHARS);
 
   return { text, blocks };
 }
@@ -179,7 +183,9 @@ function formatDate(date: Date): string {
   return `${yyyy}-${mm}-${dd} ${hh}:${mi}`;
 }
 
-function escapeMrkdwn(value: string): string {
+// Slack mrkdwn requires HTML-style entity escaping for `<`, `>`, `&` to prevent
+// it from interpreting them as link syntax (`<url|label>`) or entity refs.
+function escapeSlackText(value: string): string {
   return value.replace(/[<>&]/g, (ch) => {
     if (ch === '<') return '&lt;';
     if (ch === '>') return '&gt;';

--- a/src/slackService.ts
+++ b/src/slackService.ts
@@ -1,0 +1,188 @@
+import type { TranscriptionResult } from './geminiService';
+
+export interface SlackConfig {
+  webhookUrl: string;
+}
+
+export interface SlackSendOptions {
+  title: string;
+  date: Date;
+  result: TranscriptionResult;
+  notionUrl?: string;
+  notionError?: string;
+}
+
+export interface SlackSendResult {
+  success: boolean;
+  error?: string;
+  sentAt?: string;
+}
+
+const SLACK_HOST_PATTERN = /^https:\/\/hooks\.slack\.com\/services\//;
+const SUMMARY_PREVIEW_MAX_CHARS = 600;
+const SUMMARY_PREVIEW_MAX_LINES = 3;
+const KEY_POINTS_PREVIEW = 3;
+
+export function isLikelySlackWebhookUrl(url: string): boolean {
+  return SLACK_HOST_PATTERN.test(url.trim());
+}
+
+export class SlackService {
+  private webhookUrl: string;
+
+  constructor(config: SlackConfig) {
+    if (!isLikelySlackWebhookUrl(config.webhookUrl)) {
+      throw new Error(
+        'Slack webhook URL must start with https://hooks.slack.com/services/',
+      );
+    }
+    this.webhookUrl = config.webhookUrl.trim();
+  }
+
+  async sendMeetingSummary(options: SlackSendOptions): Promise<SlackSendResult> {
+    const payload = buildMeetingSummaryPayload(options);
+    return this.post(payload);
+  }
+
+  async sendTestMessage(): Promise<SlackSendResult> {
+    const payload = {
+      text: 'Listener.AI connection test',
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: ':white_check_mark: *Listener.AI* connection test successful.',
+          },
+        },
+      ],
+    };
+    return this.post(payload);
+  }
+
+  private async post(payload: unknown): Promise<SlackSendResult> {
+    try {
+      const response = await fetch(this.webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        const trimmed = body.slice(0, 200);
+        return {
+          success: false,
+          error: `Slack responded ${response.status}${trimmed ? `: ${trimmed}` : ''}`,
+        };
+      }
+
+      return { success: true, sentAt: new Date().toISOString() };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { success: false, error: message };
+    }
+  }
+}
+
+export function buildMeetingSummaryPayload(options: SlackSendOptions): {
+  text: string;
+  blocks: unknown[];
+} {
+  const { title, date, result, notionUrl, notionError } = options;
+  const emoji = (result.emoji || '📝').trim();
+  const headerText = truncate(`${emoji} ${title}`, 150);
+  const dateLabel = formatDate(date);
+  const summaryPreview = clampLines(
+    result.summary || '',
+    SUMMARY_PREVIEW_MAX_LINES,
+    SUMMARY_PREVIEW_MAX_CHARS,
+  );
+
+  const blocks: unknown[] = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: headerText, emoji: true },
+    },
+    {
+      type: 'context',
+      elements: [{ type: 'mrkdwn', text: dateLabel }],
+    },
+  ];
+
+  if (summaryPreview) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: summaryPreview },
+    });
+  }
+
+  const keyPoints = (result.keyPoints || [])
+    .slice(0, KEY_POINTS_PREVIEW)
+    .map((p) => `• ${escapeMrkdwn(p)}`)
+    .join('\n');
+  if (keyPoints) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `*Key points*\n${keyPoints}` },
+    });
+  }
+
+  if (notionUrl) {
+    blocks.push({
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'View in Notion', emoji: true },
+          url: notionUrl,
+        },
+      ],
+    });
+  } else if (notionError) {
+    blocks.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `:warning: Notion sync failed: ${escapeMrkdwn(truncate(notionError, 200))}`,
+        },
+      ],
+    });
+  }
+
+  const fallbackParts = [`${emoji} ${title}`, dateLabel];
+  if (summaryPreview) fallbackParts.push(summaryPreview);
+  if (notionUrl) fallbackParts.push(notionUrl);
+  const text = truncate(fallbackParts.join(' — '), 1000);
+
+  return { text, blocks };
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1)}…`;
+}
+
+function clampLines(value: string, maxLines: number, maxChars: number): string {
+  const lines = value.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  const slice = lines.slice(0, maxLines).join('\n');
+  return truncate(slice, maxChars);
+}
+
+function formatDate(date: Date): string {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mi = String(date.getMinutes()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi}`;
+}
+
+function escapeMrkdwn(value: string): string {
+  return value.replace(/[<>&]/g, (ch) => {
+    if (ch === '<') return '&lt;';
+    if (ch === '>') return '&gt;';
+    return '&amp;';
+  });
+}

--- a/src/slackService.ts
+++ b/src/slackService.ts
@@ -12,9 +12,7 @@ export interface SlackSendOptions {
   notionError?: string;
 }
 
-export type SlackSendResult =
-  | { success: true; sentAt: string }
-  | { success: false; error: string };
+export type SlackSendResult = { success: true; sentAt: string } | { success: false; error: string };
 
 export const SLACK_WEBHOOK_PREFIX = 'https://hooks.slack.com/services/';
 


### PR DESCRIPTION
## Summary
- Adds Slack Incoming Webhook integration following the existing Notion BYOK pattern: each user pastes their own webhook URL, no backend or OAuth required
- Auto mode posts a Block Kit summary (header, 3-line preview, key points, "View in Notion" button) after each meeting when `slackAutoShare` is enabled
- Manual "Send to Slack" button in the transcription modal mirrors the Notion upload affordance; `slackSentAt` is persisted in `summary.md` frontmatter so a resend prompts confirmation

Closes #102.

## Notable touches
- New `SlackService` (`src/slackService.ts`) — webhook POST + Block Kit payload builder + `sendTestMessage()`. No new npm dependency; uses built-in `fetch`
- `updateTranscriptionStatus()` in `outputService.ts` updates frontmatter (Notion URL, `slackSentAt`, `slackError`) without rewriting the markdown body
- `transcribe-audio` IPC now returns `transcriptionPath` so renderer flows can attach Notion URL + Slack send status to the right transcription folder
- Settings modal: webhook URL input (password type, never logged), auto-share checkbox, "Get Webhook URL" deep-link to `api.slack.com/apps?new_app=1`, collapsible 6-step setup help, "Send Test Message" verifies the URL before save
- Webhook URL validation rejects anything not under `https://hooks.slack.com/services/`

## Test plan
- [x] `pnpm test` — 72/72 passing (11 new SlackService tests, 2 new `updateTranscriptionStatus` tests)
- [x] `tsc --noEmit` for both main and renderer
- [x] Manual: auto mode flow records → transcribes → uploads to Notion → posts to Slack with the Notion link
- [ ] Manual: settings UI test message + Get Webhook URL deep link
- [ ] Manual: "Send to Slack" button in saved transcription modal, including resend-confirmation when `slackSentAt` is already set
- [ ] Manual: degraded path when Notion sync fails — Slack still receives the summary with a "Notion sync failed" notice

## Future (out of scope)
- Multiple webhooks per user (channel routing) — single webhook per user for now; spec'd in #102 as the OAuth/backend track
- CLI command for Slack resend

🤖 Generated with [Claude Code](https://claude.com/claude-code)