### PR TITLE
Add --version, expanded config CLI, and config unset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,13 +77,20 @@ listener export <ref> [<path>] [--json] [--transcript]
                                      Export a transcription
 listener search <query> [--limit <n>] [--transcript] [--field <name>]
                                      Search past transcriptions
+listener merge <ref1> <ref2> [<ref3>...] [--title <t>]
+                                     Concat source audio of two or more notes,
+                                     re-transcribe end-to-end, save as a new note
 listener ask <question> [--ref <ref>]
                                      Ask the AI agent about meetings or settings
-listener config list|get|set|path    Manage configuration
+listener config list|get|set|unset|path
+                                     Manage configuration
+listener --version                   Print CLI version
+listener --help                      Show usage
 ```
 
 - `<ref>` is either an index from `listener list` or a transcription folder name.
 - `--field` accepts: `title`, `summary`, `keyPoints`, `actionItems`, `transcript`, `all`.
+- `config set` / `config unset` accept the keys listed in the Configuration table below, except `audioDeviceId` (UI-only) and `lastSeenVersion` (managed by the app).
 - CLI and GUI share the same `config.json` in the app data directory.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -41,8 +41,13 @@ listener config set notionDatabaseId <your-id>
 ```bash
 listener recording.mp3                # Transcribe to default output dir
 listener recording.m4a --output ./    # Transcribe to current directory
-listener config list                  # Show all config values
+listener config list                  # Show all config values (secrets masked)
+listener config get <key>             # Print one config value
+listener config set <key> <value>     # Set a config value
+listener config unset <key>           # Clear a config value (falls back to default)
 listener config path                  # Print config file path
