### PR TITLE
Add listener transcript subcommand (alternative to #113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,12 @@ Listener.AI is an Electron desktop application for recording meetings and produc
 
 ```
 listener <file> [--output <dir>]    Transcribe and summarize an audio file
+listener transcript <file> [--output <path>] [--prompt <text>]
+                                     Transcribe to plain text only (stdout by default;
+                                     --output writes to a file, or to <dir>/<basename>.transcript.md
+                                     if the path is an existing directory). --prompt replaces
+                                     the default speaker-identification instruction; glossary
+                                     (knownWords) and per-segment positional prefix stay automatic.
 listener list [--limit <n>]         List past transcriptions
 listener show <ref>                  Print summary to stdout
 listener export <ref> [<path>] [--json] [--transcript]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ listener config set notionDatabaseId <your-id>
 ```bash
 listener recording.mp3                # Transcribe to default output dir
 listener recording.m4a --output ./    # Transcribe to current directory
+listener transcript recording.wav     # Print transcript to stdout (no summary)
+listener transcript recording.wav -o out.txt
+                                      # Write transcript to a file
+listener transcript recording.wav --prompt "Translate to English while transcribing"
+                                      # Override the default transcription instruction
 listener config list                  # Show all config values (secrets masked)
 listener config get <key>             # Print one config value
 listener config set <key> <value>     # Set a config value

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -141,6 +141,114 @@ describe('listener CLI basics', () => {
   });
 });
 
