### PR TITLE
Add transcript-only CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ listener config set notionDatabaseId <your-id>
 ```bash
 listener recording.mp3                # Transcribe to default output dir
 listener recording.m4a --output ./    # Transcribe to current directory
+listener recording.wav --transcript-only
+                                      # Skip summary/key points/action items
 listener config list                  # Show all config values (secrets masked)
 listener config get <key>             # Print one config value
 listener config set <key> <value>     # Set a config value

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ listener recording.mp3                # Transcribe to default output dir
 listener recording.m4a --output ./    # Transcribe to current directory
 listener recording.wav --transcript-only
                                       # Skip summary/key points/action items
+listener merge 1 2 --transcript-only  # Merge recordings and save transcript only
 listener config list                  # Show all config values (secrets masked)
 listener config get <key>             # Print one config value
 listener config set <key> <value>     # Set a config value

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -251,5 +251,74 @@ describe(
       assert.ok(fs.existsSync(folderA), 'source folder A should be preserved');
       assert.ok(fs.existsSync(folderB), 'source folder B should be preserved');
     });
+
+    it('merges with --transcript-only and skips summary data', async () => {
+      const recordingsDir = path.join(dataPath, 'recordings');
+      fs.mkdirSync(recordingsDir, { recursive: true });
+
+      const audioA = await makeOpusWebm(ffmpegPath!, recordingsDir, 'transcriptOnlyA.webm', 440);
+      const audioB = await makeOpusWebm(ffmpegPath!, recordingsDir, 'transcriptOnlyB.webm', 880);
+
+      const folderA = saveTranscription({
+        title: 'Transcript Only Part One',
+        result: {
+          transcript: 'Part one body.',
+          summary: 'Part one summary.',
+          keyPoints: ['a1'],
+          actionItems: ['a-action'],
+          emoji: 'A',
+          suggestedTitle: 'Transcript Only Part One',
+        },
+        audioFilePath: audioA,
+        dataPath,
+      });
+      const folderB = saveTranscription({
+        title: 'Transcript Only Part Two',
+        result: {
+          transcript: 'Part two body.',
+          summary: 'Part two summary.',
+          keyPoints: ['b1'],
+          actionItems: ['b-action'],
+          emoji: 'B',
+          suggestedTitle: 'Transcript Only Part Two',
+        },
+        audioFilePath: audioB,
+        dataPath,
+      });
+
+      const env = {
+        ...process.env,
+        NODE_ENV: 'test',
+        LISTENER_DATA_PATH: dataPath,
+        LISTENER_TEST_MODE: '1',
+        GEMINI_API_KEY: 'test-mode-key',
+      };
+
+      const { stdout, stderr } = await execFileAsync(
+        'node',
+        [
+          cliPath,
+          'merge',
+          path.basename(folderA),
+          path.basename(folderB),
+          '--title',
+          'Transcript Only Merge',
+          '--transcript-only',
+        ],
+        { env },
+      );
+
+      const resultFolder = stdout.trim();
+      const transcript = fs.readFileSync(path.join(resultFolder, 'transcript.md'), 'utf-8');
+      const summary = fs.readFileSync(path.join(resultFolder, 'summary.md'), 'utf-8');
+
+      assert.match(transcript, /Stubbed transcript\./);
+      assert.match(summary, /^title: Transcript Only Merge$/m);
+      assert.match(summary, /## Sources/);
+      assert.doesNotMatch(summary, /Stubbed summary/);
+      assert.doesNotMatch(summary, /stub point/);
+      assert.doesNotMatch(summary, /stub action/);
+      assert.match(stderr, /Skipping summary generation/);
+    });
   },
 );

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -44,6 +44,8 @@ describe('listener CLI basics', () => {
           ...process.env,
           NODE_ENV: 'test',
           LISTENER_DATA_PATH: basicsDataPath,
+          LISTENER_TEST_MODE: '1',
+          GEMINI_API_KEY: 'test-mode-key',
         },
       });
       let stdout = '';
@@ -138,6 +140,30 @@ describe('listener CLI basics', () => {
     const { code, stderr } = await runCli(['config', 'unset', 'bogusKey']);
     assert.equal(code, 1);
     assert.match(stderr, /Unknown key/);
+  });
+
+  it('--transcript-only skips summary data while saving the transcript', async () => {
+    const audioPath = path.join(basicsDataPath, 'sample.mp3');
+    const outputDir = path.join(basicsDataPath, 'exports');
+    fs.writeFileSync(audioPath, '');
+
+    const { stdout, stderr, code } = await runCli([
+      audioPath,
+      '--transcript-only',
+      '--output',
+      outputDir,
+    ]);
+
+    assert.equal(code, 0, stderr);
+    const folderPath = stdout.trim();
+    const transcript = fs.readFileSync(path.join(folderPath, 'transcript.md'), 'utf-8');
+    const summary = fs.readFileSync(path.join(folderPath, 'summary.md'), 'utf-8');
+
+    assert.match(transcript, /Stubbed transcript\./);
+    assert.doesNotMatch(summary, /Stubbed summary/);
+    assert.doesNotMatch(summary, /stub point/);
+    assert.doesNotMatch(summary, /stub action/);
+    assert.match(stderr, /Skipping summary generation/);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ const USAGE_TEXT =
   '                                           Export transcription\n' +
   '       listener search <query> [--limit <n>] [--transcript] [--field <name>]\n' +
   '                                           Search past transcriptions\n' +
-  '       listener merge <ref1> <ref2> [<ref3>...] [--title <t>]\n' +
+  '       listener merge <ref1> <ref2> [<ref3>...] [--title <t>] [--transcript-only]\n' +
   '                                           Concat the source audio of two or more notes,\n' +
   '                                           re-transcribe end-to-end, and save as a new note\n' +
   '       listener ask <question> [--ref <ref>]\n' +
@@ -553,11 +553,16 @@ async function promptYesNo(message: string): Promise<boolean> {
 async function handleMerge(args: string[]): Promise<void> {
   const refs: string[] = [];
   let title: string | undefined;
+  let transcriptOnly = false;
 
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === '--title' && i + 1 < args.length) {
       title = args[++i];
+      continue;
+    }
+    if (a === '--transcript-only') {
+      transcriptOnly = true;
       continue;
     }
     if (a.startsWith('-')) {
@@ -569,7 +574,7 @@ async function handleMerge(args: string[]): Promise<void> {
 
   if (refs.length < 2) {
     process.stderr.write(
-      'Error: merge requires at least 2 refs. Usage: listener merge <ref1> <ref2> [<ref3>...] [--title <t>]\n',
+      'Error: merge requires at least 2 refs. Usage: listener merge <ref1> <ref2> [<ref3>...] [--title <t>] [--transcript-only]\n',
     );
     process.exit(1);
   }
@@ -645,6 +650,7 @@ async function handleMerge(args: string[]): Promise<void> {
       process.stderr.write(`  ${message}\n`);
     },
     config.getSummaryPrompt(),
+    { transcriptOnly },
   );
 
   // User-supplied --title wins; Gemini's suggestion is the fallback.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,8 @@ const VERSION = (() => {
 })();
 
 const USAGE_TEXT =
-  'Usage: listener <file> [--output <dir>]    Transcribe an audio file\n' +
+  'Usage: listener <file> [--output <dir>] [--transcript-only]\n' +
+  '                                           Transcribe an audio file\n' +
   '       listener list [--limit <n>]         List past transcriptions\n' +
   '       listener show <ref>                 Print summary to stdout\n' +
   '       listener export <ref> [<path>] [--json] [--transcript]\n' +
@@ -63,6 +64,8 @@ const USAGE_TEXT =
   '\n' +
   'Options:\n' +
   '  --output <dir>   Parent directory for the output folder\n' +
+  '  --transcript-only\n' +
+  '                   Skip summary/key point/action item generation\n' +
   '  --limit <n>      Max results (0 = all, default: 20)\n' +
   '  --json           Export as JSON instead of markdown\n' +
   '  --transcript     Include transcript body (export: append; search: widen scope)\n' +
@@ -774,10 +777,13 @@ async function main(): Promise<void> {
   // Parse arguments
   let filePath: string | undefined;
   let outputDir: string | undefined;
+  let transcriptOnly = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--output' && i + 1 < args.length) {
       outputDir = args[++i];
+    } else if (args[i] === '--transcript-only') {
+      transcriptOnly = true;
     } else if (args[i].startsWith('-')) {
       process.stderr.write(`Error: Unknown option: ${args[i]}\n`);
       usageError();
@@ -834,9 +840,14 @@ async function main(): Promise<void> {
 
   process.stderr.write(`Processing: ${filePath}\n`);
 
-  const result = await gemini.transcribeAudio(filePath, (_percent, message) => {
-    process.stderr.write(`  ${message}\n`);
-  });
+  const result = await gemini.transcribeAudio(
+    filePath,
+    (_percent, message) => {
+      process.stderr.write(`  ${message}\n`);
+    },
+    undefined,
+    { transcriptOnly },
+  );
 
   const title = result.suggestedTitle || path.basename(filePath, path.extname(filePath));
 

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -18,6 +18,10 @@ export interface TranscriptionResult {
   customFields?: Record<string, unknown>;
 }
 
+export interface TranscriptionOptions {
+  transcriptOnly?: boolean;
+}
+
 export interface GeminiServiceOptions {
   apiKey: string;
   dataPath?: string;
@@ -64,6 +68,7 @@ export class GeminiService {
     audioFilePath: string,
     progressCallback?: (percent: number, message: string) => void,
     summaryPrompt?: string,
+    options: TranscriptionOptions = {},
   ): Promise<TranscriptionResult> {
     // Integration-test escape hatch: avoid the real Gemini call so tests can
     // exercise the surrounding pipeline (CLI parsing, IPC, ffmpeg, save) for
@@ -71,6 +76,17 @@ export class GeminiService {
     // in a packaged user's shell rc can't silently stub their transcripts.
     if (process.env.LISTENER_TEST_MODE && process.env.NODE_ENV === 'test') {
       if (progressCallback) progressCallback(100, 'Stubbed transcription');
+      if (options.transcriptOnly) {
+        if (progressCallback) progressCallback(95, 'Skipping summary generation...');
+        return {
+          transcript: 'Stubbed transcript.',
+          summary: '',
+          keyPoints: [],
+          actionItems: [],
+          emoji: '',
+          suggestedTitle: undefined,
+        };
+      }
       return {
         transcript: 'Stubbed transcript.',
         summary: 'Stubbed summary.',
@@ -109,6 +125,7 @@ export class GeminiService {
         duration,
         progressCallback,
         summaryPrompt,
+        options,
       );
     } catch (error) {
       console.error('Error transcribing audio:', error);
@@ -280,6 +297,7 @@ export class GeminiService {
     duration: number,
     progressCallback?: (percent: number, message: string) => void,
     customSummaryPrompt?: string,
+    options: TranscriptionOptions = {},
   ): Promise<TranscriptionResult> {
     try {
       let fullTranscript = '';
@@ -297,6 +315,20 @@ export class GeminiService {
         // Get transcript for short audio
         console.log('Transcribing short audio...');
         fullTranscript = await this.getShortAudioTranscript(audioFilePath, progressCallback);
+      }
+
+      if (options.transcriptOnly) {
+        if (progressCallback) {
+          progressCallback(95, 'Skipping summary generation...');
+        }
+        return {
+          transcript: fullTranscript,
+          summary: '',
+          keyPoints: [],
+          actionItems: [],
+          emoji: '',
+          suggestedTitle: undefined,
+        };
       }
 
       // Step 2: Generate summary, key points, action items from transcript

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -77,7 +77,7 @@ export class GeminiService {
     if (process.env.LISTENER_TEST_MODE && process.env.NODE_ENV === 'test') {
       if (progressCallback) progressCallback(100, 'Stubbed transcription');
       if (options.transcriptOnly) {
-        if (progressCallback) progressCallback(95, 'Skipping summary generation...');
+        if (progressCallback) progressCallback(100, 'Skipping summary generation...');
         return {
           transcript: 'Stubbed transcript.',
           summary: '',
@@ -319,7 +319,7 @@ export class GeminiService {
 
       if (options.transcriptOnly) {
         if (progressCallback) {
-          progressCallback(95, 'Skipping summary generation...');
+          progressCallback(100, 'Skipping summary generation...');
         }
         return {
           transcript: fullTranscript,


### PR DESCRIPTION
## Summary
- add a --transcript-only CLI option for audio transcription
- skip summary/key point/action item generation when the option is set
- document the new option and cover it with a CLI integration test

## Tests
- npx pnpm@9 run format:check
- npx pnpm@9 run build:main
- node --test dist/agentService.test.js dist/cli.test.js dist/geminiService.test.js dist/meetingDetectorService.test.js dist/outputService.test.js dist/searchService.test.js dist/services/audioConcatService.test.js dist/simpleAudioRecorder.test.js dist/slackService.test.js