### PR TITLE
fix: disable Windows auto-update fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,8 @@ jobs:
         env:
           CSC_LINK: ${{ matrix.name == 'mac' && secrets.SIGNING_CERTIFICATE || '' }}
           CSC_KEY_PASSWORD: ${{ matrix.name == 'mac' && secrets.CERT_PASSWORD || '' }}
+          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -103,4 +103,5 @@ Add secrets to your GitHub repository:
 - `WIN_CSC_LINK` - Base64 encoded .pfx certificate
 - `WIN_CSC_KEY_PASSWORD` - Windows certificate password
 
-The GitHub Actions workflow will automatically sign and notarize releases.
+The GitHub Actions workflow passes these Windows secrets to electron-builder when they are configured, so signed Windows releases do not require workflow changes once a certificate exists.
+For GitHub Releases + NSIS auto-update, there is no reliable free public-distribution path around trusted Windows code signing; the app disables automatic updates on Windows and sends users to the latest GitHub Release instead.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "oxlint --fix src renderer scripts",
     "format": "oxfmt 'src/**/*.ts' 'renderer/**/*.ts' 'renderer/**/*.tsx' 'scripts/**/*.js' 'scripts/**/*.ts'",
     "format:check": "oxfmt --check 'src/**/*.ts' 'renderer/**/*.ts' 'renderer/**/*.tsx' 'scripts/**/*.js' 'scripts/**/*.ts'",
-    "test": "tsc && node --test dist/meetingDetectorService.test.js dist/searchService.test.js dist/agentService.test.js dist/simpleAudioRecorder.test.js dist/outputService.test.js dist/slackService.test.js dist/services/audioConcatService.test.js dist/cli.test.js",
+    "test": "tsc && node --test \"dist/**/*.test.js\"",
     "dist": "pnpm run build && electron-builder",
     "dist:mac": "pnpm run build && electron-builder --mac",
     "dist:mac-x64": "pnpm run build && electron-builder --mac --x64",

--- a/renderer/ui/recordings-list.ts
+++ b/renderer/ui/recordings-list.ts
@@ -93,38 +93,57 @@ export async function createRecordingItem(recording: Recording): Promise<HTMLEle
     item.setAttribute('aria-label', `Open transcript for ${recording.title}`);
   }
 
-  item.innerHTML = `
-    <span class="recording-status" aria-hidden="true"></span>
-    <div class="recording-info">
-      <h3>${recording.title}</h3>
-      <p class="recording-meta">${metaStr}</p>
-    </div>
-    <div class="recording-actions">
-      ${
-        hasTranscript
-          ? `
-        <button class="action-button regenerate-btn" data-path="${recording.path}" data-title="${recording.title}" title="Regenerate transcript" aria-label="Regenerate transcript">
-          ↻
-        </button>
-      `
-          : `
-        <button class="action-button transcribe-btn" data-path="${recording.path}" data-title="${recording.title}">
-          Transcribe
-        </button>
-      `
-      }
-      <button class="action-button merge-btn" data-path="${recording.path}" title="Merge this with other recordings into a single note">
-        Merge
-      </button>
-      <button class="action-button reveal-btn" data-path="${recording.path}" title="Reveal in Finder">
-        Show
-      </button>
-      <button class="action-button export-m4a-btn" data-path="${recording.path}" title="Export as M4A for sharing" aria-label="Export as M4A">
-        M4A
-      </button>
-      ${hasTranscript ? '<span class="recording-chevron" aria-hidden="true">›</span>' : ''}
-    </div>
-  `;
+  const status = document.createElement('span');
+  status.className = 'recording-status';
+  status.setAttribute('aria-hidden', 'true');
+  item.appendChild(status);
+
+  const info = document.createElement('div');
+  info.className = 'recording-info';
+  const title = document.createElement('h3');
+  title.textContent = recording.title;
+  const meta = document.createElement('p');
+  meta.className = 'recording-meta';
+  meta.textContent = metaStr;
+  info.append(title, meta);
+  item.appendChild(info);
+
+  const actions = document.createElement('div');
+  actions.className = 'recording-actions';
+
+  if (hasTranscript) {
+    actions.appendChild(
+      createActionButton('regenerate-btn', '↻', {
+        title: 'Regenerate transcript',
+        ariaLabel: 'Regenerate transcript',
+      }),
+    );
+  } else {
+    actions.appendChild(createActionButton('transcribe-btn', 'Transcribe'));
+  }
+
+  actions.appendChild(
+    createActionButton('merge-btn', 'Merge', {
+      title: 'Merge this with other recordings into a single note',
+    }),
+  );
+  actions.appendChild(createActionButton('reveal-btn', 'Show', { title: 'Reveal in Finder' }));
+  actions.appendChild(
+    createActionButton('export-m4a-btn', 'M4A', {
+      title: 'Export as M4A for sharing',
+      ariaLabel: 'Export as M4A',
+    }),
+  );
+
+  if (hasTranscript) {
+    const chevron = document.createElement('span');
+    chevron.className = 'recording-chevron';
+    chevron.setAttribute('aria-hidden', 'true');
+    chevron.textContent = '›';
+    actions.appendChild(chevron);
+  }
+
+  item.appendChild(actions);
 
   if (hasTranscript) {
     // Whole-row entry: clicking (or Enter/Space) opens the transcript.
@@ -184,6 +203,20 @@ export async function createRecordingItem(recording: Recording): Promise<HTMLEle
   }
 
   return item;
