### PR TITLE
Add in-recording highlights with AI enrichment

### DIFF
--- a/renderer/audio/recorder.ts
+++ b/renderer/audio/recorder.ts
@@ -302,23 +302,23 @@ export async function processAutoMode(
 export async function handleRecordingStopped(
   audioPath: string | undefined,
   durationMs: number | undefined,
+  liveNotes?: Array<{ offsetMs: number; text: string }>,
 ): Promise<void> {
   const { meetingTitle } = getDom();
-  // Snapshot before resetRecordingUI clears state.liveNotes via hideLiveNotesPanel.
-  const liveNotesSnapshot = state.liveNotes.length > 0 ? state.liveNotes.slice() : undefined;
   resetRecordingUI();
   const recordingTitle = meetingTitle.value.trim() || 'Untitled_Meeting';
   meetingTitle.value = '';
   await refreshRecordingsList();
-  await processAutoMode(audioPath, recordingTitle, durationMs, liveNotesSnapshot);
+  await processAutoMode(audioPath, recordingTitle, durationMs, liveNotes);
 }
 
 export async function stopRecording(): Promise<void> {
   // Snapshot live notes before they get cleared by the UI reset. Passed to
   // main so they're persisted alongside the audio file regardless of whether
-  // auto-mode kicks off transcription right away.
-  const liveNotesPayload =
-    state.liveNotes.length > 0 ? { liveNotes: state.liveNotes.slice() } : undefined;
+  // auto-mode kicks off transcription right away, and forwarded into the
+  // auto-mode path so transcribe-audio gets them without re-reading state.
+  const liveNotesSnapshot = state.liveNotes.length > 0 ? state.liveNotes.slice() : undefined;
+  const liveNotesPayload = liveNotesSnapshot ? { liveNotes: liveNotesSnapshot } : undefined;
 
   // If the recorder already transitioned to inactive on its own (e.g. USB mic
   // unplugged, stream ended, Chromium force-stopped encoding), still unwind the
@@ -328,7 +328,7 @@ export async function stopRecording(): Promise<void> {
     try {
       const result = await window.electronAPI.stopRecording(liveNotesPayload);
       if (result?.success) {
-        await handleRecordingStopped(result.filePath, result.durationMs);
+        await handleRecordingStopped(result.filePath, result.durationMs, liveNotesSnapshot);
         return;
       }
     } catch {
@@ -355,7 +355,7 @@ export async function stopRecording(): Promise<void> {
     const result = await window.electronAPI.stopRecording(liveNotesPayload);
 
     if (result.success) {
-      await handleRecordingStopped(result.filePath, result.durationMs);
+      await handleRecordingStopped(result.filePath, result.durationMs, liveNotesSnapshot);
     } else if (result.reason === 'empty') {
       alert('No audio captured.');
       resetRecordingUI();

--- a/renderer/audio/recorder.ts
+++ b/renderer/audio/recorder.ts
@@ -2,6 +2,7 @@
 // auto-mode post-processing. Owns the click handler on the record button.
 
 import { getDom, state } from '../state';
+import { hideLiveNotesPanel, showLiveNotesPanel } from '../ui/live-notes';
 import { showNotification, showToast } from '../ui/notifications';
 import { refreshRecordingsList } from '../ui/recordings-list';
 import { buildProcessedStream, cleanupAudioState, pickRecordingMimeType } from './graph';
@@ -152,6 +153,7 @@ export async function startRecording(): Promise<void> {
   statusIndicator.classList.add('recording');
   statusText.textContent = 'Recording...';
   recordingTime.classList.add('active');
+  showLiveNotesPanel();
 
   startTimer();
 }
@@ -165,6 +167,7 @@ export function resetRecordingUI(): void {
   statusIndicator.classList.remove('recording');
   statusText.textContent = 'Ready to record';
   recordingTime.classList.remove('active');
+  hideLiveNotesPanel();
 }
 
 function pickMeetingTitle(recordingTitle: string, suggestedTitle?: string): string {
@@ -177,6 +180,7 @@ export async function processAutoMode(
   audioPath: string | undefined,
   recordingTitle: string,
   durationMs: number | undefined,
+  liveNotes?: Array<{ offsetMs: number; text: string }>,
 ): Promise<void> {
   const { autoModeToggle, recordButton, statusText } = getDom();
   if (!autoModeToggle.checked || !audioPath) return;
@@ -204,7 +208,7 @@ export async function processAutoMode(
 
   try {
     console.log('Auto mode: Starting transcription...');
-    const transcriptionResult = await window.electronAPI.transcribeAudio(audioPath);
+    const transcriptionResult = await window.electronAPI.transcribeAudio(audioPath, liveNotes);
 
     if (transcriptionResult.success) {
       console.log('Auto mode: Transcription complete');
@@ -300,21 +304,29 @@ export async function handleRecordingStopped(
   durationMs: number | undefined,
 ): Promise<void> {
   const { meetingTitle } = getDom();
+  // Snapshot before resetRecordingUI clears state.liveNotes via hideLiveNotesPanel.
+  const liveNotesSnapshot = state.liveNotes.length > 0 ? state.liveNotes.slice() : undefined;
   resetRecordingUI();
   const recordingTitle = meetingTitle.value.trim() || 'Untitled_Meeting';
   meetingTitle.value = '';
   await refreshRecordingsList();
-  await processAutoMode(audioPath, recordingTitle, durationMs);
+  await processAutoMode(audioPath, recordingTitle, durationMs, liveNotesSnapshot);
 }
 
 export async function stopRecording(): Promise<void> {
+  // Snapshot live notes before they get cleared by the UI reset. Passed to
+  // main so they're persisted alongside the audio file regardless of whether
+  // auto-mode kicks off transcription right away.
+  const liveNotesPayload =
+    state.liveNotes.length > 0 ? { liveNotes: state.liveNotes.slice() } : undefined;
+
   // If the recorder already transitioned to inactive on its own (e.g. USB mic
   // unplugged, stream ended, Chromium force-stopped encoding), still unwind the
   // session so the next recording isn't blocked by stuck state.
   if (!state.mediaRecorder || state.mediaRecorder.state === 'inactive') {
     cleanupAudioState();
     try {
-      const result = await window.electronAPI.stopRecording();
+      const result = await window.electronAPI.stopRecording(liveNotesPayload);
       if (result?.success) {
         await handleRecordingStopped(result.filePath, result.durationMs);
         return;
@@ -340,7 +352,7 @@ export async function stopRecording(): Promise<void> {
     await state.chunkSendChain;
     cleanupAudioState();
 
-    const result = await window.electronAPI.stopRecording();
+    const result = await window.electronAPI.stopRecording(liveNotesPayload);
 
     if (result.success) {
       await handleRecordingStopped(result.filePath, result.durationMs);

--- a/renderer/electronAPI.d.ts
+++ b/renderer/electronAPI.d.ts
@@ -52,7 +52,7 @@ export type ElectronAPI = {
     filePath?: string;
   }>;
   sendRecordingChunk: (data: ArrayBuffer) => void;
-  stopRecording: () => Promise<{
+  stopRecording: (opts?: { liveNotes?: Array<{ offsetMs: number; text: string }> }) => Promise<{
     success: boolean;
     filePath?: string;
     durationMs?: number;
@@ -68,7 +68,10 @@ export type ElectronAPI = {
   }>;
   saveConfig: (config: ConfigPayload) => Promise<{ success: boolean; error?: string }>;
   getConfig: () => Promise<Record<string, unknown>>;
-  transcribeAudio: (filePath: string) => Promise<{
+  transcribeAudio: (
+    filePath: string,
+    liveNotes?: Array<{ offsetMs: number; text: string }>,
+  ) => Promise<{
     success: boolean;
     data?: any;
     newFilePath?: string;

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -48,6 +48,25 @@
 
       <div id="recordingTime" class="recording-time">00:00</div>
 
+      <div id="liveNotesPanel" class="live-notes-panel" style="display: none;">
+        <div class="live-notes-header">
+          <span class="live-notes-title">🗒️ Highlights</span>
+          <button type="button" id="liveNoteFlagButton" class="live-note-flag-button" title="Add a timestamped flag">
+            🏴 Flag
+          </button>
+        </div>
+        <ul id="liveNotesList" class="live-notes-list" aria-live="polite"></ul>
+        <p id="liveNotesEmpty" class="live-notes-empty">No highlights yet. Hit Flag to mark a moment, or type below.</p>
+        <input
+          type="text"
+          id="liveNoteInput"
+          class="live-note-input"
+          placeholder="Type a note and press Enter -- captures the current time"
+          autocomplete="off"
+          spellcheck="false"
+        />
+      </div>
+
       <div class="auto-mode-container">
         <label class="toggle-container">
           <input type="checkbox" id="autoModeToggle">

--- a/renderer/main.ts
+++ b/renderer/main.ts
@@ -9,6 +9,7 @@ import { setupAgentConfirmHandler, setupHomeChat, setupModalChat } from './ui/ch
 import { checkAndPromptForConfig, setupConfigModal } from './ui/config-modal';
 import { setupDragAndDrop, setupPasteListener } from './ui/drag-drop';
 import { setupHomeToggles } from './ui/home-toggles';
+import { setupLiveNotes } from './ui/live-notes';
 import { setupMicSelector } from './ui/mic-selector';
 import { setupNotifications } from './ui/notifications';
 import { setupPermissionStatus } from './ui/permission-status';
@@ -80,6 +81,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     // recorder before UI that triggers it, then UI modules in any order.
     setupNotifications();
     setupRecorder();
+    setupLiveNotes();
     setupHomeToggles();
     setupMicSelector();
     setupPermissionStatus();

--- a/renderer/state.ts
+++ b/renderer/state.ts
@@ -6,6 +6,11 @@
 // (lines ~34-57, 262, 292-296). Field names are preserved for greppability
 // against the original code during review.
 
+export type LiveNote = {
+  offsetMs: number;
+  text: string;
+};
+
 export type RecorderState = {
   isRecording: boolean;
   recordingStartTime: number | null;
@@ -29,6 +34,10 @@ export type RecorderState = {
 
   // System-audio cleanup (set by createSystemAudioSource).
   systemAudioCleanup: (() => void | Promise<void>) | null;
+
+  // Timestamped notes captured while recording. Cleared on start. Forwarded
+  // to main via transcribeAudio so they land in summary.md + Notion.
+  liveNotes: LiveNote[];
 };
 
 export const state: RecorderState = {
@@ -45,6 +54,7 @@ export const state: RecorderState = {
   graphHead: null,
   chunkSendChain: Promise.resolve(),
   systemAudioCleanup: null,
+  liveNotes: [],
 };
 
 // DOM references resolved once at DOMContentLoaded, used by many UI modules.

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -360,6 +360,123 @@ h1 {
   display: block;
 }
 
+.live-notes-panel {
+  margin-top: 14px;
+  padding: 14px;
+  background: #f8fafc;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 10px;
+}
+
+.live-notes-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.live-notes-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #0f172a;
+  letter-spacing: -0.005em;
+}
+
+.live-note-flag-button {
+  appearance: none;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: white;
+  color: #0f172a;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 5px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.live-note-flag-button:hover {
+  background: #eff6ff;
+  border-color: rgba(52, 152, 219, 0.5);
+}
+
+.live-note-flag-button:active {
+  background: #dbeafe;
+}
+
+.live-notes-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 180px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.live-note-item {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 6px 8px;
+  background: white;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 6px;
+  font-size: 13px;
+  color: #0f172a;
+  line-height: 1.4;
+}
+
+.live-note-time {
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  font-weight: 600;
+  color: #64748b;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.live-note-text {
+  flex: 1;
+  word-break: break-word;
+}
+
+.live-note-text--flag {
+  color: #64748b;
+}
+
+.live-notes-empty {
+  margin: 4px 0 0;
+  padding: 6px 4px;
+  font-size: 12px;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.live-note-input {
+  margin-top: 10px;
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 13px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 8px;
+  background: white;
+  color: #0f172a;
+  box-sizing: border-box;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.live-note-input::placeholder {
+  color: #94a3b8;
+}
+
+.live-note-input:focus {
+  outline: none;
+  border-color: rgba(52, 152, 219, 0.55);
+  box-shadow: var(--focus-ring);
+}
+
 .recordings-section {
   background: white;
   border-radius: 12px;

--- a/renderer/ui/live-notes.ts
+++ b/renderer/ui/live-notes.ts
@@ -1,0 +1,123 @@
+// In-recording notes panel (Plaud-style highlights). Visible only while
+// recording. Holds an append-only list of {offsetMs, text} captured from the
+// user; the flag button records the moment with empty text, the text input
+// records the moment with the typed text. Notes leave the renderer when
+// transcribeAudio forwards them to main at the end of the recording.
+
+import { type LiveNote, state } from '../state';
+
+const NOTE_MAX_TEXT = 2000;
+const NOTE_MAX_COUNT = 500;
+
+let panelEl: HTMLElement | null = null;
+let listEl: HTMLElement | null = null;
+let inputEl: HTMLInputElement | null = null;
+let flagButtonEl: HTMLButtonElement | null = null;
+let emptyHintEl: HTMLElement | null = null;
+
+function formatTimestamp(offsetMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(offsetMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+function currentOffsetMs(): number {
+  if (state.recordingStartTime == null) return 0;
+  return Math.max(0, Date.now() - state.recordingStartTime);
+}
+
+function renderList(): void {
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  for (const note of state.liveNotes) {
+    const item = document.createElement('li');
+    item.className = 'live-note-item';
+
+    const ts = document.createElement('span');
+    ts.className = 'live-note-time';
+    ts.textContent = formatTimestamp(note.offsetMs);
+
+    const body = document.createElement('span');
+    body.className = 'live-note-text';
+    const trimmed = note.text.trim();
+    if (trimmed) {
+      body.textContent = trimmed;
+    } else {
+      body.textContent = '🏴';
+      body.classList.add('live-note-text--flag');
+    }
+
+    item.appendChild(ts);
+    item.appendChild(body);
+    listEl.appendChild(item);
+  }
+
+  if (emptyHintEl) {
+    emptyHintEl.style.display = state.liveNotes.length === 0 ? '' : 'none';
+  }
+}
+
+function appendNote(note: LiveNote): void {
+  if (state.liveNotes.length >= NOTE_MAX_COUNT) return;
+  state.liveNotes.push(note);
+  renderList();
+}
+
+function addFlag(): void {
+  if (!state.isRecording) return;
+  appendNote({ offsetMs: currentOffsetMs(), text: '' });
+}
+
+function commitTextInput(): void {
+  if (!state.isRecording || !inputEl) return;
+  const text = inputEl.value.trim();
+  if (!text) return;
+  appendNote({ offsetMs: currentOffsetMs(), text: text.slice(0, NOTE_MAX_TEXT) });
+  inputEl.value = '';
+}
+
+export function showLiveNotesPanel(): void {
+  state.liveNotes = [];
+  renderList();
+  if (panelEl) panelEl.style.display = '';
+  if (inputEl) inputEl.value = '';
+}
+
+export function hideLiveNotesPanel(): void {
+  if (panelEl) panelEl.style.display = 'none';
+  if (inputEl) inputEl.value = '';
+  state.liveNotes = [];
+  renderList();
+}
+
+export function setupLiveNotes(): void {
+  panelEl = document.getElementById('liveNotesPanel');
+  listEl = document.getElementById('liveNotesList');
+  inputEl = document.getElementById('liveNoteInput') as HTMLInputElement | null;
+  flagButtonEl = document.getElementById('liveNoteFlagButton') as HTMLButtonElement | null;
+  emptyHintEl = document.getElementById('liveNotesEmpty');
+
+  if (!panelEl || !listEl || !inputEl || !flagButtonEl) return;
+
+  // Start hidden -- the recorder shows it via showLiveNotesPanel on start.
+  panelEl.style.display = 'none';
+
+  flagButtonEl.addEventListener('click', () => {
+    addFlag();
+  });
+
+  inputEl.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter') return;
+    // Korean/Japanese/Chinese IMEs use Enter to commit the in-flight
+    // composition (e.g. finishing 지금). Acting on Enter mid-composition
+    // submits a partial note and double-fires when the IME re-emits Enter
+    // after the composition lands. keyCode === 229 covers older WebKit
+    // that doesn't set isComposing.
+    if (event.isComposing || event.keyCode === 229) return;
+    event.preventDefault();
+    commitTextInput();
+  });
+
+  renderList();
+}

--- a/renderer/ui/live-notes.ts
+++ b/renderer/ui/live-notes.ts
@@ -78,10 +78,10 @@ function commitTextInput(): void {
 }
 
 export function showLiveNotesPanel(): void {
-  state.liveNotes = [];
+  // hideLiveNotesPanel (via resetRecordingUI) already clears state.liveNotes
+  // when a previous recording ends, so we only render+show here.
   renderList();
   if (panelEl) panelEl.style.display = '';
-  if (inputEl) inputEl.value = '';
 }
 
 export function hideLiveNotesPanel(): void {

--- a/renderer/ui/markdown-utils.ts
+++ b/renderer/ui/markdown-utils.ts
@@ -31,6 +31,58 @@ export function escapeHtml(str: unknown): string {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type TranscriptionData = any;
 
+function formatLiveNoteTimestamp(offsetMs: unknown): string {
+  const n = Number(offsetMs);
+  const totalSeconds = Number.isFinite(n) ? Math.max(0, Math.floor(n / 1000)) : 0;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+function liveNotesToLines(liveNotes: unknown): string[] {
+  if (!Array.isArray(liveNotes) || liveNotes.length === 0) return [];
+  const lines: string[] = [];
+  for (const note of liveNotes) {
+    if (!note || typeof note !== 'object') continue;
+    const ts = formatLiveNoteTimestamp((note as { offsetMs?: unknown }).offsetMs);
+    const raw = (note as { text?: unknown }).text;
+    const text = typeof raw === 'string' ? raw.trim() : '';
+    lines.push(text ? `- [${ts}] ${text}` : `- [${ts}] 🏴`);
+  }
+  return lines;
+}
+
+function highlightsToLines(highlights: unknown): string[] {
+  if (!Array.isArray(highlights) || highlights.length === 0) return [];
+  const lines: string[] = [];
+  for (const h of highlights) {
+    if (!h || typeof h !== 'object') continue;
+    const ts = formatLiveNoteTimestamp((h as { offsetMs?: unknown }).offsetMs);
+    const userText = (h as { userText?: unknown }).userText;
+    const title = typeof userText === 'string' ? userText.trim() : '';
+    lines.push(title ? `### [${ts}] ${title}` : `### [${ts}] 🏴`);
+    const subtitle = (h as { subtitle?: unknown }).subtitle;
+    if (typeof subtitle === 'string' && subtitle.trim()) {
+      lines.push(`*${subtitle.trim()}*`);
+    }
+    const bullets = (h as { bullets?: unknown }).bullets;
+    if (Array.isArray(bullets) && bullets.length > 0) {
+      lines.push('');
+      for (const b of bullets) {
+        if (typeof b === 'string' && b.trim()) lines.push(`- ${b}`);
+      }
+    }
+    lines.push('');
+  }
+  return lines;
+}
+
+function renderHighlightLines(data: TranscriptionData): string[] {
+  const enriched = highlightsToLines(data.highlights);
+  if (enriched.length > 0) return enriched;
+  return liveNotesToLines(data.liveNotes);
+}
+
 // Convert structured transcription data to a markdown string
 export function structuredToMarkdown(data: TranscriptionData, section: string): string {
   const lines: string[] = [];
@@ -59,6 +111,15 @@ export function structuredToMarkdown(data: TranscriptionData, section: string): 
       for (const item of data.actionItems) {
         lines.push(`- ${item}`);
       }
+      lines.push('');
+    }
+  }
+
+  if (section === 'all' || section === 'livenotes') {
+    const noteLines = renderHighlightLines(data);
+    if (noteLines.length > 0) {
+      if (section === 'all') lines.push('## 🗒️ Highlights\n');
+      lines.push(...noteLines);
       lines.push('');
     }
   }
@@ -112,6 +173,15 @@ export function renderDynamicFields(data: TranscriptionData): void {
   }
   if (data.actionItems?.length) {
     fields.push({ key: 'actions', label: 'Action Items', value: data.actionItems });
+  }
+  const hasHighlights = Array.isArray(data.highlights) && data.highlights.length > 0;
+  const hasLiveNotes = Array.isArray(data.liveNotes) && data.liveNotes.length > 0;
+  if (hasHighlights || hasLiveNotes) {
+    fields.push({
+      key: 'livenotes',
+      label: '🗒️ Highlights',
+      value: hasHighlights ? data.highlights : data.liveNotes,
+    });
   }
   if (data.customFields) {
     for (const [key, value] of Object.entries(data.customFields)) {

--- a/renderer/ui/transcription-modal.ts
+++ b/renderer/ui/transcription-modal.ts
@@ -128,6 +128,8 @@ export function showSavedTranscript(
       suggestedTitle: metadata.suggestedTitle,
       customFields: metadata.customFields,
       emoji: metadata.emoji,
+      liveNotes: metadata.liveNotes,
+      highlights: metadata.highlights,
     };
     currentMeetingTitle = title;
     currentFilePath = filePath;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -436,6 +436,26 @@ async function handleExport(args: string[]): Promise<void> {
         /* ignore */
       }
     }
+    let liveNotes: Array<{ offsetMs: number; text: string }> | undefined;
+    if (meta.liveNotes) {
+      try {
+        const parsed =
+          typeof meta.liveNotes === 'string' ? JSON.parse(meta.liveNotes) : meta.liveNotes;
+        if (Array.isArray(parsed)) liveNotes = parsed;
+      } catch {
+        /* ignore */
+      }
+    }
+    let highlights: unknown[] | undefined;
+    if (meta.highlights) {
+      try {
+        const parsed =
+          typeof meta.highlights === 'string' ? JSON.parse(meta.highlights) : meta.highlights;
+        if (Array.isArray(parsed)) highlights = parsed;
+      } catch {
+        /* ignore */
+      }
+    }
     const obj: Record<string, unknown> = {
       title: meta.title || '',
       transcribedAt: meta.transcribedAt || '',
@@ -443,6 +463,8 @@ async function handleExport(args: string[]): Promise<void> {
       keyPoints: meta.keyPoints || [],
       actionItems: meta.actionItems || [],
       customFields,
+      ...(liveNotes ? { liveNotes } : {}),
+      ...(highlights ? { highlights } : {}),
     };
     if (includeTranscript) {
       obj.transcript = meta.transcript || '';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,8 @@ import {
   getTranscriptionsDir,
   listTranscriptions,
   parseFrontmatter,
+  parseHighlightsField,
+  parseLiveNotesField,
   readTranscription,
   sanitizeForPath,
   saveTranscription,
@@ -436,26 +438,8 @@ async function handleExport(args: string[]): Promise<void> {
         /* ignore */
       }
     }
-    let liveNotes: Array<{ offsetMs: number; text: string }> | undefined;
-    if (meta.liveNotes) {
-      try {
-        const parsed =
-          typeof meta.liveNotes === 'string' ? JSON.parse(meta.liveNotes) : meta.liveNotes;
-        if (Array.isArray(parsed)) liveNotes = parsed;
-      } catch {
-        /* ignore */
-      }
-    }
-    let highlights: unknown[] | undefined;
-    if (meta.highlights) {
-      try {
-        const parsed =
-          typeof meta.highlights === 'string' ? JSON.parse(meta.highlights) : meta.highlights;
-        if (Array.isArray(parsed)) highlights = parsed;
-      } catch {
-        /* ignore */
-      }
-    }
+    const liveNotes = parseLiveNotesField(meta.liveNotes);
+    const highlights = parseHighlightsField(meta.highlights);
     const obj: Record<string, unknown> = {
       title: meta.title || '',
       transcribedAt: meta.transcribedAt || '',

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -8,6 +8,83 @@ import { FFmpegManager } from './services/ffmpegManager';
 
 const execFileAsync = promisify(execFile);
 
+function formatOffsetTimestamp(offsetMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(offsetMs / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return hours > 0 ? `${pad(hours)}:${pad(minutes)}:${pad(seconds)}` : `${pad(minutes)}:${pad(seconds)}`;
+}
+
+// Append a section to the summary prompt instructing Gemini to enrich each
+// user-flagged moment with a subtitle + categorized bullets, returned as a
+// `highlights` array on the JSON response. Returns '' when there's nothing to
+// enrich -- prompt stays untouched in that case so we don't pay for empty
+// instructions.
+function buildHighlightsPromptBlock(
+  notes: Array<{ offsetMs: number; text: string }>,
+): string {
+  if (notes.length === 0) return '';
+  const lines = notes.map(
+    (n) => `- offsetMs=${n.offsetMs}, timestamp=${formatOffsetTimestamp(n.offsetMs)}, userText=${JSON.stringify(n.text)}`,
+  );
+  return `In addition, the user flagged the following moments during the meeting. For each note, produce a structured analysis tied to that moment in the transcript:
+
+${lines.join('\n')}
+
+For every flagged moment above, write one entry in a JSON array named "highlights". Each entry must include:
+- "offsetMs": the exact integer from the input
+- "userText": the user's typed text, copied verbatim
+- "subtitle": a short topic label in Korean (3-7 words) summarising what was being discussed at that timestamp
+- "bullets": 2-5 short Korean bullet strings categorising the discussion at that point. Prefix each bullet with one of these categories when applicable, omitting categories that don't fit: "결정 사항:", "주요 인사이트:", "실행 항목:", "식별된 리스크:". If none of the categories fit, just write the bullet without a prefix.
+
+Use the transcript as the ground truth -- if the user's typed text doesn't clearly match anything in the transcript, fall back to the meeting content nearest the given timestamp. Return the highlights array as an additional key alongside the other fields in the JSON.`;
+}
+
+function mergeHighlights(
+  liveNotes: Array<{ offsetMs: number; text: string }> | undefined,
+  raw: unknown,
+): HighlightEntry[] | undefined {
+  if (!liveNotes || liveNotes.length === 0) return undefined;
+  // Index Gemini's returned highlights by offsetMs so we can attach
+  // enrichment to the matching user note. Treat anything malformed as
+  // "no enrichment for that note" -- the bare offset+userText still
+  // round-trips so the user's data is never lost.
+  const byOffset = new Map<number, { subtitle?: string; bullets?: string[] }>();
+  if (Array.isArray(raw)) {
+    for (const item of raw) {
+      if (!item || typeof item !== 'object') continue;
+      const offsetMs = Number((item as { offsetMs?: unknown }).offsetMs);
+      if (!Number.isFinite(offsetMs)) continue;
+      const subtitleRaw = (item as { subtitle?: unknown }).subtitle;
+      const bulletsRaw = (item as { bullets?: unknown }).bullets;
+      const subtitle =
+        typeof subtitleRaw === 'string' && subtitleRaw.trim().length > 0
+          ? subtitleRaw.trim()
+          : undefined;
+      const bullets = Array.isArray(bulletsRaw)
+        ? bulletsRaw
+            .map((b) => (typeof b === 'string' ? b.trim() : ''))
+            .filter((b) => b.length > 0)
+        : undefined;
+      byOffset.set(offsetMs, {
+        subtitle,
+        bullets: bullets && bullets.length > 0 ? bullets : undefined,
+      });
+    }
+  }
+  return liveNotes.map((note) => {
+    const enrichment = byOffset.get(note.offsetMs);
+    return {
+      offsetMs: note.offsetMs,
+      userText: note.text,
+      subtitle: enrichment?.subtitle,
+      bullets: enrichment?.bullets,
+    };
+  });
+}
+
 export interface TranscriptionResult {
   transcript: string;
   summary: string;
@@ -16,6 +93,22 @@ export interface TranscriptionResult {
   emoji: string;
   suggestedTitle?: string;
   customFields?: Record<string, unknown>;
+  // Notes captured live by the user during the recording. Not produced by
+  // Gemini -- attached by main after transcription returns.
+  liveNotes?: Array<{ offsetMs: number; text: string }>;
+  // Plaud-style enriched view of the user's live notes: each entry pairs the
+  // user-typed text with an AI-generated subtitle + categorized bullets that
+  // describe what was being discussed around that moment in the meeting.
+  // Pure flag-only notes (empty text) round-trip as `userText: ""` with no
+  // subtitle/bullets -- they remain bare timestamp markers.
+  highlights?: HighlightEntry[];
+}
+
+export interface HighlightEntry {
+  offsetMs: number;
+  userText: string;
+  subtitle?: string;
+  bullets?: string[];
 }
 
 export interface GeminiServiceOptions {
@@ -64,6 +157,7 @@ export class GeminiService {
     audioFilePath: string,
     progressCallback?: (percent: number, message: string) => void,
     summaryPrompt?: string,
+    liveNotes?: Array<{ offsetMs: number; text: string }>,
   ): Promise<TranscriptionResult> {
     // Integration-test escape hatch: avoid the real Gemini call so tests can
     // exercise the surrounding pipeline (CLI parsing, IPC, ffmpeg, save) for
@@ -109,6 +203,7 @@ export class GeminiService {
         duration,
         progressCallback,
         summaryPrompt,
+        liveNotes,
       );
     } catch (error) {
       console.error('Error transcribing audio:', error);
@@ -280,6 +375,7 @@ export class GeminiService {
     duration: number,
     progressCallback?: (percent: number, message: string) => void,
     customSummaryPrompt?: string,
+    liveNotes?: Array<{ offsetMs: number; text: string }>,
   ): Promise<TranscriptionResult> {
     try {
       let fullTranscript = '';
@@ -304,7 +400,7 @@ export class GeminiService {
         progressCallback(85, 'Generating summary and key points...');
       }
 
-      const summaryPrompt =
+      const basePrompt =
         customSummaryPrompt ||
         `Based on this meeting transcript, provide:
 
@@ -322,6 +418,10 @@ Return as JSON:
   "actionItems": ["action 1", "action 2"],
   "emoji": "📝"
 }`;
+
+      const enrichableNotes = (liveNotes ?? []).filter((n) => (n.text ?? '').trim().length > 0);
+      const highlightsBlock = buildHighlightsPromptBlock(enrichableNotes);
+      const summaryPrompt = highlightsBlock ? `${basePrompt}\n\n${highlightsBlock}` : basePrompt;
 
       const summaryResult = await this.ai.models.generateContent({
         model: this.proModel,
@@ -348,12 +448,15 @@ Return as JSON:
         'keyPoints',
         'actionItems',
         'emoji',
+        'highlights',
       ]);
       const customFields: Record<string, unknown> = {};
+      let rawHighlights: unknown;
 
       try {
         const parsed = JSON.parse(summaryText);
         summaryData = parsed;
+        rawHighlights = (parsed as { highlights?: unknown }).highlights;
 
         // Extract custom fields (any keys not in the known set)
         for (const [key, value] of Object.entries(parsed)) {
@@ -370,6 +473,8 @@ Return as JSON:
         }
       }
 
+      const highlights = mergeHighlights(liveNotes, rawHighlights);
+
       if (progressCallback) {
         progressCallback(95, 'Finalizing results...');
       }
@@ -382,6 +487,7 @@ Return as JSON:
         emoji: summaryData.emoji,
         suggestedTitle: summaryData.suggestedTitle,
         customFields: Object.keys(customFields).length > 0 ? customFields : undefined,
+        highlights,
       };
     } catch (error) {
       console.error('Error in two-step transcription:', error);

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -4,30 +4,21 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { GoogleGenAI } from '@google/genai';
 import { mimeTypeForExtension } from './audioFormats';
+import { formatOffsetTimestamp, type LiveNote } from './outputService';
 import { FFmpegManager } from './services/ffmpegManager';
 
 const execFileAsync = promisify(execFile);
-
-function formatOffsetTimestamp(offsetMs: number): string {
-  const totalSeconds = Math.max(0, Math.floor(offsetMs / 1000));
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return hours > 0 ? `${pad(hours)}:${pad(minutes)}:${pad(seconds)}` : `${pad(minutes)}:${pad(seconds)}`;
-}
 
 // Append a section to the summary prompt instructing Gemini to enrich each
 // user-flagged moment with a subtitle + categorized bullets, returned as a
 // `highlights` array on the JSON response. Returns '' when there's nothing to
 // enrich -- prompt stays untouched in that case so we don't pay for empty
 // instructions.
-function buildHighlightsPromptBlock(
-  notes: Array<{ offsetMs: number; text: string }>,
-): string {
+function buildHighlightsPromptBlock(notes: LiveNote[]): string {
   if (notes.length === 0) return '';
   const lines = notes.map(
-    (n) => `- offsetMs=${n.offsetMs}, timestamp=${formatOffsetTimestamp(n.offsetMs)}, userText=${JSON.stringify(n.text)}`,
+    (n) =>
+      `- offsetMs=${n.offsetMs}, timestamp=${formatOffsetTimestamp(n.offsetMs)}, userText=${JSON.stringify(n.text)}`,
   );
   return `In addition, the user flagged the following moments during the meeting. For each note, produce a structured analysis tied to that moment in the transcript:
 
@@ -43,7 +34,7 @@ Use the transcript as the ground truth -- if the user's typed text doesn't clear
 }
 
 function mergeHighlights(
-  liveNotes: Array<{ offsetMs: number; text: string }> | undefined,
+  liveNotes: LiveNote[] | undefined,
   raw: unknown,
 ): HighlightEntry[] | undefined {
   if (!liveNotes || liveNotes.length === 0) return undefined;
@@ -64,9 +55,7 @@ function mergeHighlights(
           ? subtitleRaw.trim()
           : undefined;
       const bullets = Array.isArray(bulletsRaw)
-        ? bulletsRaw
-            .map((b) => (typeof b === 'string' ? b.trim() : ''))
-            .filter((b) => b.length > 0)
+        ? bulletsRaw.map((b) => (typeof b === 'string' ? b.trim() : '')).filter((b) => b.length > 0)
         : undefined;
       byOffset.set(offsetMs, {
         subtitle,
@@ -95,7 +84,7 @@ export interface TranscriptionResult {
   customFields?: Record<string, unknown>;
   // Notes captured live by the user during the recording. Not produced by
   // Gemini -- attached by main after transcription returns.
-  liveNotes?: Array<{ offsetMs: number; text: string }>;
+  liveNotes?: LiveNote[];
   // Plaud-style enriched view of the user's live notes: each entry pairs the
   // user-typed text with an AI-generated subtitle + categorized bullets that
   // describe what was being discussed around that moment in the meeting.
@@ -157,7 +146,7 @@ export class GeminiService {
     audioFilePath: string,
     progressCallback?: (percent: number, message: string) => void,
     summaryPrompt?: string,
-    liveNotes?: Array<{ offsetMs: number; text: string }>,
+    liveNotes?: LiveNote[],
   ): Promise<TranscriptionResult> {
     // Integration-test escape hatch: avoid the real Gemini call so tests can
     // exercise the surrounding pipeline (CLI parsing, IPC, ffmpeg, save) for
@@ -375,7 +364,7 @@ export class GeminiService {
     duration: number,
     progressCallback?: (percent: number, message: string) => void,
     customSummaryPrompt?: string,
-    liveNotes?: Array<{ offsetMs: number; text: string }>,
+    liveNotes?: LiveNote[],
   ): Promise<TranscriptionResult> {
     try {
       let fullTranscript = '';

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import { NotionService } from './notionService';
 import {
   formatTimestamp,
   getTranscriptionsDir,
+  type LiveNote,
   readTranscription,
   sanitizeForPath,
   saveTranscription,
@@ -1069,7 +1070,7 @@ ipcMain.on('recording-chunk', (_event, data: ArrayBuffer | Uint8Array) => {
   }
 });
 
-ipcMain.handle('stop-recording', async () => {
+ipcMain.handle('stop-recording', async (_, opts?: { liveNotes?: unknown }) => {
   try {
     finalizeRecordingSession();
     const result = await audioRecorder.stopRecording();
@@ -1082,6 +1083,18 @@ ipcMain.handle('stop-recording', async () => {
         // Silently skip if ffmpeg isn't available — file still plays, transcription
         // pipeline is unaffected.
         await remuxRecordingHeader(result.filePath);
+
+        // Persist live notes alongside the audio so they survive even if the
+        // user transcribes later (auto-mode off). transcribe-audio falls back
+        // to this when its own arg is missing.
+        const liveNotes = sanitizeLiveNotes(opts?.liveNotes);
+        if (liveNotes && liveNotes.length > 0) {
+          try {
+            await metadataService.saveMetadata(result.filePath, { liveNotes });
+          } catch (err) {
+            console.error('Failed to persist live notes to metadata:', err);
+          }
+        }
       }
     }
     return result;
@@ -1180,6 +1193,28 @@ function isContainedTranscriptionPath(folderPath: string | undefined): folderPat
   return resolved === root || resolved.startsWith(root + path.sep);
 }
 
+// Validate + normalize the renderer's live-notes payload before it touches disk.
+// Renderer state is untrusted (compromised content scripts, future agent flows)
+// so this enforces shape + caps text length to keep summary.md/Notion sane.
+const LIVE_NOTE_MAX_TEXT = 2000;
+const LIVE_NOTE_MAX_COUNT = 500;
+function sanitizeLiveNotes(raw: unknown): LiveNote[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: LiveNote[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const offsetMs = Number((item as { offsetMs?: unknown }).offsetMs);
+    const text = (item as { text?: unknown }).text;
+    if (!Number.isFinite(offsetMs)) continue;
+    out.push({
+      offsetMs: Math.max(0, Math.floor(offsetMs)),
+      text: typeof text === 'string' ? text.slice(0, LIVE_NOTE_MAX_TEXT) : '',
+    });
+    if (out.length >= LIVE_NOTE_MAX_COUNT) break;
+  }
+  return out.length > 0 ? out : undefined;
+}
+
 // Tell the renderer the config has changed out-of-band so it can re-read and
 // re-render its UI state (toggle checkboxes etc.). Used by the agent flow.
 function broadcastConfigChanged(): void {
@@ -1264,9 +1299,23 @@ ipcMain.handle('get-meeting-status', async () => {
 });
 
 // Transcription handler
-ipcMain.handle('transcribe-audio', async (_, filePath: string) => {
+ipcMain.handle('transcribe-audio', async (_, filePath: string, liveNotesRaw?: unknown) => {
   try {
     console.log('Transcription requested for:', filePath);
+    let liveNotes = sanitizeLiveNotes(liveNotesRaw);
+    if (!liveNotes || liveNotes.length === 0) {
+      // Fall back to whatever stop-recording persisted -- covers the
+      // record-now-transcribe-later flow when auto-mode is off.
+      try {
+        const existing = await metadataService.getMetadata(filePath);
+        const fromMetadata = sanitizeLiveNotes(existing?.liveNotes);
+        if (fromMetadata && fromMetadata.length > 0) {
+          liveNotes = fromMetadata;
+        }
+      } catch (err) {
+        console.warn('Failed to read live notes from metadata:', err);
+      }
+    }
 
     // Send progress update
     if (mainWindow) {
@@ -1305,9 +1354,20 @@ ipcMain.handle('transcribe-audio', async (_, filePath: string) => {
     };
 
     const summaryPrompt = configService.getSummaryPrompt();
-    const result = await geminiService.transcribeAudio(filePath, progressCallback, summaryPrompt);
+    const result = await geminiService.transcribeAudio(
+      filePath,
+      progressCallback,
+      summaryPrompt,
+      liveNotes,
+    );
     console.log('Transcription completed successfully');
     console.log('Saving metadata for:', filePath);
+
+    // Attach renderer-captured notes so downstream consumers (Notion upload,
+    // re-render in the modal) can read them off the result object.
+    if (liveNotes && liveNotes.length > 0) {
+      result.liveNotes = liveNotes;
+    }
 
     // Save transcription files (summary.md + transcript.md)
     const title = result.suggestedTitle || path.basename(filePath, path.extname(filePath));
@@ -1318,6 +1378,7 @@ ipcMain.handle('transcribe-audio', async (_, filePath: string) => {
         result,
         audioFilePath: filePath,
         dataPath: app.getPath('userData'),
+        liveNotes,
       });
       console.log('Transcription saved to:', transcriptionPath);
     } catch (error) {
@@ -1332,6 +1393,7 @@ ipcMain.handle('transcribe-audio', async (_, filePath: string) => {
           suggestedTitle: result.suggestedTitle,
           transcriptionPath,
           customFields: result.customFields,
+          liveNotes,
           transcribedAt: new Date().toISOString(),
         });
       } else {
@@ -1344,6 +1406,7 @@ ipcMain.handle('transcribe-audio', async (_, filePath: string) => {
           keyPoints: result.keyPoints,
           actionItems: result.actionItems,
           customFields: result.customFields,
+          liveNotes,
           transcribedAt: new Date().toISOString(),
         });
       }
@@ -1546,6 +1609,8 @@ ipcMain.handle('get-metadata', async (_, filePath: string) => {
             actionItems: transcription.actionItems,
             customFields: transcription.customFields ?? metadata.customFields,
             emoji: transcription.emoji,
+            liveNotes: transcription.liveNotes ?? metadata.liveNotes,
+            highlights: transcription.highlights,
             notionPageUrl: transcription.notionPageUrl,
             slackSentAt: transcription.slackSentAt,
             slackError: transcription.slackError,

--- a/src/notionService.ts
+++ b/src/notionService.ts
@@ -8,6 +8,13 @@ export interface NotionConfig {
   databaseId: string;
 }
 
+function formatLiveNoteTimestamp(offsetMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(offsetMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
 export class NotionService {
   private notion: Client;
   private databaseId: string;
@@ -138,6 +145,72 @@ export class NotionService {
             },
           } as BlockObjectRequest);
         });
+      }
+
+      // Highlights section -- prefer the AI-enriched view (per-moment title +
+      // subtitle + categorized bullets, Plaud-style) when Gemini populated it,
+      // and fall back to the bare bullet list when only the raw liveNotes are
+      // available (e.g. pure flags with no typed text).
+      if (transcriptionResult.highlights && transcriptionResult.highlights.length > 0) {
+        children.push({
+          type: 'heading_2',
+          heading_2: {
+            rich_text: [{ type: 'text', text: { content: '🗒️ Highlights' } }],
+          },
+        } as BlockObjectRequest);
+        for (const h of transcriptionResult.highlights) {
+          const ts = formatLiveNoteTimestamp(h.offsetMs);
+          const title = (h.userText ?? '').trim();
+          const headingContent = (title ? `[${ts}] ${title}` : `[${ts}] 🏴`).slice(0, 1900);
+          children.push({
+            type: 'heading_3',
+            heading_3: {
+              rich_text: [{ type: 'text', text: { content: headingContent } }],
+            },
+          } as BlockObjectRequest);
+          if (h.subtitle?.trim()) {
+            children.push({
+              type: 'paragraph',
+              paragraph: {
+                rich_text: [
+                  {
+                    type: 'text',
+                    text: { content: h.subtitle.trim().slice(0, 1900) },
+                    annotations: { italic: true },
+                  },
+                ],
+              },
+            } as BlockObjectRequest);
+          }
+          if (h.bullets?.length) {
+            for (const bullet of h.bullets) {
+              children.push({
+                type: 'bulleted_list_item',
+                bulleted_list_item: {
+                  rich_text: [{ type: 'text', text: { content: bullet.slice(0, 1900) } }],
+                },
+              } as BlockObjectRequest);
+            }
+          }
+        }
+      } else if (transcriptionResult.liveNotes && transcriptionResult.liveNotes.length > 0) {
+        children.push({
+          type: 'heading_2',
+          heading_2: {
+            rich_text: [{ type: 'text', text: { content: '🗒️ Highlights' } }],
+          },
+        } as BlockObjectRequest);
+        for (const note of transcriptionResult.liveNotes) {
+          const ts = formatLiveNoteTimestamp(note.offsetMs);
+          const text = (note.text ?? '').trim();
+          const content = text ? `[${ts}] ${text}`.slice(0, 1900) : `[${ts}] 🏴`;
+          children.push({
+            type: 'bulleted_list_item',
+            bulleted_list_item: {
+              rich_text: [{ type: 'text', text: { content } }],
+            },
+          } as BlockObjectRequest);
+        }
       }
 
       // Add custom fields

--- a/src/notionService.ts
+++ b/src/notionService.ts
@@ -1,18 +1,11 @@
 import { Client } from '@notionhq/client';
 import type { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
 import type { TranscriptionResult } from './geminiService';
-import { camelToLabel } from './outputService';
+import { camelToLabel, formatOffsetTimestamp } from './outputService';
 
 export interface NotionConfig {
   apiKey: string;
   databaseId: string;
-}
-
-function formatLiveNoteTimestamp(offsetMs: number): string {
-  const totalSeconds = Math.max(0, Math.floor(offsetMs / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
 }
 
 export class NotionService {
@@ -151,65 +144,67 @@ export class NotionService {
       // subtitle + categorized bullets, Plaud-style) when Gemini populated it,
       // and fall back to the bare bullet list when only the raw liveNotes are
       // available (e.g. pure flags with no typed text).
-      if (transcriptionResult.highlights && transcriptionResult.highlights.length > 0) {
+      const enrichedHighlights = transcriptionResult.highlights?.length
+        ? transcriptionResult.highlights
+        : null;
+      const fallbackNotes = transcriptionResult.liveNotes?.length
+        ? transcriptionResult.liveNotes
+        : null;
+      if (enrichedHighlights || fallbackNotes) {
         children.push({
           type: 'heading_2',
           heading_2: {
             rich_text: [{ type: 'text', text: { content: '🗒️ Highlights' } }],
           },
         } as BlockObjectRequest);
-        for (const h of transcriptionResult.highlights) {
-          const ts = formatLiveNoteTimestamp(h.offsetMs);
-          const title = (h.userText ?? '').trim();
-          const headingContent = (title ? `[${ts}] ${title}` : `[${ts}] 🏴`).slice(0, 1900);
-          children.push({
-            type: 'heading_3',
-            heading_3: {
-              rich_text: [{ type: 'text', text: { content: headingContent } }],
-            },
-          } as BlockObjectRequest);
-          if (h.subtitle?.trim()) {
+        if (enrichedHighlights) {
+          for (const h of enrichedHighlights) {
+            const ts = formatOffsetTimestamp(h.offsetMs);
+            const title = (h.userText ?? '').trim();
+            const headingContent = (title ? `[${ts}] ${title}` : `[${ts}] 🏴`).slice(0, 1900);
             children.push({
-              type: 'paragraph',
-              paragraph: {
-                rich_text: [
-                  {
-                    type: 'text',
-                    text: { content: h.subtitle.trim().slice(0, 1900) },
-                    annotations: { italic: true },
-                  },
-                ],
+              type: 'heading_3',
+              heading_3: {
+                rich_text: [{ type: 'text', text: { content: headingContent } }],
               },
             } as BlockObjectRequest);
-          }
-          if (h.bullets?.length) {
-            for (const bullet of h.bullets) {
+            if (h.subtitle?.trim()) {
               children.push({
-                type: 'bulleted_list_item',
-                bulleted_list_item: {
-                  rich_text: [{ type: 'text', text: { content: bullet.slice(0, 1900) } }],
+                type: 'paragraph',
+                paragraph: {
+                  rich_text: [
+                    {
+                      type: 'text',
+                      text: { content: h.subtitle.trim().slice(0, 1900) },
+                      annotations: { italic: true },
+                    },
+                  ],
                 },
               } as BlockObjectRequest);
             }
+            if (h.bullets?.length) {
+              for (const bullet of h.bullets) {
+                children.push({
+                  type: 'bulleted_list_item',
+                  bulleted_list_item: {
+                    rich_text: [{ type: 'text', text: { content: bullet.slice(0, 1900) } }],
+                  },
+                } as BlockObjectRequest);
+              }
+            }
           }
-        }
-      } else if (transcriptionResult.liveNotes && transcriptionResult.liveNotes.length > 0) {
-        children.push({
-          type: 'heading_2',
-          heading_2: {
-            rich_text: [{ type: 'text', text: { content: '🗒️ Highlights' } }],
-          },
-        } as BlockObjectRequest);
-        for (const note of transcriptionResult.liveNotes) {
-          const ts = formatLiveNoteTimestamp(note.offsetMs);
-          const text = (note.text ?? '').trim();
-          const content = text ? `[${ts}] ${text}`.slice(0, 1900) : `[${ts}] 🏴`;
-          children.push({
-            type: 'bulleted_list_item',
-            bulleted_list_item: {
-              rich_text: [{ type: 'text', text: { content } }],
-            },
-          } as BlockObjectRequest);
+        } else if (fallbackNotes) {
+          for (const note of fallbackNotes) {
+            const ts = formatOffsetTimestamp(note.offsetMs);
+            const text = (note.text ?? '').trim();
+            const content = text ? `[${ts}] ${text}`.slice(0, 1900) : `[${ts}] 🏴`;
+            children.push({
+              type: 'bulleted_list_item',
+              bulleted_list_item: {
+                rich_text: [{ type: 'text', text: { content } }],
+              },
+            } as BlockObjectRequest);
+          }
         }
       }
 

--- a/src/outputService.test.ts
+++ b/src/outputService.test.ts
@@ -134,6 +134,151 @@ describe('updateTranscriptionStatus', () => {
   });
 });
 
+describe('saveTranscription with liveNotes', () => {
+  it('round-trips liveNotes through frontmatter (text + flag-only)', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Notes Sync',
+      result: baseResult,
+      dataPath,
+      liveNotes: [
+        { offsetMs: 8_000, text: '지금' },
+        { offsetMs: 12_500, text: '' },
+        { offsetMs: 30_000, text: '액션 아이템: 후속 미팅 잡기' },
+      ],
+    });
+
+    const data = await readTranscription(folderPath);
+    assert.ok(data, 'readTranscription returned null');
+    assert.deepEqual(data!.liveNotes, [
+      { offsetMs: 8_000, text: '지금' },
+      { offsetMs: 12_500, text: '' },
+      { offsetMs: 30_000, text: '액션 아이템: 후속 미팅 잡기' },
+    ]);
+  });
+
+  it('omits liveNotes from frontmatter when none provided', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Notes Sync 2',
+      result: baseResult,
+      dataPath,
+    });
+
+    const summaryRaw = fs.readFileSync(path.join(folderPath, 'summary.md'), 'utf-8');
+    const { meta } = parseFrontmatter(summaryRaw);
+    assert.equal(meta.liveNotes, undefined);
+
+    const data = await readTranscription(folderPath);
+    assert.equal(data!.liveNotes, undefined);
+  });
+
+  it('renders the Highlights section with mm:ss timestamps and flag fallback', () => {
+    const body = formatSummary(baseResult, 'Notes Sync', undefined, [
+      { offsetMs: 8_000, text: '지금' },
+      { offsetMs: 12_500, text: '' },
+      { offsetMs: 65_000, text: '계약 조건 확인' },
+    ]);
+    assert.match(body, /## 🗒️ Highlights/);
+    assert.match(body, /- \[00:08\] 지금/);
+    assert.match(body, /- \[00:12\] 🏴/);
+    assert.match(body, /- \[01:05\] 계약 조건 확인/);
+  });
+
+  it('omits the Highlights section when liveNotes is empty', () => {
+    const body = formatSummary(baseResult, 'Notes Sync');
+    assert.doesNotMatch(body, /## 🗒️ Highlights/);
+  });
+
+  it('updateTranscriptionStatus preserves liveNotes across a status write', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Notes Persist',
+      result: baseResult,
+      dataPath,
+      liveNotes: [{ offsetMs: 1_000, text: 'first note' }],
+    });
+
+    await updateTranscriptionStatus(folderPath, {
+      notionPageUrl: 'https://www.notion.so/page',
+    });
+
+    const data = await readTranscription(folderPath);
+    assert.deepEqual(data!.liveNotes, [{ offsetMs: 1_000, text: 'first note' }]);
+    assert.equal(data!.notionPageUrl, 'https://www.notion.so/page');
+  });
+});
+
+describe('saveTranscription with AI-enriched highlights', () => {
+  const resultWithHighlights: TranscriptionResult = {
+    ...baseResult,
+    highlights: [
+      {
+        offsetMs: 8_000,
+        userText: '지금',
+        subtitle: '도입 인사',
+        bullets: ['주요 인사이트: 첫 인사를 교환했다.', '실행 항목: 후속 미팅 일정 조율'],
+      },
+      {
+        offsetMs: 12_500,
+        userText: '',
+      },
+    ],
+  };
+
+  it('round-trips highlights through frontmatter (rich + flag-only)', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Highlights Sync',
+      result: resultWithHighlights,
+      dataPath,
+      liveNotes: [
+        { offsetMs: 8_000, text: '지금' },
+        { offsetMs: 12_500, text: '' },
+      ],
+    });
+
+    const data = await readTranscription(folderPath);
+    assert.ok(data, 'readTranscription returned null');
+    assert.deepEqual(data!.highlights, [
+      {
+        offsetMs: 8_000,
+        userText: '지금',
+        subtitle: '도입 인사',
+        bullets: ['주요 인사이트: 첫 인사를 교환했다.', '실행 항목: 후속 미팅 일정 조율'],
+      },
+      { offsetMs: 12_500, userText: '', subtitle: undefined, bullets: undefined },
+    ]);
+  });
+
+  it('renders rich Highlights body (heading + subtitle + bullets) when highlights present', () => {
+    const body = formatSummary(
+      resultWithHighlights,
+      'Highlights Sync',
+      undefined,
+      [
+        { offsetMs: 8_000, text: '지금' },
+        { offsetMs: 12_500, text: '' },
+      ],
+      resultWithHighlights.highlights,
+    );
+    assert.match(body, /## 🗒️ Highlights/);
+    assert.match(body, /### \[00:08\] 지금/);
+    assert.match(body, /\*도입 인사\*/);
+    assert.match(body, /- 주요 인사이트: 첫 인사를 교환했다\./);
+    assert.match(body, /### \[00:12\] 🏴/);
+  });
+
+  it('falls back to bare bullet list when highlights are absent but liveNotes exist', () => {
+    const body = formatSummary(baseResult, 'Highlights Sync', undefined, [
+      { offsetMs: 8_000, text: '지금' },
+    ]);
+    assert.match(body, /## 🗒️ Highlights/);
+    assert.match(body, /- \[00:08\] 지금/);
+    assert.doesNotMatch(body, /### \[00:08\]/);
+  });
+});
+
 describe('sanitizeForPath', () => {
   it('replaces filesystem-hostile characters', () => {
     assert.equal(sanitizeForPath('LG : meeting / part 1?'), 'LG _ meeting _ part 1_');

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -8,11 +8,21 @@ export interface LiveNote {
   text: string;
 }
 
-function formatNoteTimestamp(offsetMs: number): string {
+/**
+ * Format a millisecond offset as `mm:ss` (or `hh:mm:ss` when the offset crosses
+ * one hour) — used by every Highlights-rendering sink (summary.md, Notion,
+ * modal, CLI) and by the Gemini prompt so the LLM sees the same coordinate
+ * system as the saved output.
+ */
+export function formatOffsetTimestamp(offsetMs: number): string {
   const totalSeconds = Math.max(0, Math.floor(offsetMs / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;
-  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return hours > 0
+    ? `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`
+    : `${pad(minutes)}:${pad(seconds)}`;
 }
 
 export function sanitizeForPath(name: string): string {
@@ -86,30 +96,31 @@ export function formatSummary(
   // Prefer the AI-enriched "highlights" view when present -- it carries the
   // same user notes plus per-moment subtitle/bullets. Fall back to the bare
   // bullet list of liveNotes when Gemini didn't produce highlights.
-  const renderedHighlights = highlights && highlights.length > 0 ? highlights : null;
-  if (renderedHighlights) {
+  const enriched = highlights && highlights.length > 0 ? highlights : null;
+  if (enriched || liveNotes?.length) {
     lines.push('## 🗒️ Highlights\n');
-    for (const h of renderedHighlights) {
-      const ts = formatNoteTimestamp(h.offsetMs);
-      const title = (h.userText ?? '').trim();
-      lines.push(title ? `### [${ts}] ${title}` : `### [${ts}] 🏴`);
-      if (h.subtitle?.trim()) {
-        lines.push(`*${h.subtitle.trim()}*`);
-      }
-      if (h.bullets?.length) {
+    if (enriched) {
+      for (const h of enriched) {
+        const ts = formatOffsetTimestamp(h.offsetMs);
+        const title = (h.userText ?? '').trim();
+        lines.push(title ? `### [${ts}] ${title}` : `### [${ts}] 🏴`);
+        if (h.subtitle?.trim()) {
+          lines.push(`*${h.subtitle.trim()}*`);
+        }
+        if (h.bullets?.length) {
+          lines.push('');
+          for (const b of h.bullets) lines.push(`- ${b}`);
+        }
         lines.push('');
-        for (const b of h.bullets) lines.push(`- ${b}`);
+      }
+    } else {
+      for (const note of liveNotes!) {
+        const ts = formatOffsetTimestamp(note.offsetMs);
+        const text = note.text?.trim();
+        lines.push(text ? `- [${ts}] ${text}` : `- [${ts}] 🏴`);
       }
       lines.push('');
     }
-  } else if (liveNotes?.length) {
-    lines.push('## 🗒️ Highlights\n');
-    for (const note of liveNotes) {
-      const ts = formatNoteTimestamp(note.offsetMs);
-      const text = note.text?.trim();
-      lines.push(text ? `- [${ts}] ${text}` : `- [${ts}] 🏴`);
-    }
-    lines.push('');
   }
 
   if (result.customFields) {
@@ -266,7 +277,7 @@ export function parseFrontmatter(content: string): { meta: Record<string, unknow
   return { meta, body };
 }
 
-function parseLiveNotesField(raw: unknown): LiveNote[] | undefined {
+export function parseLiveNotesField(raw: unknown): LiveNote[] | undefined {
   if (!raw) return undefined;
   try {
     const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
@@ -289,7 +300,7 @@ function parseLiveNotesField(raw: unknown): LiveNote[] | undefined {
   }
 }
 
-function parseHighlightsField(raw: unknown): HighlightEntry[] | undefined {
+export function parseHighlightsField(raw: unknown): HighlightEntry[] | undefined {
   if (!raw) return undefined;
   try {
     const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
@@ -305,8 +316,7 @@ function parseHighlightsField(raw: unknown): HighlightEntry[] | undefined {
       entries.push({
         offsetMs: Math.max(0, Math.floor(offsetMs)),
         userText: typeof userText === 'string' ? userText : '',
-        subtitle:
-          typeof subtitle === 'string' && subtitle.trim().length > 0 ? subtitle : undefined,
+        subtitle: typeof subtitle === 'string' && subtitle.trim().length > 0 ? subtitle : undefined,
         bullets: Array.isArray(bullets)
           ? bullets.map((b) => (typeof b === 'string' ? b : '')).filter((b) => b.length > 0)
           : undefined,

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -1,6 +1,19 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import type { TranscriptionResult } from './geminiService';
+import type { HighlightEntry, TranscriptionResult } from './geminiService';
+
+/** One timestamped note captured while recording. Empty `text` = bare flag. */
+export interface LiveNote {
+  offsetMs: number;
+  text: string;
+}
+
+function formatNoteTimestamp(offsetMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(offsetMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
 
 export function sanitizeForPath(name: string): string {
   return name
@@ -32,6 +45,8 @@ export function formatSummary(
   result: TranscriptionResult,
   title: string,
   mergedFrom?: string[],
+  liveNotes?: LiveNote[],
+  highlights?: HighlightEntry[],
 ): string {
   const lines: string[] = [];
   lines.push(`# ${title}\n`);
@@ -64,6 +79,35 @@ export function formatSummary(
     lines.push('## Action Items\n');
     for (const item of result.actionItems) {
       lines.push(`- ${item}`);
+    }
+    lines.push('');
+  }
+
+  // Prefer the AI-enriched "highlights" view when present -- it carries the
+  // same user notes plus per-moment subtitle/bullets. Fall back to the bare
+  // bullet list of liveNotes when Gemini didn't produce highlights.
+  const renderedHighlights = highlights && highlights.length > 0 ? highlights : null;
+  if (renderedHighlights) {
+    lines.push('## 🗒️ Highlights\n');
+    for (const h of renderedHighlights) {
+      const ts = formatNoteTimestamp(h.offsetMs);
+      const title = (h.userText ?? '').trim();
+      lines.push(title ? `### [${ts}] ${title}` : `### [${ts}] 🏴`);
+      if (h.subtitle?.trim()) {
+        lines.push(`*${h.subtitle.trim()}*`);
+      }
+      if (h.bullets?.length) {
+        lines.push('');
+        for (const b of h.bullets) lines.push(`- ${b}`);
+      }
+      lines.push('');
+    }
+  } else if (liveNotes?.length) {
+    lines.push('## 🗒️ Highlights\n');
+    for (const note of liveNotes) {
+      const ts = formatNoteTimestamp(note.offsetMs);
+      const text = note.text?.trim();
+      lines.push(text ? `- [${ts}] ${text}` : `- [${ts}] 🏴`);
     }
     lines.push('');
   }
@@ -107,6 +151,8 @@ interface SummaryFrontmatter {
   transcribedAt: string;
   emoji?: string;
   mergedFrom?: string[];
+  liveNotes?: LiveNote[];
+  highlights?: HighlightEntry[];
   notionPageUrl?: string;
   slackSentAt?: string;
   slackError?: string;
@@ -141,6 +187,12 @@ function buildFrontmatter(meta: SummaryFrontmatter): string {
   if (meta.mergedFrom?.length) {
     lines.push('mergedFrom:');
     for (const src of meta.mergedFrom) lines.push(`  - ${yamlQuote(src)}`);
+  }
+  if (meta.liveNotes?.length) {
+    lines.push(`liveNotes: ${yamlQuote(JSON.stringify(meta.liveNotes))}`);
+  }
+  if (meta.highlights?.length) {
+    lines.push(`highlights: ${yamlQuote(JSON.stringify(meta.highlights))}`);
   }
   if (meta.notionPageUrl) {
     lines.push(`notionPageUrl: ${yamlQuote(meta.notionPageUrl)}`);
@@ -214,6 +266,59 @@ export function parseFrontmatter(content: string): { meta: Record<string, unknow
   return { meta, body };
 }
 
+function parseLiveNotesField(raw: unknown): LiveNote[] | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    if (!Array.isArray(parsed)) return undefined;
+    const notes: LiveNote[] = [];
+    for (const item of parsed) {
+      if (!item || typeof item !== 'object') continue;
+      const offsetMs = Number((item as { offsetMs?: unknown }).offsetMs);
+      const text = (item as { text?: unknown }).text;
+      if (!Number.isFinite(offsetMs)) continue;
+      notes.push({
+        offsetMs: Math.max(0, Math.floor(offsetMs)),
+        text: typeof text === 'string' ? text : '',
+      });
+    }
+    return notes.length > 0 ? notes : undefined;
+  } catch (e) {
+    console.warn('Failed to parse liveNotes from frontmatter:', e);
+    return undefined;
+  }
+}
+
+function parseHighlightsField(raw: unknown): HighlightEntry[] | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    if (!Array.isArray(parsed)) return undefined;
+    const entries: HighlightEntry[] = [];
+    for (const item of parsed) {
+      if (!item || typeof item !== 'object') continue;
+      const offsetMs = Number((item as { offsetMs?: unknown }).offsetMs);
+      if (!Number.isFinite(offsetMs)) continue;
+      const userText = (item as { userText?: unknown }).userText;
+      const subtitle = (item as { subtitle?: unknown }).subtitle;
+      const bullets = (item as { bullets?: unknown }).bullets;
+      entries.push({
+        offsetMs: Math.max(0, Math.floor(offsetMs)),
+        userText: typeof userText === 'string' ? userText : '',
+        subtitle:
+          typeof subtitle === 'string' && subtitle.trim().length > 0 ? subtitle : undefined,
+        bullets: Array.isArray(bullets)
+          ? bullets.map((b) => (typeof b === 'string' ? b : '')).filter((b) => b.length > 0)
+          : undefined,
+      });
+    }
+    return entries.length > 0 ? entries : undefined;
+  } catch (e) {
+    console.warn('Failed to parse highlights from frontmatter:', e);
+    return undefined;
+  }
+}
+
 function yamlUnquote(value: string): string {
   if (value.startsWith('"') && value.endsWith('"')) {
     return value
@@ -237,6 +342,11 @@ export interface SaveTranscriptionOptions {
   outputDir?: string; // override parent dir (for CLI --output)
   dataPath: string; // app data path (default location)
   mergedFrom?: string[]; // source folder names when this note was created by merging others
+  liveNotes?: LiveNote[]; // timestamped notes captured during recording
+}
+
+function getResultHighlights(result: TranscriptionResult): HighlightEntry[] | undefined {
+  return result.highlights && result.highlights.length > 0 ? result.highlights : undefined;
 }
 
 /**
@@ -251,6 +361,7 @@ export function saveTranscription(opts: SaveTranscriptionOptions): string {
 
   const transcribedAt = new Date().toISOString();
 
+  const highlights = getResultHighlights(opts.result);
   // summary.md with frontmatter (stores all raw data for machine reading)
   const frontmatter = buildFrontmatter({
     title: opts.title,
@@ -264,8 +375,16 @@ export function saveTranscription(opts: SaveTranscriptionOptions): string {
     transcribedAt,
     emoji: opts.result.emoji,
     mergedFrom: opts.mergedFrom,
+    liveNotes: opts.liveNotes,
+    highlights,
   });
-  const summaryBody = formatSummary(opts.result, opts.title, opts.mergedFrom);
+  const summaryBody = formatSummary(
+    opts.result,
+    opts.title,
+    opts.mergedFrom,
+    opts.liveNotes,
+    highlights,
+  );
   fs.writeFileSync(
     path.join(folderPath, 'summary.md'),
     `${frontmatter}\n\n${summaryBody}`,
@@ -371,6 +490,8 @@ export interface ReadTranscriptionResult {
   transcribedAt?: string;
   emoji?: string;
   mergedFrom?: string[];
+  liveNotes?: LiveNote[];
+  highlights?: HighlightEntry[];
   notionPageUrl?: string;
   slackSentAt?: string;
   slackError?: string;
@@ -402,6 +523,9 @@ export async function readTranscription(
       }
     }
 
+    const liveNotes = parseLiveNotesField(meta.liveNotes);
+    const highlights = parseHighlightsField(meta.highlights);
+
     return {
       title: (meta.title as string) || path.basename(folderPath),
       suggestedTitle: meta.suggestedTitle as string | undefined,
@@ -414,6 +538,8 @@ export async function readTranscription(
       transcribedAt: meta.transcribedAt as string | undefined,
       emoji: meta.emoji as string | undefined,
       mergedFrom: meta.mergedFrom as string[] | undefined,
+      liveNotes,
+      highlights,
       notionPageUrl: meta.notionPageUrl as string | undefined,
       slackSentAt: meta.slackSentAt as string | undefined,
       slackError: meta.slackError as string | undefined,
@@ -454,6 +580,9 @@ export async function updateTranscriptionStatus(
     }
   }
 
+  const liveNotes = parseLiveNotesField(meta.liveNotes);
+  const highlights = parseHighlightsField(meta.highlights);
+
   // Spread first so any unknown frontmatter keys (added by future writers, or
   // by hand-edits) survive the round-trip; named fields override with proper
   // typing and defaults.
@@ -464,6 +593,8 @@ export async function updateTranscriptionStatus(
     transcript: (meta.transcript as string) || '',
     transcribedAt: (meta.transcribedAt as string) || new Date().toISOString(),
     customFields,
+    liveNotes,
+    highlights,
   };
 
   applyStatusUpdate(merged, 'notionPageUrl', updates.notionPageUrl);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -5,7 +5,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   startRecording: (payload: { title: string; mimeType: string }) =>
     ipcRenderer.invoke('start-recording', payload),
   sendRecordingChunk: (data: ArrayBuffer) => ipcRenderer.send('recording-chunk', data),
-  stopRecording: () => ipcRenderer.invoke('stop-recording'),
+  stopRecording: (opts?: { liveNotes?: Array<{ offsetMs: number; text: string }> }) =>
+    ipcRenderer.invoke('stop-recording', opts),
   abortRecording: () => ipcRenderer.invoke('abort-recording'),
   onRecordingStatus: (callback: (status: string) => void) => {
     ipcRenderer.on('recording-status', (_, status) => callback(status));
@@ -27,7 +28,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     slackAutoShare?: boolean;
   }) => ipcRenderer.invoke('save-config', config),
   getConfig: () => ipcRenderer.invoke('get-config'),
-  transcribeAudio: (filePath: string) => ipcRenderer.invoke('transcribe-audio', filePath),
+  transcribeAudio: (filePath: string, liveNotes?: Array<{ offsetMs: number; text: string }>) =>
+    ipcRenderer.invoke('transcribe-audio', filePath, liveNotes),
   uploadToNotion: (data: {
     title: string;
     transcriptionData: any;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,12 +1,12 @@
 import { contextBridge, ipcRenderer } from 'electron';
+import type { LiveNote } from './outputService';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   platform: process.platform,
   startRecording: (payload: { title: string; mimeType: string }) =>
     ipcRenderer.invoke('start-recording', payload),
   sendRecordingChunk: (data: ArrayBuffer) => ipcRenderer.send('recording-chunk', data),
-  stopRecording: (opts?: { liveNotes?: Array<{ offsetMs: number; text: string }> }) =>
-    ipcRenderer.invoke('stop-recording', opts),
+  stopRecording: (opts?: { liveNotes?: LiveNote[] }) => ipcRenderer.invoke('stop-recording', opts),
   abortRecording: () => ipcRenderer.invoke('abort-recording'),
   onRecordingStatus: (callback: (status: string) => void) => {
     ipcRenderer.on('recording-status', (_, status) => callback(status));
@@ -28,7 +28,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     slackAutoShare?: boolean;
   }) => ipcRenderer.invoke('save-config', config),
   getConfig: () => ipcRenderer.invoke('get-config'),
-  transcribeAudio: (filePath: string, liveNotes?: Array<{ offsetMs: number; text: string }>) =>
+  transcribeAudio: (filePath: string, liveNotes?: LiveNote[]) =>
     ipcRenderer.invoke('transcribe-audio', filePath, liveNotes),
   uploadToNotion: (data: {
     title: string;

--- a/src/services/metadataService.ts
+++ b/src/services/metadataService.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import { app } from 'electron';
+import type { LiveNote } from '../outputService';
 
 interface RecordingMetadata {
   filePath: string;
@@ -15,7 +16,7 @@ interface RecordingMetadata {
   suggestedTitle?: string;
   transcribedAt?: string;
   customFields?: Record<string, unknown>;
-  liveNotes?: Array<{ offsetMs: number; text: string }>;
+  liveNotes?: LiveNote[];
 }
 
 export class MetadataService {

--- a/src/services/metadataService.ts
+++ b/src/services/metadataService.ts
@@ -15,6 +15,7 @@ interface RecordingMetadata {
   suggestedTitle?: string;
   transcribedAt?: string;
   customFields?: Record<string, unknown>;
+  liveNotes?: Array<{ offsetMs: number; text: string }>;
 }
 
 export class MetadataService {


### PR DESCRIPTION
Closes #103.

## Summary

- 녹음 중 타임스탬프와 함께 메모를 남길 수 있는 Plaud-style **Highlights** 패널 추가 (🏴 bare flag + 텍스트 입력)
- 정지 시 노트가 `summary.md` frontmatter + metadata + Notion에 모두 저장 — auto-mode 꺼져 있어도 손실 없음
- 각 사용자 메모를 transcript context와 함께 Gemini에 넘겨 **subtitle + 카테고리 bullet**(`결정 사항` / `주요 인사이트` / `실행 항목` / `식별된 리스크`)으로 enrichment. 빈 플래그는 bare marker로 유지.
- transcription 모달 "All" 탭과 별도 "🗒️ Highlights" 탭, Notion `🗒️ Highlights` 섹션, `listener export --json`까지 같은 prefer-highlights-fallback-liveNotes 분기

## Capture

- [renderer/ui/live-notes.ts](https://github.com/asleep-ai/listener-ai/blob/claude/amazing-tu-9903b8/renderer/ui/live-notes.ts) — 녹음 중에만 나타나는 리스트 + 입력란 + 🏴 버튼. 한글 IME 조합 중 Enter는 `event.isComposing` 가드로 무시 (조합 끝난 뒤만 commit)
- [renderer/audio/recorder.ts](https://github.com/asleep-ai/listener-ai/blob/claude/amazing-tu-9903b8/renderer/audio/recorder.ts) — 시작 시 panel show, 정지 직전 `state.liveNotes` 스냅샷 → `electronAPI.stopRecording({ liveNotes })` 로 전달
- 새 `LiveNote = { offsetMs, text }` 타입. 빈 텍스트 = 🏴 플래그

## Pipeline

- [src/main.ts](https://github.com/asleep-ai/listener-ai/blob/claude/amazing-tu-9903b8/src/main.ts) — `stop-recording`이 liveNotes를 받아 metadata 즉시 저장 (auto-mode off 대비). `transcribe-audio`가 arg 없으면 metadata에서 fallback. 페이로드는 `sanitizeLiveNotes`로 size cap + 검증
- [src/geminiService.ts](https://github.com/asleep-ai/listener-ai/blob/claude/amazing-tu-9903b8/src/geminiService.ts) — `transcribeAudio(..., liveNotes)`. 텍스트 있는 노트만 enrichment 대상. `buildHighlightsPromptBlock`이 사용자 customSummaryPrompt 뒤에 highlights 지시 append (커스텀 프롬프트 보호). `mergeHighlights`가 Gemini 응답을 offsetMs로 user note에 매칭 — 누락/실패 시에도 bare offset+userText로 round-trip

## Storage / Render

- [src/outputService.ts](https://github.com/asleep-ai/listener-ai/blob/claude/amazing-tu-9903b8/src/outputService.ts) — frontmatter에 `liveNotes` + `highlights` JSON 블롭, `formatSummary`가 highlights 있으면 `### [mm:ss / hh:mm:ss] title` + *subtitle* + bullets, 없으면 bare bullet. 타임스탬프는 1시간 넘으면 `hh:mm:ss`로 자동 확장 (Gemini 프롬프트 / Notion / CLI 모두 동일 helper 공유)
- [src/notionService.ts](https://github.com/asleep-ai/listener-ai/blob/claude/amazing-tu-9903b8/src/notionService.ts) — Action Items 다음에 `🗒️ Highlights` heading + per-highlight `heading_3` + italic subtitle + `bulleted_list_item`
- [renderer/ui/markdown-utils.ts](https://github.com/asleep-ai/listener-ai/blob/claude/amazing-tu-9903b8/renderer/ui/markdown-utils.ts) — 모달이 highlights/liveNotes 둘 다 인식, dynamic tab 추가, copy 버튼 호환
- [src/cli.ts](https://github.com/asleep-ai/listener-ai/blob/claude/amazing-tu-9903b8/src/cli.ts) — `listener export --json` 응답에 `liveNotes` + `highlights` 노출

## Tests

- 92 tests pass (`pnpm test`)
- 새 케이스 8건: liveNotes 라운드트립(텍스트/플래그/부재), markdown 섹션 렌더, status update 보존, highlights 라운드트립(rich+flag-only), rich body 렌더, liveNotes fallback

## Test plan
- [ ] 녹음 시작 → 한글로 메모 + Enter (조합 중 Enter는 무시됨 확인)
- [ ] 🏴 플래그 1-2회 → 정지 → summary.md \`liveNotes\`/\`highlights\` frontmatter + \`## 🗒️ Highlights\` 섹션 확인
- [ ] 모달 "Highlights" 탭에 Plaud-style 카드 (heading + subtitle + bullets) 표시
- [ ] Notion 자동 업로드된 페이지에서 Action Items 다음 \`🗒️ Highlights\` heading + 카드형 블록 확인
- [ ] \`listener export --json <ref>\` 출력에 \`liveNotes\` + \`highlights\` 포함
- [ ] auto-mode OFF로 녹음 → 나중에 모달에서 transcribe → 노트가 metadata에서 살아남는지
- [ ] 1시간 넘는 녹음에서 timestamp가 \`hh:mm:ss\`로 찍히는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)