+listener --version                    # Print CLI version
+listener --help                       # Show usage
 ```
 
 Supported formats: mp3, m4a, wav, ogg, flac, aac, wma, opus, webm

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -25,6 +25,122 @@ before(() => {
 
 after(() => rmDir(dataPath));
 
+describe('listener CLI basics', () => {
+  let basicsDataPath: string;
+
+  before(() => {
+    basicsDataPath = makeTempDir('cli-basics');
+  });
+
+  after(() => rmDir(basicsDataPath));
+
+  function runCli(
+    args: string[],
+  ): Promise<{ stdout: string; stderr: string; code: number | null }> {
+    return new Promise((resolve) => {
+      const { spawn } = require('child_process') as typeof import('child_process');
+      const child = spawn('node', [cliPath, ...args], {
+        env: {
+          ...process.env,
+          NODE_ENV: 'test',
+          LISTENER_DATA_PATH: basicsDataPath,
+        },
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (d: Buffer) => {
+        stdout += d.toString();
+      });
+      child.stderr.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      child.on('close', (code: number | null) => {
+        resolve({ stdout, stderr, code });
+      });
+    });
+  }
+
+  it('--version prints version on stdout and exits 0', async () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'),
+    ) as { version: string };
+    const { stdout, code } = await runCli(['--version']);
+    assert.equal(code, 0);
+    assert.equal(stdout.trim(), `listener ${pkg.version}`);
+  });
+
+  it('-V is an alias for --version', async () => {
+    const { stdout, code } = await runCli(['-V']);
+    assert.equal(code, 0);
+    assert.match(stdout, /^listener \d/);
+  });
+
+  it('--help exits 0 and writes to stdout', async () => {
+    const { stdout, stderr, code } = await runCli(['--help']);
+    assert.equal(code, 0);
+    assert.match(stdout, /Usage: listener/);
+    assert.equal(stderr, '');
+  });
+
+  it('no args exits 1 and writes to stderr', async () => {
+    const { stdout, stderr, code } = await runCli([]);
+    assert.equal(code, 1);
+    assert.match(stderr, /Usage: listener/);
+    assert.equal(stdout, '');
+  });
+
+  it('config set + get round-trips knownWords as comma-separated', async () => {
+    const set = await runCli(['config', 'set', 'knownWords', 'foo, bar ,baz']);
+    assert.equal(set.code, 0);
+    const get = await runCli(['config', 'get', 'knownWords']);
+    assert.equal(get.code, 0);
+    assert.equal(get.stdout.trim(), 'foo,bar,baz');
+  });
+
+  it('config set rejects invalid boolean', async () => {
+    const { stderr, code } = await runCli(['config', 'set', 'recordSystemAudio', 'yes']);
+    assert.equal(code, 1);
+    assert.match(stderr, /must be "true" or "false"/);
+  });
+
+  it('config set + get round-trips boolean', async () => {
+    await runCli(['config', 'set', 'recordSystemAudio', 'true']);
+    const { stdout } = await runCli(['config', 'get', 'recordSystemAudio']);
+    assert.equal(stdout.trim(), 'true');
+  });
+
+  it('config unset clears the stored value', async () => {
+    await runCli(['config', 'set', 'geminiModel', 'gemini-2.5-flash']);
+    const before = await runCli(['config', 'get', 'geminiModel']);
+    assert.equal(before.stdout.trim(), 'gemini-2.5-flash');
+    const unset = await runCli(['config', 'unset', 'geminiModel']);
+    assert.equal(unset.code, 0);
+    const after = await runCli(['config', 'get', 'geminiModel']);
+    // Falls back to the default model returned by ConfigService.getGeminiModel().
+    assert.equal(after.stdout.trim(), 'gemini-2.5-pro');
+  });
+
+  it('config list masks slackWebhookUrl', async () => {
+    await runCli([
+      'config',
+      'set',
+      'slackWebhookUrl',
+      'https://hooks.slack.com/services/SECRET123',
+    ]);
+    const { stdout } = await runCli(['config', 'list']);
+    const line = stdout.split('\n').find((l) => l.startsWith('slackWebhookUrl='));
+    assert.ok(line, 'expected slackWebhookUrl in config list');
+    assert.match(line!, /^slackWebhookUrl=\*\*\*\*/);
+    assert.doesNotMatch(line!, /SECRET123/);
+  });
+
+  it('config unset on unknown key fails with non-zero exit', async () => {
+    const { code, stderr } = await runCli(['config', 'unset', 'bogusKey']);
+    assert.equal(code, 1);
+    assert.match(stderr, /Unknown key/);
+  });
+});
+
 describe(
   'listener merge (CLI integration)',
   { skip: !ffmpegPath ? 'ffmpeg not installed' : undefined },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { type AgentScope, AgentService, type ConfigProposal } from './agentService';
 import { extensionForMimeType } from './audioFormats';
-import { ConfigService } from './configService';
+import { type AppConfig, ConfigService } from './configService';
 import { getDataPath } from './dataPath';
 import { GeminiService } from './geminiService';
 import {
@@ -33,33 +33,51 @@ const SUPPORTED_EXTENSIONS = new Set([
   '.webm',
 ]);
 
-function usage(): never {
-  process.stderr.write(
-    'Usage: listener <file> [--output <dir>]    Transcribe an audio file\n' +
-      '       listener list [--limit <n>]         List past transcriptions\n' +
-      '       listener show <ref>                 Print summary to stdout\n' +
-      '       listener export <ref> [<path>] [--json] [--transcript]\n' +
-      '                                           Export transcription\n' +
-      '       listener search <query> [--limit <n>] [--transcript] [--field <name>]\n' +
-      '                                           Search past transcriptions\n' +
-      '       listener merge <ref1> <ref2> [<ref3>...] [--title <t>]\n' +
-      '                                           Concat the source audio of two or more notes,\n' +
-      '                                           re-transcribe end-to-end, and save as a new note\n' +
-      '       listener ask <question> [--ref <ref>]\n' +
-      '                                           Ask the AI agent about saved meetings or settings\n' +
-      '       listener config list|get|set|path   Manage configuration\n' +
-      '\n' +
-      '<ref> is a number from `listener list` or a folder name.\n' +
-      '\n' +
-      'Options:\n' +
-      '  --output <dir>   Parent directory for the output folder\n' +
-      '  --limit <n>      Max results (0 = all, default: 20)\n' +
-      '  --json           Export as JSON instead of markdown\n' +
-      '  --transcript     Include transcript body (export: append; search: widen scope)\n' +
-      '  --field <name>   Restrict search to one of: title, summary, keyPoints, actionItems, transcript, all\n' +
-      '  --help           Show this help message\n',
-  );
+const VERSION = (() => {
+  try {
+    const pkgPath = path.join(__dirname, '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+})();
+
+const USAGE_TEXT =
+  'Usage: listener <file> [--output <dir>]    Transcribe an audio file\n' +
+  '       listener list [--limit <n>]         List past transcriptions\n' +
+  '       listener show <ref>                 Print summary to stdout\n' +
+  '       listener export <ref> [<path>] [--json] [--transcript]\n' +
+  '                                           Export transcription\n' +
+  '       listener search <query> [--limit <n>] [--transcript] [--field <name>]\n' +
+  '                                           Search past transcriptions\n' +
+  '       listener merge <ref1> <ref2> [<ref3>...] [--title <t>]\n' +
+  '                                           Concat the source audio of two or more notes,\n' +
+  '                                           re-transcribe end-to-end, and save as a new note\n' +
+  '       listener ask <question> [--ref <ref>]\n' +
+  '                                           Ask the AI agent about saved meetings or settings\n' +
+  '       listener config list|get|set|unset|path\n' +
+  '                                           Manage configuration\n' +
+  '\n' +
+  '<ref> is a number from `listener list` or a folder name.\n' +
+  '\n' +
+  'Options:\n' +
+  '  --output <dir>   Parent directory for the output folder\n' +
+  '  --limit <n>      Max results (0 = all, default: 20)\n' +
+  '  --json           Export as JSON instead of markdown\n' +
+  '  --transcript     Include transcript body (export: append; search: widen scope)\n' +
+  '  --field <name>   Restrict search to one of: title, summary, keyPoints, actionItems, transcript, all\n' +
+  '  --version, -V    Print CLI version\n' +
+  '  --help, -h       Show this help message\n';
+
+function usageError(): never {
+  process.stderr.write(USAGE_TEXT);
   process.exit(1);
+}
+
+function showHelp(): never {
+  process.stdout.write(USAGE_TEXT);
+  process.exit(0);
 }
 
 const KNOWN_CONFIG_KEYS = [
@@ -69,17 +87,118 @@ const KNOWN_CONFIG_KEYS = [
   'notionApiKey',
   'notionDatabaseId',
   'autoMode',
+  'meetingDetection',
+  'displayDetection',
   'globalShortcut',
+  'knownWords',
+  'summaryPrompt',
+  'maxRecordingMinutes',
+  'recordingReminderMinutes',
   'minRecordingSeconds',
+  'recordSystemAudio',
+  'slackWebhookUrl',
+  'slackAutoShare',
 ] as const;
 type ConfigKey = (typeof KNOWN_CONFIG_KEYS)[number];
 
-function maskValue(key: string, value: string | undefined): string {
+function isSensitiveKey(key: string): boolean {
+  const lk = key.toLowerCase();
+  return lk.includes('key') || lk.includes('webhook');
+}
+
+function maskValue(key: string, value: unknown): string {
   if (value == null || value === '') return '(not set)';
-  if (key.toLowerCase().includes('key')) {
-    return value.length > 4 ? `****${value.slice(-4)}` : '****';
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '(none)';
+    const joined = value.map((x) => String(x)).join(', ');
+    return joined.length > 60 ? `${joined.slice(0, 57)}...` : joined;
   }
-  return value;
+  const str = String(value);
+  if (isSensitiveKey(key)) {
+    return str.length > 4 ? `****${str.slice(-4)}` : '****';
+  }
+  if (str.length > 60) return `${str.slice(0, 57)}...`;
+  return str;
+}
+
+function parseBool(key: string, v: string): boolean {
+  if (v !== 'true' && v !== 'false') {
+    process.stderr.write(`Error: ${key} must be "true" or "false"\n`);
+    process.exit(1);
+  }
+  return v === 'true';
+}
+
+function parseNonNegInt(key: string, v: string): number {
+  const n = Number.parseInt(v, 10);
+  if (Number.isNaN(n) || n < 0 || String(n) !== v.trim()) {
+    process.stderr.write(`Error: ${key} must be a non-negative integer\n`);
+    process.exit(1);
+  }
+  return n;
+}
+
+function parseKnownWords(v: string): string[] {
+  return v
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function applyConfigSet(config: ConfigService, key: ConfigKey, value: string): void {
+  switch (key) {
+    case 'geminiApiKey':
+      config.setGeminiApiKey(value);
+      return;
+    case 'geminiModel':
+      config.setGeminiModel(value);
+      return;
+    case 'geminiFlashModel':
+      config.setGeminiFlashModel(value);
+      return;
+    case 'notionApiKey':
+      config.setNotionApiKey(value);
+      return;
+    case 'notionDatabaseId':
+      config.setNotionDatabaseId(value);
+      return;
+    case 'autoMode':
+      config.setAutoMode(parseBool('autoMode', value));
+      return;
+    case 'meetingDetection':
+      config.updateConfig({ meetingDetection: parseBool('meetingDetection', value) });
+      return;
+    case 'displayDetection':
+      config.setDisplayDetection(parseBool('displayDetection', value));
+      return;
+    case 'globalShortcut':
+      config.setGlobalShortcut(value);
+      return;
+    case 'knownWords':
+      config.setKnownWords(parseKnownWords(value));
+      return;
+    case 'summaryPrompt':
+      config.setSummaryPrompt(value);
+      return;
+    case 'maxRecordingMinutes':
+      config.setMaxRecordingMinutes(parseNonNegInt('maxRecordingMinutes', value));
+      return;
+    case 'recordingReminderMinutes':
+      config.setRecordingReminderMinutes(parseNonNegInt('recordingReminderMinutes', value));
+      return;
+    case 'minRecordingSeconds':
+      config.setMinRecordingSeconds(parseNonNegInt('minRecordingSeconds', value));
+      return;
+    case 'recordSystemAudio':
+      config.setRecordSystemAudio(parseBool('recordSystemAudio', value));
+      return;
+    case 'slackWebhookUrl':
+      config.setSlackWebhookUrl(value);
+      return;
+    case 'slackAutoShare':
+      config.setSlackAutoShare(parseBool('slackAutoShare', value));
+      return;
+  }
 }
 
 function handleConfig(subArgs: string[]): void {
@@ -87,8 +206,12 @@ function handleConfig(subArgs: string[]): void {
   const config = new ConfigService(dataPath);
   const sub = subArgs[0];
 
-  if (!sub || sub === '--help') {
-    usage();
+  if (!sub) {
+    usageError();
+  }
+
+  if (sub === '--help' || sub === '-h') {
+    showHelp();
   }
 
   if (sub === 'path') {
@@ -100,8 +223,7 @@ function handleConfig(subArgs: string[]): void {
     const all = config.getAllConfig();
     for (const key of KNOWN_CONFIG_KEYS) {
       const raw = all[key as keyof typeof all];
-      const display = maskValue(key, raw == null ? undefined : String(raw));
-      process.stdout.write(`${key}=${display}\n`);
+      process.stdout.write(`${key}=${maskValue(key, raw)}\n`);
     }
     return;
   }
@@ -119,7 +241,11 @@ function handleConfig(subArgs: string[]): void {
     }
     const all = config.getAllConfig();
     const val = all[key as keyof typeof all];
-    process.stdout.write(`${val ?? ''}\n`);
+    if (Array.isArray(val)) {
+      process.stdout.write(`${val.join(',')}\n`);
+    } else {
+      process.stdout.write(`${val ?? ''}\n`);
+    }
     return;
   }
 
@@ -137,38 +263,29 @@ function handleConfig(subArgs: string[]): void {
       process.stderr.write(`Known keys: ${KNOWN_CONFIG_KEYS.join(', ')}\n`);
       process.exit(1);
     }
-    const setters: Record<ConfigKey, (v: string) => void> = {
-      geminiApiKey: (v) => config.setGeminiApiKey(v),
-      geminiModel: (v) => config.setGeminiModel(v),
-      geminiFlashModel: (v) => config.setGeminiFlashModel(v),
-      notionApiKey: (v) => config.setNotionApiKey(v),
-      notionDatabaseId: (v) => config.setNotionDatabaseId(v),
-      autoMode: (v) => {
-        if (v !== 'true' && v !== 'false') {
-          process.stderr.write('Error: autoMode must be "true" or "false"\n');
-          process.exit(1);
-        }
-        config.setAutoMode(v === 'true');
-      },
-      globalShortcut: (v) => config.setGlobalShortcut(v),
-      minRecordingSeconds: (v) => {
-        const n = Number.parseInt(v, 10);
-        if (Number.isNaN(n) || n < 0 || String(n) !== v.trim()) {
-          process.stderr.write(
-            'Error: minRecordingSeconds must be a non-negative integer (0 disables)\n',
-          );
-          process.exit(1);
-        }
-        config.setMinRecordingSeconds(n);
-      },
-    };
-    setters[key](value);
+    applyConfigSet(config, key, value);
     process.stderr.write(`Set ${key}\n`);
     return;
   }
 
+  if (sub === 'unset') {
+    const key = subArgs[1] as ConfigKey;
+    if (!key) {
+      process.stderr.write('Error: Missing key. Usage: listener config unset <key>\n');
+      process.exit(1);
+    }
+    if (!KNOWN_CONFIG_KEYS.includes(key)) {
+      process.stderr.write(`Error: Unknown key: ${key}\n`);
+      process.stderr.write(`Known keys: ${KNOWN_CONFIG_KEYS.join(', ')}\n`);
+      process.exit(1);
+    }
+    config.unsetKey(key as keyof AppConfig);
+    process.stderr.write(`Unset ${key}\n`);
+    return;
+  }
+
   process.stderr.write(`Error: Unknown config command: ${sub}\n`);
-  usage();
+  usageError();
 }
 
 async function resolveRef(ref: string, dataPath: string): Promise<string> {
@@ -606,8 +723,17 @@ async function handleAsk(args: string[]): Promise<void> {
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
-  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
-    usage();
+  if (args.includes('--version') || args.includes('-V')) {
+    process.stdout.write(`listener ${VERSION}\n`);
+    return;
+  }
+
+  if (args.includes('--help') || args.includes('-h')) {
+    showHelp();
+  }
+
+  if (args.length === 0) {
+    usageError();
   }
 
   if (args[0] === 'config') {
@@ -654,7 +780,7 @@ async function main(): Promise<void> {
       outputDir = args[++i];
     } else if (args[i].startsWith('-')) {
       process.stderr.write(`Error: Unknown option: ${args[i]}\n`);
-      usage();
+      usageError();
     } else {
       filePath = args[i];
     }
@@ -662,7 +788,7 @@ async function main(): Promise<void> {
 
   if (!filePath) {
     process.stderr.write('Error: No audio file specified.\n');
-    usage();
+    usageError();
   }
 
   // Resolve to absolute path

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -266,6 +266,11 @@ export class ConfigService {
     this.saveConfig();
   }
 
+  unsetKey(key: keyof AppConfig): void {
+    delete this.config[key];
+    this.saveConfig();
+  }
+
   getAllConfig(): AppConfig {
     return {
       geminiApiKey: this.getGeminiApiKey(),


### PR DESCRIPTION
## Summary
- The CLI shipped without `--version` / `-V`, and `--help` exited with code 1 (treating help as an error). Both fixed.
- `listener config` only knew 8 of the 17 settable keys defined in `ConfigService` — silently dropping `meetingDetection`, `knownWords`, `summaryPrompt`, `recordSystemAudio`, `slackWebhookUrl`, etc. Expanded to 17 (excludes `audioDeviceId` UI-only, `lastSeenVersion` app-managed).
- New `listener config unset <key>` clears a stored value (falls back to default on next read), backed by a new `ConfigService.unsetKey()`. Previously users had to hand-edit `config.json`.
- `config list` now masks `slackWebhookUrl` (was leaking in plain), comma-joins array values like `knownWords`, and truncates long strings like `summaryPrompt` past 60 chars.
- `usage()` split into `usageError()` (stderr, exit 1) and `showHelp()` (stdout, exit 0). `USAGE_TEXT` documents the new flags and `unset`.

## Test plan
- [x] 10 new CLI integration tests in `src/cli.test.ts` exercise `--version`, `-V`, `--help` exit code, `config set/get/unset` round-trips for new keys, boolean validation, slack URL masking, unknown-key error path. All 82 tests in the full suite pass.
- [x] Manual smoke: `node dist/cli.js --version` → `listener 2.5.0`. `--help` writes to stdout and exits 0. `config list` shows masked Slack webhook (`****cret`).
- [x] `tsc` clean.

## Notes
- `--version` reads from `package.json` at runtime via `__dirname/../package.json`, so npm-installed CLI (where the file sits next to `dist/`) and the bundled Electron build both resolve correctly.
- Comments throughout `cli.ts` explain the *why* of less-obvious bits (e.g. why `meetingDetection` uses `updateConfig` while siblings use dedicated setters — there's no `setMeetingDetection` on ConfigService).