+}
+
+function createActionButton(
+  className: string,
+  label: string,
+  options: { title?: string; ariaLabel?: string } = {},
+): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.className = `action-button ${className}`;
+  button.type = 'button';
+  if (options.title) button.title = options.title;
+  if (options.ariaLabel) button.setAttribute('aria-label', options.ariaLabel);
+  button.textContent = label;
+  return button;
 }
 
 // On ffmpeg-missing, point the user at transcription (which downloads ffmpeg)

--- a/src/geminiService.test.ts
+++ b/src/geminiService.test.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import * as path from 'path';
+import { GeminiService } from './geminiService';
+import { findFfmpegSync, makeOpusWebm, makeTempDir, rmDir } from './test-helpers';
+
+const ffmpegPath = findFfmpegSync();
+
+let workDir: string;
+
+type GeminiServiceFfmpegHelpers = {
+  getAudioDuration(audioFilePath: string): Promise<number>;
+  splitAudioIntoSegments(audioFilePath: string, segmentDurationSeconds: number): Promise<string[]>;
+};
+
+before(() => {
+  workDir = makeTempDir('gemini-ffmpeg');
+});
+
+after(() => {
+  rmDir(workDir);
+});
+
+function makeService(): GeminiServiceFfmpegHelpers {
+  return new GeminiService({
+    apiKey: 'test-key',
+    dataPath: workDir,
+    proModel: 'gemini-test-pro',
+    flashModel: 'gemini-test-flash',
+  }) as unknown as GeminiServiceFfmpegHelpers;
+}
+
+describe(
+  'GeminiService ffmpeg helpers',
+  { skip: !ffmpegPath ? 'ffmpeg not installed' : undefined },
+  () => {
+    it('reads duration for paths containing shell-sensitive quotes', async () => {
+      const audioPath = await makeOpusWebm(ffmpegPath!, workDir, 'meeting "final".webm', 440);
+      const duration = await makeService().getAudioDuration(audioPath);
+
+      assert.ok(duration > 0.8 && duration < 1.2, `expected ~1s duration, got ${duration}s`);
+    });
+
+    it('splits paths containing shell-sensitive quotes into segment files', async () => {
+      const audioPath = await makeOpusWebm(ffmpegPath!, workDir, 'segment "source".webm', 550);
+      const segmentFiles = await makeService().splitAudioIntoSegments(audioPath, 1);
+
+      assert.ok(segmentFiles.length > 0, 'expected at least one segment');
+      for (const segmentFile of segmentFiles) {
+        assert.equal(path.dirname(segmentFile), workDir);
+        assert.ok(fs.existsSync(segmentFile), `segment should exist: ${segmentFile}`);
+      }
+    });
+  },
+);

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -1,8 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { GoogleGenAI } from '@google/genai';
 import { mimeTypeForExtension } from './audioFormats';
 import { FFmpegManager } from './services/ffmpegManager';
+
+const execFileAsync = promisify(execFile);
 
 export interface TranscriptionResult {
   transcript: string;
@@ -126,24 +130,26 @@ export class GeminiService {
     }
   }
 