+describe('listener transcript (CLI integration)', () => {
+  let transcriptDataPath: string;
+
+  before(() => {
+    transcriptDataPath = makeTempDir('cli-transcript');
+  });
+
+  after(() => rmDir(transcriptDataPath));
+
+  function runCli(
+    args: string[],
+  ): Promise<{ stdout: string; stderr: string; code: number | null }> {
+    return new Promise((resolve) => {
+      const { spawn } = require('child_process') as typeof import('child_process');
+      const child = spawn('node', [cliPath, ...args], {
+        env: {
+          ...process.env,
+          NODE_ENV: 'test',
+          LISTENER_DATA_PATH: transcriptDataPath,
+          LISTENER_TEST_MODE: '1',
+          GEMINI_API_KEY: 'test-mode-key',
+        },
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (d: Buffer) => {
+        stdout += d.toString();
+      });
+      child.stderr.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      child.on('close', (code: number | null) => {
+        resolve({ stdout, stderr, code });
+      });
+    });
+  }
+
+  function makeAudio(name: string): string {
+    const audioPath = path.join(transcriptDataPath, name);
+    fs.writeFileSync(audioPath, '');
+    return audioPath;
+  }
+
+  it('prints transcript to stdout and creates no transcription folder', async () => {
+    const audio = makeAudio('stdout.mp3');
+    const { stdout, stderr, code } = await runCli(['transcript', audio]);
+    assert.equal(code, 0, stderr);
+    assert.match(stdout, /Stubbed transcript\./);
+
+    const store = path.join(transcriptDataPath, 'transcriptions');
+    const entries = fs.existsSync(store) ? fs.readdirSync(store) : [];
+    assert.equal(entries.length, 0, 'transcript subcommand must not write to the store');
+  });
+
+  it('writes to --output <file> and prints the file path on stdout', async () => {
+    const audio = makeAudio('file-out.mp3');
+    const outFile = path.join(transcriptDataPath, 'out.txt');
+    const { stdout, stderr, code } = await runCli(['transcript', audio, '--output', outFile]);
+    assert.equal(code, 0, stderr);
+    assert.equal(stdout.trim(), outFile);
+    assert.match(fs.readFileSync(outFile, 'utf-8'), /Stubbed transcript\./);
+  });
+
+  it('-o is an alias for --output and a directory target writes <basename>.transcript.md', async () => {
+    const audio = makeAudio('meeting.mp3');
+    const outDir = path.join(transcriptDataPath, 'transcripts-out');
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const { stdout, stderr, code } = await runCli(['transcript', audio, '-o', outDir]);
+    assert.equal(code, 0, stderr);
+    const expected = path.join(outDir, 'meeting.transcript.md');
+    assert.equal(stdout.trim(), expected);
+    assert.match(fs.readFileSync(expected, 'utf-8'), /Stubbed transcript\./);
+  });
+
+  it('accepts --prompt and still emits the transcript on stdout', async () => {
+    const audio = makeAudio('with-prompt.mp3');
+    const { stdout, stderr, code } = await runCli([
+      'transcript',
+      audio,
+      '--prompt',
+      'Translate to English while transcribing',
+    ]);
+    assert.equal(code, 0, stderr);
+    assert.match(stdout, /Stubbed transcript\./);
+  });
+
+  it('errors when no audio file is given', async () => {
+    const { stderr, code } = await runCli(['transcript']);
+    assert.equal(code, 1);
+    assert.match(stderr, /No audio file specified/);
+  });
+
+  it('errors when the audio file does not exist', async () => {
+    const { stderr, code } = await runCli(['transcript', '/nonexistent/path/audio.mp3']);
+    assert.equal(code, 1);
+    assert.match(stderr, /File not found/);
+  });
+
+  it('errors when the output parent directory does not exist', async () => {
+    const audio = makeAudio('bad-parent.mp3');
+    const bogus = path.join(transcriptDataPath, 'no-such-dir', 'out.txt');
+    const { stderr, code } = await runCli(['transcript', audio, '--output', bogus]);
+    assert.equal(code, 1);
+    assert.match(stderr, /Output directory does not exist/);
+  });
+});
+
 describe(
   'listener merge (CLI integration)',
   { skip: !ffmpegPath ? 'ffmpeg not installed' : undefined },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,7 +46,9 @@ const VERSION = (() => {
 })();
 
 const USAGE_TEXT =
-  'Usage: listener <file> [--output <dir>]    Transcribe an audio file\n' +
+  'Usage: listener <file> [--output <dir>]    Transcribe an audio file into a meeting note\n' +
+  '       listener transcript <file> [--output <path>] [--prompt <text>]\n' +
+  '                                           Transcribe to plain text only (no summary)\n' +
   '       listener list [--limit <n>]         List past transcriptions\n' +
   '       listener show <ref>                 Print summary to stdout\n' +
   '       listener export <ref> [<path>] [--json] [--transcript]\n' +
@@ -64,7 +66,10 @@ const USAGE_TEXT =
   '<ref> is a number from `listener list` or a folder name.\n' +
   '\n' +
   'Options:\n' +
-  '  --output <dir>   Parent directory for the output folder\n' +
+  '  --output, -o <path>\n' +
+  '                   Parent directory for the output folder (transcribe);\n' +
+  '                   destination file or directory (transcript)\n' +
+  '  --prompt <text>  Override the default transcription instruction (transcript)\n' +
   '  --limit <n>      Max results (0 = all, default: 20)\n' +
   '  --json           Export as JSON instead of markdown\n' +
   '  --transcript     Include transcript body (export: append; search: widen scope)\n' +
@@ -726,6 +731,120 @@ async function handleAsk(args: string[]): Promise<void> {
   }
 }
 
+async function handleTranscript(args: string[]): Promise<void> {
+  let filePath: string | undefined;
+  let outputArg: string | undefined;
+  let promptText: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if ((a === '--output' || a === '-o') && i + 1 < args.length) {
+      outputArg = args[++i];
+      continue;
+    }
+    if (a === '--prompt' && i + 1 < args.length) {
+      promptText = args[++i];
+      continue;
+    }
+    if (a.startsWith('-')) {
+      process.stderr.write(`Error: Unknown option: ${a}\n`);
+      process.exit(1);
+    }
+    if (filePath) {
+      process.stderr.write(`Error: Unexpected argument: ${a}\n`);
+      process.exit(1);
+    }
+    filePath = a;
+  }
+
+  if (!filePath) {
+    process.stderr.write(
+      'Error: No audio file specified. Usage: listener transcript <file> [--output <path>] [--prompt <text>]\n',
+    );
+    process.exit(1);
+  }
+
+  filePath = path.resolve(filePath);
+
+  if (!fs.existsSync(filePath)) {
+    process.stderr.write(`Error: File not found: ${filePath}\n`);
+    process.exit(1);
+  }
+
+  const ext = path.extname(filePath).toLowerCase();
+  if (!SUPPORTED_EXTENSIONS.has(ext)) {
+    process.stderr.write(`Error: Unsupported file type: ${ext}\n`);
+    process.stderr.write(`Supported formats: ${[...SUPPORTED_EXTENSIONS].join(', ')}\n`);
+    process.exit(1);
+  }
+
+  const dataPath = getDataPath();
+  const config = new ConfigService(dataPath);
+  const apiKey = config.getGeminiApiKey();
+  if (!apiKey) {
+    process.stderr.write(
+      'Error: Gemini API key not found.\n' +
+        'Set GEMINI_API_KEY env var or configure via the Listener.AI app.\n',
+    );
+    process.exit(1);
+  }
+
+  // Resolve --output before the expensive transcription so we fail fast on a
+  // bad path. Existing directory => <dir>/<basename>.transcript.md.
+  // Anything else => the path itself, treated as a file.
+  let outputPath: string | undefined;
+  if (outputArg) {
+    const resolved = path.resolve(outputArg);
+    let isDir = false;
+    try {
+      isDir = fs.statSync(resolved).isDirectory();
+    } catch {
+      // ENOENT or similar: treat as a file path, validated below.
+    }
+    if (isDir) {
+      outputPath = path.join(resolved, `${path.basename(filePath, ext)}.transcript.md`);
+    } else {
+      outputPath = resolved;
+      const parent = path.dirname(outputPath);
+      if (!fs.existsSync(parent)) {
+        process.stderr.write(`Error: Output directory does not exist: ${parent}\n`);
+        process.exit(1);
+      }
+    }
+  }
+
+  const gemini = new GeminiService({
+    apiKey,
+    dataPath,
+    knownWords: config.getKnownWords(),
+    proModel: config.getGeminiModel(),
+    flashModel: config.getGeminiFlashModel(),
+  });
+
+  process.stderr.write(`Processing: ${filePath}\n`);
+
+  const result = await gemini.transcribeAudio(
+    filePath,
+    (_percent, message) => {
+      process.stderr.write(`  ${message}\n`);
+    },
+    undefined,
+    undefined,
+    { transcriptOnly: true, transcriptionPrompt: promptText },
+  );
+
+  if (outputPath) {
+    fs.writeFileSync(outputPath, result.transcript, 'utf-8');
+    process.stderr.write('Done.\n');
+    process.stdout.write(`${outputPath}\n`);
+  } else {
+    // Wait for the OS to drain the write before returning, so multi-MB
+    // transcripts piped to a slow consumer are not truncated on process exit.
+    const out = result.transcript.endsWith('\n') ? result.transcript : `${result.transcript}\n`;
+    await new Promise<void>((resolve) => process.stdout.write(out, () => resolve()));
+  }
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
@@ -777,12 +896,17 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (args[0] === 'transcript') {
+    await handleTranscript(args.slice(1));
+    return;
+  }
+
   // Parse arguments
   let filePath: string | undefined;
   let outputDir: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--output' && i + 1 < args.length) {
+    if ((args[i] === '--output' || args[i] === '-o') && i + 1 < args.length) {
       outputDir = args[++i];
     } else if (args[i].startsWith('-')) {
       process.stderr.write(`Error: Unknown option: ${args[i]}\n`);

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -100,6 +100,49 @@ export interface HighlightEntry {
   bullets?: string[];
 }
 
+export interface TranscriptionOptions {
+  transcriptOnly?: boolean;
+  /**
+   * Override the default speaker-identification instruction sent to Gemini
+   * during transcription. The user-supplied glossary (knownWords) and
+   * per-segment positional prefix are still applied automatically.
+   */
+  transcriptionPrompt?: string;
+}
+
+function transcriptOnlyResult(transcript: string): TranscriptionResult {
+  return {
+    transcript,
+    summary: '',
+    keyPoints: [],
+    actionItems: [],
+    emoji: '',
+  };
+}
+
+const DEFAULT_TRANSCRIPT_PROMPT = `Please transcribe this audio recording with proper speaker identification.
+
+Format requirements:
+1. IDENTIFY different speakers and label them as 참가자1, 참가자2, etc.
+2. Each speaker's turn MUST start on a NEW LINE
+3. Format: 참가자X: [what they said]
+4. Add a blank line between different speakers
+
+Example format:
+참가자1: 안녕하세요, 오늘 회의를 시작하겠습니다.
+
+참가자2: 네, 준비됐습니다.
+
+참가자1: 첫 번째 안건은...
+
+IMPORTANT:
+- You MUST identify and differentiate between speakers
+- Each speaker turn MUST start on a new line
+- Add blank line between different speakers
+- DO NOT include timestamps
+- Keep the transcription in the original spoken language
+- Return ONLY the transcription text, no JSON formatting`;
+
 export interface GeminiServiceOptions {
   apiKey: string;
   dataPath?: string;
@@ -147,6 +190,7 @@ export class GeminiService {
     progressCallback?: (percent: number, message: string) => void,
     summaryPrompt?: string,
     liveNotes?: LiveNote[],
+    options: TranscriptionOptions = {},
   ): Promise<TranscriptionResult> {
     // Integration-test escape hatch: avoid the real Gemini call so tests can
     // exercise the surrounding pipeline (CLI parsing, IPC, ffmpeg, save) for
@@ -154,6 +198,9 @@ export class GeminiService {
     // in a packaged user's shell rc can't silently stub their transcripts.
     if (process.env.LISTENER_TEST_MODE && process.env.NODE_ENV === 'test') {
       if (progressCallback) progressCallback(100, 'Stubbed transcription');
+      if (options.transcriptOnly) {
+        return transcriptOnlyResult('Stubbed transcript.');
+      }
       return {
         transcript: 'Stubbed transcript.',
         summary: 'Stubbed summary.',
@@ -168,7 +215,7 @@ export class GeminiService {
       // Check file size
       const stats = fs.statSync(audioFilePath);
       const fileSizeInMB = stats.size / (1024 * 1024);
-      console.log(`Audio file size: ${fileSizeInMB.toFixed(2)} MB`);
+      console.error(`Audio file size: ${fileSizeInMB.toFixed(2)} MB`);
 
       if (progressCallback) {
         progressCallback(15, `Processing ${fileSizeInMB.toFixed(1)} MB audio file...`);
@@ -176,7 +223,7 @@ export class GeminiService {
 
       // Get audio duration using ffmpeg
       const duration = await this.getAudioDuration(audioFilePath);
-      console.log(`Audio duration: ${duration} seconds`);
+      console.error(`Audio duration: ${duration} seconds`);
 
       // If duration is 0, log a warning but continue processing
       if (duration === 0) {
@@ -186,13 +233,14 @@ export class GeminiService {
       }
 
       // Always use the two-step approach for consistency
-      console.log('Using two-step transcription approach...');
+      console.error('Using two-step transcription approach...');
       return await this.transcribeWithTwoSteps(
         audioFilePath,
         duration,
         progressCallback,
         summaryPrompt,
         liveNotes,
+        options,
       );
     } catch (error) {
       console.error('Error transcribing audio:', error);
@@ -221,7 +269,7 @@ export class GeminiService {
 
       // Use ffmpeg with -f null to get file info including duration
       // This will output file info to stderr which we can parse
-      console.log('Running ffmpeg for duration:', ffmpegPath, audioFilePath);
+      console.error('Running ffmpeg for duration:', ffmpegPath, audioFilePath);
 
       const { stderr } = await execFileAsync(ffmpegPath, [
         '-i',
@@ -243,7 +291,7 @@ export class GeminiService {
         const minutes = Number.parseInt(durationMatch[2]);
         const seconds = Number.parseFloat(durationMatch[3]);
         const totalSeconds = hours * 3600 + minutes * 60 + seconds;
-        console.log(`FFmpeg extracted duration: ${totalSeconds} seconds`);
+        console.error(`FFmpeg extracted duration: ${totalSeconds} seconds`);
         return totalSeconds;
       }
 
@@ -254,7 +302,7 @@ export class GeminiService {
         const minutes = Number.parseInt(altDurationMatch[2]);
         const seconds = Number.parseInt(altDurationMatch[3]);
         const totalSeconds = hours * 3600 + minutes * 60 + seconds;
-        console.log(`FFmpeg extracted duration (alt format): ${totalSeconds} seconds`);
+        console.error(`FFmpeg extracted duration (alt format): ${totalSeconds} seconds`);
         return totalSeconds;
       }
 
@@ -303,7 +351,7 @@ export class GeminiService {
         .map((file) => path.join(outputDir, file))
         .sort();
 
-      console.log(`Split audio into ${segmentFiles.length} segments`);
+      console.error(`Split audio into ${segmentFiles.length} segments`);
       return segmentFiles;
     } catch (error: any) {
       console.error('Error splitting audio:', error);
@@ -365,6 +413,7 @@ export class GeminiService {
     progressCallback?: (percent: number, message: string) => void,
     customSummaryPrompt?: string,
     liveNotes?: LiveNote[],
+    options: TranscriptionOptions = {},
   ): Promise<TranscriptionResult> {
     try {
       let fullTranscript = '';
@@ -372,16 +421,28 @@ export class GeminiService {
       // Step 1: Get transcript
       if (duration > 300) {
         // Use segmented approach for long audio
-        console.log('Audio is longer than 5 minutes, using segmented transcription...');
+        console.error('Audio is longer than 5 minutes, using segmented transcription...');
         fullTranscript = await this.getSegmentedTranscript(
           audioFilePath,
           duration,
           progressCallback,
+          options.transcriptionPrompt,
         );
       } else {
         // Get transcript for short audio
-        console.log('Transcribing short audio...');
-        fullTranscript = await this.getShortAudioTranscript(audioFilePath, progressCallback);
+        console.error('Transcribing short audio...');
+        fullTranscript = await this.getShortAudioTranscript(
+          audioFilePath,
+          progressCallback,
+          options.transcriptionPrompt,
+        );
+      }
+
+      if (options.transcriptOnly) {
+        if (progressCallback) {
+          progressCallback(100, 'Transcript ready');
+        }
+        return transcriptOnlyResult(fullTranscript);
       }
 
       // Step 2: Generate summary, key points, action items from transcript
@@ -488,6 +549,7 @@ Return as JSON:
   private async getShortAudioTranscript(
     audioFilePath: string,
     progressCallback?: (percent: number, message: string) => void,
+    customPrompt?: string,
   ): Promise<string> {
     try {
       const stats = fs.statSync(audioFilePath);
@@ -500,7 +562,7 @@ Return as JSON:
       // Use Files API for files over 20MB
       let fileUri: string | null = null;
       if (fileSizeInMB > 20) {
-        console.log('File is over 20MB, using Files API for upload...');
+        console.error('File is over 20MB, using Files API for upload...');
 
         if (progressCallback) {
           progressCallback(25, 'Uploading large file to Gemini...');
@@ -519,7 +581,7 @@ Return as JSON:
         let file = await this.ai.files.get({ name: uploadResult.name || '' });
         let retries = 0;
         while (file.state === 'PROCESSING' && retries < 30) {
-          console.log(`Waiting for file to be processed... (attempt ${retries + 1}/30)`);
+          console.error(`Waiting for file to be processed... (attempt ${retries + 1}/30)`);
           await new Promise((resolve) => setTimeout(resolve, 2000));
           file = await this.ai.files.get({ name: uploadResult.name || '' });
           retries++;
@@ -534,28 +596,7 @@ Return as JSON:
         progressCallback(50, 'Transcribing audio...');
       }
 
-      const transcriptPrompt = `${this.buildGlossaryBlock()}Please transcribe this audio recording with proper speaker identification.
-
-Format requirements:
-1. IDENTIFY different speakers and label them as 참가자1, 참가자2, etc.
-2. Each speaker's turn MUST start on a NEW LINE
-3. Format: 참가자X: [what they said]
-4. Add a blank line between different speakers
-
-Example format:
-참가자1: 안녕하세요, 오늘 회의를 시작하겠습니다.
-
-참가자2: 네, 준비됐습니다.
-
-참가자1: 첫 번째 안건은...
-
-IMPORTANT:
-- You MUST identify and differentiate between speakers
-- Each speaker turn MUST start on a new line
-- Add blank line between different speakers
-- DO NOT include timestamps
-- Keep the transcription in the original spoken language
-- Return ONLY the transcription text, no JSON formatting`;
+      const transcriptPrompt = `${this.buildGlossaryBlock()}${customPrompt ?? DEFAULT_TRANSCRIPT_PROMPT}`;
 
       let result: Awaited<ReturnType<typeof this.ai.models.generateContent>>;
       if (fileUri) {
@@ -635,29 +676,14 @@ IMPORTANT:
   }
 
   // Create prompt for segment transcription
-  private createSegmentPrompt(segmentIndex: number, totalSegments: number): string {
-    return `${this.buildGlossaryBlock()}Please transcribe audio segment ${segmentIndex + 1} of ${totalSegments} with proper speaker identification.
-
-Format requirements:
-1. IDENTIFY different speakers and label them as 참가자1, 참가자2, etc.
-2. Each speaker's turn MUST start on a NEW LINE
-3. Format: 참가자X: [what they said]
-4. Add a blank line between different speakers
-
-Example format:
-참가자1: 안녕하세요, 오늘 회의를 시작하겠습니다.
-
-참가자2: 네, 준비됐습니다.
-
-참가자1: 첫 번째 안건은...
-
-IMPORTANT:
-- You MUST identify and differentiate between speakers
-- Each speaker turn MUST start on a new line
-- Add blank line between different speakers
-- DO NOT include timestamps
-- Keep the transcription in the original spoken language
-- Return ONLY the transcription text, no JSON formatting`;
+  private createSegmentPrompt(
+    segmentIndex: number,
+    totalSegments: number,
+    customPrompt?: string,
+  ): string {
+    const positional = `[Audio segment ${segmentIndex + 1} of ${totalSegments}]\n\n`;
+    const body = customPrompt ?? DEFAULT_TRANSCRIPT_PROMPT;
+    return `${this.buildGlossaryBlock()}${positional}${body}`;
   }
 
   // Transcribe a single segment with retry logic
@@ -667,14 +693,15 @@ IMPORTANT:
     totalSegments: number,
     segmentStartTime: number,
     segmentEndTime: number,
+    customPrompt?: string,
   ): Promise<{ index: number; content: string }> {
     const maxRetries = 3;
     let lastError: any = null;
-    const segmentPrompt = this.createSegmentPrompt(segmentIndex, totalSegments);
+    const segmentPrompt = this.createSegmentPrompt(segmentIndex, totalSegments, customPrompt);
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        console.log(
+        console.error(
           `Starting transcription for segment ${segmentIndex + 1}/${totalSegments} (attempt ${attempt}/${maxRetries})...`,
         );
 
@@ -706,7 +733,7 @@ IMPORTANT:
 
         const transcript = result.text || '';
 
-        console.log(`Completed transcription for segment ${segmentIndex + 1}/${totalSegments}`);
+        console.error(`Completed transcription for segment ${segmentIndex + 1}/${totalSegments}`);
 
         // Add segment time range header
         const segmentHeader = this.createSegmentHeader(
@@ -729,7 +756,7 @@ IMPORTANT:
         if (attempt < maxRetries) {
           // Wait before retry with exponential backoff
           const retryDelay = Math.min(1000 * 2 ** (attempt - 1), 10000); // Max 10 seconds
-          console.log(`Retrying segment ${segmentIndex + 1} in ${retryDelay}ms...`);
+          console.error(`Retrying segment ${segmentIndex + 1} in ${retryDelay}ms...`);
           await new Promise((resolve) => setTimeout(resolve, retryDelay));
         }
       }
@@ -751,6 +778,7 @@ IMPORTANT:
     audioFilePath: string,
     duration: number,
     progressCallback?: (percent: number, message: string) => void,
+    customPrompt?: string,
   ): Promise<string> {
     try {
       // Split audio into 5-minute segments
@@ -771,6 +799,7 @@ IMPORTANT:
           segmentFiles.length,
           segmentStartTime,
           segmentEndTime,
+          customPrompt,
         );
       });
 


### PR DESCRIPTION
## Summary

Alternative to [#113](https://github.com/asleep-ai/listener-ai/pull/113). Same goal — let CLI users get just the transcript text without spending a second Gemini call on summary/keyPoints/actionItems — but shaped as a dedicated subcommand instead of a flag bolted onto the existing meeting-note pipeline.

```bash
listener transcript foo.mp3                  # transcript -> stdout (pipe-friendly)
listener transcript foo.mp3 -o out.txt       # write to a file
listener transcript foo.mp3 -o ./            # write to ./foo.transcript.md
```

The transcript subcommand does **not** write into the transcription store, so the result does not appear in \`listener list\`/\`search\`/\`show\`. The existing \`listener <file>\` and \`listener merge\` keep their current behavior (full meeting-note pipeline).

## Why a subcommand, not a flag

Review of #113 surfaced one critical issue with the flag-on-the-existing-pipeline shape: writing \`summary: ''\` to \`summary.md\`'s YAML frontmatter round-trips back as an empty array (\`[]\`), because \`parseFrontmatter\` treats an empty scalar as the start of a list. \`searchService.findIndex\` then calls \`.toLowerCase()\` on that array and crashes \`listener search\` against transcript-only notes. Sidestepping it required either patching the YAML quoting or rethinking the duplication between frontmatter and body — both larger than the feature warranted.

A separate subcommand avoids the problem entirely: no \`summary.md\`, no frontmatter, no YAML escaping, no participation in the store. It also matches the actual user intent more cleanly ("just give me text" vs "make me a meeting note, but skip half of it").

## What changed

- \`src/geminiService.ts\` — new \`TranscriptionOptions { transcriptOnly }\`, short-circuit after Step 1 in \`transcribeWithTwoSteps\`, mirrored in the \`LISTENER_TEST_MODE\` stub
- \`src/cli.ts\` — new \`handleTranscript\` handler + \`transcript\` subcommand routing, updated \`USAGE_TEXT\`
- \`src/cli.test.ts\` — six new integration tests (stdout, --output file, -o alias, --output directory, missing-file/missing-parent errors, store-untouched assertion)
- \`README.md\`, \`CLAUDE.md\` — usage examples and CLI reference updated

## Tests

- \`tsc\` clean
- \`oxlint\`: 0 warnings 0 errors
- \`oxfmt --check\`: pass
- \`node --test\` across the full suite: 90 pass, 0 fail (17 in \`cli.test.js\`, including the 6 new ones)

## Conflict with #113

This PR overlaps the same files (\`README.md\`, \`src/cli.ts\`, \`src/geminiService.ts\`, \`src/cli.test.ts\`) and replaces the flag-shaped UX from #113. Only one of the two should land.