-  // Get audio duration using ffprobe
+  // Get audio duration using ffmpeg
   private async getAudioDuration(audioFilePath: string): Promise<number> {
-    const { exec } = require('child_process');
-    const { promisify } = require('util');
-    const execAsync = promisify(exec);
-
     try {
       const ffmpegPath = await this.getFFmpegPath();
 
       // Use ffmpeg with -f null to get file info including duration
       // This will output file info to stderr which we can parse
-      const ffmpegCommand = `"${ffmpegPath}" -i "${audioFilePath}" -f null -`;
-      console.log('Running ffmpeg command for duration:', ffmpegCommand);
+      console.log('Running ffmpeg for duration:', ffmpegPath, audioFilePath);
 
-      const { stderr } = await execAsync(ffmpegCommand).catch((e: any) => {
+      const { stderr } = await execFileAsync(ffmpegPath, [
+        '-i',
+        audioFilePath,
+        '-f',
+        'null',
+        '-',
+      ]).catch((error: unknown) => {
+        const execError = error as { stdout?: string; stderr?: string };
         // FFmpeg exits with non-zero code when output is null, but still provides info in stderr
         // This is expected behavior, so we return the error object which contains stdout/stderr
-        return { stdout: e.stdout || '', stderr: e.stderr || '' };
+        return { stdout: execError.stdout || '', stderr: execError.stderr || '' };
       });
 
       // Extract duration from stderr (where ffmpeg outputs file info)
@@ -183,10 +189,6 @@ export class GeminiService {
     audioFilePath: string,
     segmentDuration = 300,
   ): Promise<string[]> {
-    const { exec } = require('child_process');
-    const { promisify } = require('util');
-    const execAsync = promisify(exec);
-
     const outputDir = path.dirname(audioFilePath);
     const baseName = path.basename(audioFilePath, path.extname(audioFilePath));
     const ext = path.extname(audioFilePath);
@@ -198,9 +200,17 @@ export class GeminiService {
 
     try {
       // Split audio into segments
-      await execAsync(
-        `"${ffmpegPath}" -i "${audioFilePath}" -f segment -segment_time ${segmentDuration} -c copy "${segmentPath}"`,
-      );
+      await execFileAsync(ffmpegPath, [
+        '-i',
+        audioFilePath,
+        '-f',
+        'segment',
+        '-segment_time',
+        String(segmentDuration),
+        '-c',
+        'copy',
+        segmentPath,
+      ]);
 
       // Find all created segment files
       const segmentFiles = fs

--- a/src/main.ts
+++ b/src/main.ts
@@ -438,7 +438,7 @@ app.whenReady().then(() => {
           },
         },
         {
-          label: 'Check for Updates...',
+          label: autoUpdaterService.getManualUpdateLabel(),
           click: () => {
             autoUpdaterService.checkForUpdatesManually();
           },
@@ -454,7 +454,7 @@ app.whenReady().then(() => {
         { role: 'about' } as any,
         { type: 'separator' } as any,
         {
-          label: 'Check for Updates...',
+          label: autoUpdaterService.getManualUpdateLabel(),
           click: () => {
             autoUpdaterService.checkForUpdatesManually();
           },
@@ -1659,34 +1659,48 @@ ipcMain.handle('get-recordings', async () => {
     // Read all files in the recordings directory
     const files = fs.readdirSync(recordingsDir);
 
-    // Filter for audio files and get their stats
-    const recordings = files
-      .filter((file: string) => {
-        // Filter out segment files
-        if (file.includes('_segment_')) return false;
-        return isSupportedAudioExtension(path.extname(file));
-      })
-      .map((file: string) => {
-        const filePath = path.join(recordingsDir, file);
-        const stats = fs.statSync(filePath);
+    // Filter for audio files and get their stats. Skip per-file races so one
+    // deleted recording does not make the whole list fail.
+    const recordings: Array<{
+      filename: string;
+      path: string;
+      title: string;
+      timestamp: string | undefined;
+      size: number;
+      createdAt: Date;
+      modifiedAt: Date;
+    }> = [];
+    for (const file of files) {
+      if (file.includes('_segment_')) continue;
+      if (!isSupportedAudioExtension(path.extname(file))) continue;
 
-        // Extract title from filename (format: title_timestamp.ext)
-        const nameWithoutExt = path.basename(file, path.extname(file));
-        const parts = nameWithoutExt.split('_');
-        const timestamp = parts.pop(); // Remove timestamp
-        const title = parts.join('_') || 'Untitled';
+      const filePath = path.join(recordingsDir, file);
+      let stats: fs.Stats;
+      try {
+        stats = fs.statSync(filePath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw err;
+      }
 
-        return {
-          filename: file,
-          path: filePath,
-          title: title,
-          timestamp: timestamp,
-          size: stats.size,
-          createdAt: stats.birthtime,
-          modifiedAt: stats.mtime,
-        };
-      })
-      .sort((a: any, b: any) => b.createdAt.getTime() - a.createdAt.getTime()); // Sort by newest first
+      // Extract title from filename (format: title_timestamp.ext)
+      const nameWithoutExt = path.basename(file, path.extname(file));
+      const parts = nameWithoutExt.split('_');
+      const timestamp = parts.pop(); // Remove timestamp
+      const title = parts.join('_') || 'Untitled';
+
+      recordings.push({
+        filename: file,
+        path: filePath,
+        title,
+        timestamp,
+        size: stats.size,
+        createdAt: stats.birthtime,
+        modifiedAt: stats.mtime,
+      });
+    }
+
+    recordings.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()); // Sort by newest first
 
     return { success: true, recordings };
   } catch (error) {

--- a/src/services/autoUpdaterService.ts
+++ b/src/services/autoUpdaterService.ts
@@ -32,6 +32,11 @@ export class AutoUpdaterService {
       return;
     }
 
+    if (this.isWindowsAutoUpdateDisabled()) {
+      console.log('Auto-updater disabled on Windows; using GitHub Releases instead');
+      return;
+    }
+
     autoUpdater.on('checking-for-update', () => {
       console.log('Checking for updates...');
       this.sendStatusToWindow('checking-for-update');
@@ -109,7 +114,7 @@ export class AutoUpdaterService {
   }
 
   public checkForUpdates() {
-    if (this.isDevelopment()) return;
+    if (this.isDevelopment() || this.isWindowsAutoUpdateDisabled()) return;
 
     autoUpdater.checkForUpdatesAndNotify().catch((err) => {
       console.error('Failed to check for updates:', err);
@@ -117,7 +122,7 @@ export class AutoUpdaterService {
   }
 
   public startPeriodicCheck(intervalMs: number = PERIODIC_CHECK_INTERVAL_MS) {
-    if (this.isDevelopment()) return;
+    if (this.isDevelopment() || this.isWindowsAutoUpdateDisabled()) return;
     if (this.periodicTimer) return;
 
     this.periodicTimer = setInterval(() => {
@@ -140,6 +145,10 @@ export class AutoUpdaterService {
   }
 
   public downloadUpdate() {
+    if (this.isWindowsAutoUpdateDisabled()) {
+      this.showManualUpdateDialog();
+      return;
+    }
     if (this.updateState.type !== 'available') return;
 
     const version = this.updateState.version;
@@ -193,7 +202,7 @@ export class AutoUpdaterService {
   }
 
   public quitAndInstall() {
-    if (this.isDevelopment()) return;
+    if (this.isDevelopment() || this.isWindowsAutoUpdateDisabled()) return;
     if (this.updateState.type !== 'downloaded') return;
 
     // Prevent the macOS close handler's hide-instead-of-quit fallback from
@@ -251,6 +260,16 @@ export class AutoUpdaterService {
     return process.env.NODE_ENV === 'development' || app.isPackaged === false;
   }
 
+  private isWindowsAutoUpdateDisabled(): boolean {
+    return process.platform === 'win32';
+  }
+
+  public getManualUpdateLabel(): string {
+    return this.isWindowsAutoUpdateDisabled()
+      ? 'Download Latest Version...'
+      : 'Check for Updates...';
+  }
+
   public checkForUpdatesManually() {
     if (this.isDevelopment()) {
       dialog.showMessageBox(this.mainWindow || new BrowserWindow({ show: false }), {
@@ -259,6 +278,11 @@ export class AutoUpdaterService {
         message: 'Auto-update is disabled in development mode.',
         buttons: ['OK'],
       });
+      return;
+    }
+
+    if (this.isWindowsAutoUpdateDisabled()) {
+      this.showManualUpdateDialog();
       return;
     }
 
@@ -277,6 +301,24 @@ export class AutoUpdaterService {
       })
       .catch((err) => {
         this.showUpdateFailedDialog(err.message);
+      });
+  }
+
+  private showManualUpdateDialog() {
+    dialog
+      .showMessageBox(this.mainWindow || new BrowserWindow({ show: false }), {
+        type: 'info',
+        title: 'Manual Update Required',
+        message: 'Automatic updates are disabled on Windows.',
+        detail: `Download the latest installer from GitHub Releases.\n\nCurrent version: ${app.getVersion()}`,
+        buttons: ['Open GitHub Releases', 'Later'],
+        defaultId: 0,
+        cancelId: 1,
+      })
+      .then((result) => {
+        if (result.response === 0) {
+          shell.openExternal(RELEASES_URL);
+        }
       });
   }
 


### PR DESCRIPTION
## Summary

This disables automatic updates on Windows and routes users to the latest GitHub Release instead, avoiding an unreliable unsigned NSIS update path. It also tightens release signing docs, test discovery, FFmpeg helper execution, and recording list rendering as part of the same packaging hardening pass.

## Key changes

- Skip `electron-updater` setup, periodic checks, downloads, and installs on Windows.
- Change the update menu label on Windows to `Download Latest Version...` and open the latest GitHub Release from the manual-update dialog.
- Pass optional Windows signing secrets through the release workflow when certificates are configured.
- Replace shell-built FFmpeg commands with `execFile` argument arrays and cover quoted paths in tests.
- Render recording list items with DOM APIs instead of interpolated `innerHTML`.
- Expand `npm run test` to discover every compiled `*.test.js` file.

## Type of change

Bug fix, documentation, refactor.

## Testing performed

- `./node_modules/.bin/oxfmt --check src/services/autoUpdaterService.ts src/main.ts src/geminiService.ts src/geminiService.test.ts renderer/ui/recordings-list.ts`
- `./node_modules/.bin/oxlint src renderer scripts`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.renderer.json`
- `npm run test` - 84 passed
- `npm run build`

## Related issues

None.
