### PR TITLE
feat(codex): default to gpt-4o-transcribe-diarize for speaker labels

### DIFF
--- a/docs/model-pricing.md
+++ b/docs/model-pricing.md
@@ -1,0 +1,113 @@
+# AI Model Pricing Reference
+
+Pricing for the AI models Listener.AI uses (or could switch to) for transcription, summarization, and the chat agent. Verified May 2026.
+
+When prices drift, update the date in the cell and re-cite from the provider's own pricing page (not blogs).
+
+## Models currently in production
+
+| Use case | Provider config | Model | Pricing | Notes |
+|---|---|---|---|---|
+| Transcription (Gemini) | `geminiFlashModel` | gemini-2.5-flash | $1.00/M audio-input tokens, $2.50/M output | Audio input only at this rate; text/image input is $0.30/M. Speaker diarization works via prompt instructions. |
+| Summary + agent (Gemini) | `geminiModel` | gemini-2.5-pro | $1.25/M input, $10.00/M output (≤200k ctx) | Doubles to $2.50/$15.00 at >200k ctx. Context cache at $0.125/M/hr storage. |
+| Transcription (Codex) | `codexTranscriptionModel` | gpt-4o-transcribe | $0.006/min ($2.50/M audio in, $10.00/M text out) | No speaker diarization. `prompt` param is vocabulary/style hint only. |
+| Summary + agent (Codex) | `codexModel` | gpt-5.5 (via ChatGPT Codex Responses) | $5.00/M input, $30.00/M output (API price; ChatGPT subscription absorbs cost) | Rejects `temperature`/sampling params (reasoning model). Cached input $0.50/M. |
+
+## Provider notes
+
+**Google Gemini** — API key via Google AI Studio or Vertex AI. Free tier exists for AI Studio but is rate-limited and not for production. No announced end-of-life for 2.5 Flash or 2.5 Pro as of May 2026.
+
+**OpenAI Codex (ChatGPT subscription)** — OAuth via `@earendil-works/pi-ai/oauth`. Codex GUI usage on Plus/Pro plans is metered against shared 5-hour message-window allowances. Business/Enterprise plans switched to per-token credits aligned with API rates on 2026-04-02. The same models are also accessible directly via API key at the per-token prices below.
+
+**OpenAI Transcription** — API key. Metered separately from the ChatGPT subscription. Listener.AI's OAuth flow currently passes the ChatGPT access token as the Bearer for `/v1/audio/transcriptions`, which OpenAI accepts. End-of-life: `whisper-1` is still available at the same per-minute rate as `gpt-4o-transcribe`.
+
+## Full pricing tables
+
+### Gemini (Google)
+
+All prices per 1M tokens unless noted.
+
+| Model | Input | Output | Notes |
+|---|---|---|---|
+| gemini-2.5-pro (≤200k ctx) | $1.25 | $10.00 | Context cache: $0.125/M/hr storage |
+| gemini-2.5-pro (>200k ctx) | $2.50 | $15.00 | Same model, higher-context tier |
+| gemini-2.5-flash (text/image/video in) | $0.30 | $2.50 | Context cache: $0.03/M/hr |
+| gemini-2.5-flash (audio in) | $1.00 | $2.50 | Output price same regardless of input modality |
+
+Batch tier: 50% of standard. Priority tier: ~1.8× standard. Source: <https://ai.google.dev/pricing> (verified 2026-05-13).
+
+### OpenAI Chat / Codex
+
+All prices per 1M tokens.
+
+| Model | Input | Output | Notes |
+|---|---|---|---|
+| gpt-5.5 | $5.00 | $30.00 | Current Codex flagship. Cached input $0.50/M. |
+| gpt-5.4 | $2.50 | $15.00 | Cached input $0.25/M |
+| gpt-5.4-mini | $0.75 | $4.50 | Cached input $0.075/M |
+| gpt-5.4-nano | $0.20 | $1.25 | Cached input $0.02/M |
+| gpt-5 | $1.25 | $10.00 | Previous-gen flagship; no caching listed |
+| gpt-4o | $2.50 | $10.00 | Legacy; still accessible. 4.1 family is OpenAI's recommended replacement. |
+| gpt-4o-mini | $0.15 | $0.60 | Legacy; still accessible |
+| gpt-4o-audio-preview | unverified | — | Not on the public pricing page as of May 2026; superseded by the realtime API |
+
+Sources: <https://developers.openai.com/api/docs/pricing>, <https://developers.openai.com/codex/pricing> (verified 2026-05-13).
+
+### OpenAI Transcription
+
+Prices per audio minute (primary). Token-based alternative shown for reference.
+
+| Model | $/min | Token alt | Speaker diarization | Notes |
+|---|---|---|---|---|
+| gpt-4o-transcribe | $0.006 | $2.50/M audio in, $10.00/M text out | No | Current default in Listener.AI. `prompt` = vocabulary/style hint, not instruction. |
+| gpt-4o-mini-transcribe | $0.003 | $1.25/M audio in, $5.00/M text out | No | Cheaper, lower accuracy. |
+| gpt-4o-transcribe-diarize | $0.006 | Same as gpt-4o-transcribe | **Yes** (`response_format: 'diarized_json'`) | Released 2025-10-18. No `prompt` support. `chunking_strategy: 'auto'` required for >30s audio. Known quirks: word skipping, occasional hallucinated speaker counts. |
+| whisper-1 | $0.006 | — | No | Same price as gpt-4o-transcribe. |
+
+Source: <https://costgoat.com/pricing/openai-transcription> (verified 2026-05-13), <https://platform.openai.com/docs/models/gpt-4o-transcribe-diarize>.
+
+### Third-party transcription (with diarization)
+
+For comparison only — none of these are wired into Listener.AI today.
+
+| Service / Model | Price | Korean | Diarization | Free tier | Source |
+|---|---|---|---|---|---|
+| AssemblyAI Universal-2 | $0.15/hr (~$0.0025/min) | Yes | +$0.02/hr | 185 hrs pre-recorded | <https://www.assemblyai.com/pricing/> |
+| AssemblyAI Universal-3 Pro | $0.21/hr (~$0.0035/min) | Not yet | +$0.02/hr | 185 hrs pre-recorded | <https://www.assemblyai.com/pricing/> |
+| Deepgram Nova-3 Multilingual | $0.0092/min pre-rec, $0.0058/min stream | Yes | +$0.0020/min | $200 credit | <https://deepgram.com/pricing> |
+| Deepgram Nova-3 Monolingual | $0.0077/min pre-rec, $0.0048/min stream | n/a | +$0.0020/min | $200 credit | <https://deepgram.com/pricing> |
+| Rev.ai Reverb | $0.20/hr (~$0.0033/min) | Yes | unverified | 5 hr credit | <https://www.rev.ai/pricing> |
+| Rev.ai Reverb Turbo | $0.10/hr (~$0.0017/min) | Yes | unverified | 5 hr credit | <https://www.rev.ai/pricing> |
+| Speechmatics (Pro tier) | from $0.24/hr (~$0.004/min) | Yes | not publicly itemized | 480 min/month | <https://www.speechmatics.com/pricing> |
+
+All verified 2026-05-13.
+
+## Speaker diarization options
+
+The Gemini path natively returns "참가자1: ... / 참가자2: ..." because `gemini-2.5-flash` is a multimodal LLM and follows the system prompt. The Codex path through `/v1/audio/transcriptions` does not — `prompt` is documented as a vocabulary/style hint only. Three viable paths if speaker labels are needed on the Codex side:
+
+1. **`gpt-4o-transcribe-diarize`** (default since this PR) — same endpoint, same price, native diarization. Loses the `prompt` parameter, so user glossaries (`knownWords`) can't be passed. Output is `{segments: [{speaker, start, end, text}]}` which we remap onto our `참가자N` convention.
+2. **Post-process via Codex chat** — transcribe with `gpt-4o-transcribe` as today, then send the plain transcript to `gpt-5.5` with a "label by speaker" instruction. Adds one round-trip; quality drops for 3+ speakers since the model can only infer from conversational cues, not voice.
+3. **Third-party API** (AssemblyAI / Deepgram / Speechmatics) — requires a separate API key and breaks the "ChatGPT subscription only" promise. Highest accuracy but worst UX for Codex users.
+
+### Known limitations of the diarize default
+
+- **Cross-segment speaker incoherence.** We intentionally split long audio into 5-minute chunks and upload them in parallel — this is much faster than a single long upload for both Gemini and OpenAI. The diarize model re-numbers speakers per request, so "참가자1" in segment 1 is not guaranteed to be the same physical person as "참가자1" in segment 2. Each chunk is internally consistent. To merge speakers across chunks you would need to seed `known_speaker_references` from the first chunk and re-upload — not implemented today.
+- **`knownWords` glossary is dropped.** The diarize model rejects the `prompt` parameter. Users who depend on vocabulary biasing should run `listener config set codexTranscriptionModel gpt-4o-transcribe` to go back to the pre-diarize path (no speaker labels).
+- **Word skipping + speaker count hallucination.** Reported by the OpenAI community at launch (Oct 2025). Language-agnostic, no Korean-specific benchmark.
+- **No forced `language` hint.** We let Whisper's auto-detection (first ~30s) decide. Forcing `language: 'ko'` slightly improves accuracy for purely Korean audio but degrades English/code-switched sections (acronyms transcribed phonetically, e.g. "API" → "에이피아이"). Most meetings here are bilingual, so auto-detect wins on average.
+
+For Korean meetings the data points are thin. AssemblyAI Universal-2 has confirmed Korean diarization with consistent speaker IDs across the whole recording, which is the obvious fallback if cross-chunk incoherence becomes a real problem.
+
+## Sources
+
+- [Google AI Pricing](https://ai.google.dev/pricing)
+- [OpenAI API Pricing](https://developers.openai.com/api/docs/pricing)
+- [OpenAI Codex Pricing](https://developers.openai.com/codex/pricing)
+- [OpenAI Transcription pricing aggregator](https://costgoat.com/pricing/openai-transcription)
+- [gpt-4o-transcribe-diarize model card](https://platform.openai.com/docs/models/gpt-4o-transcribe-diarize)
+- [AssemblyAI Pricing](https://www.assemblyai.com/pricing/)
+- [AssemblyAI supported languages](https://www.assemblyai.com/docs/pre-recorded-audio/supported-languages)
+- [Deepgram Pricing](https://deepgram.com/pricing)
+- [Rev.ai Pricing](https://www.rev.ai/pricing)
+- [Speechmatics Pricing](https://www.speechmatics.com/pricing)

--- a/src/aiProvider.ts
+++ b/src/aiProvider.ts
@@ -5,7 +5,20 @@ export type AiProvider = (typeof AI_PROVIDERS)[number];
 export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
 export const DEFAULT_CODEX_MODEL = 'gpt-5.5';
-export const DEFAULT_CODEX_TRANSCRIPTION_MODEL = 'gpt-4o-transcribe';
+// gpt-4o-transcribe-diarize ships native speaker diarization at the same
+// per-minute price ($0.006/min) as the non-diarize model. Trade-offs vs
+// gpt-4o-transcribe (see docs/model-pricing.md):
+//   - doesn't accept the `prompt` parameter, so user glossaries
+//     (`knownWords`) are silently dropped on this path
+//   - we still segment audio into 5-min chunks for parallel-upload speed,
+//     so "Speaker 0" in chunk 1 is not guaranteed to be the same physical
+//     person as "Speaker 0" in chunk 2
+export const DEFAULT_CODEX_TRANSCRIPTION_MODEL = 'gpt-4o-transcribe-diarize';
+
+// Pre-diarize model id. Useful for users who want the older prompt-driven
+// behavior (vocabulary hints via `knownWords`) at the cost of speaker
+// labels. Switch via `listener config set codexTranscriptionModel gpt-4o-transcribe`.
+export const CODEX_TRANSCRIPTION_NON_DIARIZE_MODEL = 'gpt-4o-transcribe';
 
 export function isAiProvider(value: string): value is AiProvider {
   return (AI_PROVIDERS as readonly string[]).includes(value);

--- a/src/codexTranscription.test.ts
+++ b/src/codexTranscription.test.ts
@@ -1,0 +1,92 @@
+// Covers the diarized_json response reshape that gpt-4o-transcribe-diarize
+// returns. Behavior we lock in:
+//   - Re-label OpenAI speaker ids onto our 참가자N convention
+//   - Merge consecutive segments from the same speaker onto one line
+//   - Empty-string segments are skipped
+//   - No segments / no usable text throws (so the renderer sees an error,
+//     not a blank transcript that gets quietly saved)
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { formatDiarizedSegments, isDiarizeModel } from './codexTranscription';
+
+describe('isDiarizeModel', () => {
+  it('matches the diarize model id', () => {
+    assert.equal(isDiarizeModel('gpt-4o-transcribe-diarize'), true);
+    assert.equal(isDiarizeModel('  gpt-4o-transcribe-diarize  '), true);
+  });
+
+  it('does not match the non-diarize transcription models', () => {
+    assert.equal(isDiarizeModel('gpt-4o-transcribe'), false);
+    assert.equal(isDiarizeModel('gpt-4o-mini-transcribe'), false);
+    assert.equal(isDiarizeModel('whisper-1'), false);
+  });
+});
+
+describe('formatDiarizedSegments', () => {
+  it('maps Speaker 0/1 to 참가자1/2 in first-seen order', () => {
+    const out = formatDiarizedSegments([
+      { speaker: 'Speaker 0', text: '안녕하세요' },
+      { speaker: 'Speaker 1', text: '네 반갑습니다' },
+      { speaker: 'Speaker 0', text: '회의 시작하겠습니다' },
+    ]);
+    assert.equal(
+      out,
+      '참가자1: 안녕하세요\n\n참가자2: 네 반갑습니다\n\n참가자1: 회의 시작하겠습니다',
+    );
+  });
+
+  it('merges consecutive segments from the same speaker onto one line', () => {
+    const out = formatDiarizedSegments([
+      { speaker: 'Speaker 0', text: '첫 문장입니다' },
+      { speaker: 'Speaker 0', text: '두 번째 문장입니다' },
+      { speaker: 'Speaker 1', text: '제가 답변드릴게요' },
+    ]);
+    const lines = out.split('\n\n');
+    assert.equal(lines.length, 2);
+    assert.equal(lines[0], '참가자1: 첫 문장입니다 두 번째 문장입니다');
+    assert.equal(lines[1], '참가자2: 제가 답변드릴게요');
+  });
+
+  it('honors user-supplied speaker names if OpenAI returns them', () => {
+    // When `known_speaker_names[]` is set, OpenAI labels segments with the
+    // user-supplied names instead of "Speaker 0/1". Treat each unique label
+    // as a new participant in first-seen order, same as the Speaker N path.
+    const out = formatDiarizedSegments([
+      { speaker: '한결', text: '안녕하세요' },
+      { speaker: '주연', text: '안녕하세요' },
+    ]);
+    assert.equal(out, '참가자1: 안녕하세요\n\n참가자2: 안녕하세요');
+  });
+
+  it('drops segments with empty/whitespace-only text', () => {
+    const out = formatDiarizedSegments([
+      { speaker: 'Speaker 0', text: '' },
+      { speaker: 'Speaker 0', text: '   ' },
+      { speaker: 'Speaker 1', text: '실제 내용' },
+    ]);
+    assert.equal(out, '참가자1: 실제 내용');
+  });
+
+  it('treats missing speaker as a single "unknown" bucket', () => {
+    const out = formatDiarizedSegments([{ text: '첫 번째' }, { text: '두 번째' }]);
+    // Same bucket, so segments merge.
+    assert.equal(out, '참가자1: 첫 번째 두 번째');
+  });
+
+  it('throws when no segments are returned (renderer must see an error)', () => {
+    assert.throws(() => formatDiarizedSegments([]), /no segments/);
+    assert.throws(() => formatDiarizedSegments(undefined), /no segments/);
+  });
+
+  it('throws when segments are present but all empty', () => {
+    assert.throws(
+      () =>
+        formatDiarizedSegments([
+          { speaker: 'Speaker 0', text: '' },
+          { speaker: 'Speaker 1', text: '   ' },
+        ]),
+      /no usable text/,
+    );
+  });
+});

--- a/src/codexTranscription.ts
+++ b/src/codexTranscription.ts
@@ -5,6 +5,16 @@
 // Codex transcription flow needs only a multipart POST, so a thin direct
 // fetch is simpler than wedging audio into pi-ai's chat model.
 //
+// Two output shapes, branched on model id:
+//   - `gpt-4o-transcribe-diarize` (default) returns `diarized_json` with
+//     speaker-labeled segments. We re-label "Speaker 0/1/..." onto the
+//     same `참가자N` convention the Gemini path uses so downstream code
+//     (summarization, transcript.md, Notion) doesn't have to care which
+//     transcription engine produced the text. This model rejects `prompt`,
+//     so user-supplied glossaries (`knownWords`) are dropped on this path.
+//   - `gpt-4o-transcribe` (and `whisper-1`) return `{text}` and accept
+//     `prompt` for vocabulary biasing, but produce no speaker labels.
+//
 // Format support: OpenAI accepts mp3, mp4, mpeg, mpga, m4a, wav, webm. Inputs
 // outside that set are remuxed upstream in geminiService.ts via ffmpeg before
 // reaching this helper.
@@ -14,6 +24,7 @@ import * as path from 'path';
 import { mimeTypeForExtension } from './audioFormats';
 
 const OPENAI_API_BASE_URL = 'https://api.openai.com/v1';
+const DIARIZE_MODEL_ID = 'gpt-4o-transcribe-diarize';
 
 export const OPENAI_TRANSCRIPTION_EXTENSIONS = new Set([
   '.mp3',
@@ -27,17 +38,46 @@ export const OPENAI_TRANSCRIPTION_EXTENSIONS = new Set([
 
 export type CodexTokenProvider = () => Promise<string>;
 
-export async function transcribeCodexAudio(params: {
+export interface DiarizedSegment {
+  speaker?: string;
+  text?: string;
+  start?: number;
+  end?: number;
+}
+
+export interface TranscribeCodexAudioParams {
   getToken: CodexTokenProvider;
   audioFilePath: string;
   model: string;
+  /** Vocabulary/style hint. Ignored when model is `gpt-4o-transcribe-diarize`. */
   prompt?: string;
-}): Promise<string> {
+  /** ISO 639-1 language code (e.g. "ko"). Improves accuracy when set. */
+  language?: string;
+}
+
+export function isDiarizeModel(model: string): boolean {
+  return model.trim() === DIARIZE_MODEL_ID;
+}
+
+export async function transcribeCodexAudio(params: TranscribeCodexAudioParams): Promise<string> {
   const audioData = fs.readFileSync(params.audioFilePath);
   const ext = path.extname(params.audioFilePath);
+  const model = params.model.trim();
+  const diarize = isDiarizeModel(model);
+
   const form = new FormData();
-  form.append('model', params.model.trim());
-  if (params.prompt?.trim()) {
+  form.append('model', model);
+  if (params.language) {
+    form.append('language', params.language);
+  }
+  if (diarize) {
+    // Required for the diarize model. `chunking_strategy=auto` lets OpenAI
+    // split long audio internally while keeping speaker identity coherent
+    // across chunks -- so we can hand it a whole 50-minute meeting (subject
+    // to the 25MB file-size limit upstream).
+    form.append('response_format', 'diarized_json');
+    form.append('chunking_strategy', 'auto');
+  } else if (params.prompt?.trim()) {
     form.append('prompt', params.prompt.trim());
   }
   form.append(
@@ -46,11 +86,23 @@ export async function transcribeCodexAudio(params: {
     path.basename(params.audioFilePath),
   );
 
+  const sizeMB = (audioData.byteLength / (1024 * 1024)).toFixed(2);
+  const startedAt = Date.now();
+  console.log(
+    `[codex-transcribe] -> ${path.basename(params.audioFilePath)} ${sizeMB}MB model=${model}${
+      diarize ? ' diarize=true' : params.prompt ? ` prompt=${params.prompt.length}chars` : ''
+    }${params.language ? ` lang=${params.language}` : ''}`,
+  );
+
   const response = await fetch(`${OPENAI_API_BASE_URL}/audio/transcriptions`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${await params.getToken()}` },
     body: form,
   });
+  const elapsed = Date.now() - startedAt;
+  console.log(
+    `[codex-transcribe] <- ${elapsed}ms status=${response.status} ${response.statusText}`,
+  );
 
   if (!response.ok) {
     // Truncate the error body so a verbose upstream response doesn't leak
@@ -62,9 +114,57 @@ export async function transcribeCodexAudio(params: {
     );
   }
 
+  if (diarize) {
+    const payload = (await response.json()) as { segments?: DiarizedSegment[] };
+    return formatDiarizedSegments(payload.segments);
+  }
+
   const payload = (await response.json()) as { text?: unknown };
   if (typeof payload.text !== 'string' || payload.text.trim().length === 0) {
     throw new Error('OpenAI transcription response missing text');
   }
   return payload.text;
+}
+
+// Re-label OpenAI's raw speaker ids ("Speaker 0", "Speaker 1", or the names
+// supplied via `known_speaker_names[]` if used) onto our `참가자N` convention,
+// matching the format Gemini emits when prompted for speaker labels. Empty
+// segments are dropped; consecutive segments from the same speaker are merged
+// onto a single line so downstream consumers don't see one speaker split into
+// 30+ "참가자1: ..." stubs.
+export function formatDiarizedSegments(segments?: DiarizedSegment[]): string {
+  if (!segments || segments.length === 0) {
+    throw new Error('OpenAI diarized transcription returned no segments');
+  }
+
+  const speakerIdx = new Map<string, number>();
+  let nextIdx = 1;
+  const lines: string[] = [];
+  let activeLabel: string | undefined;
+  let activeBuffer = '';
+
+  for (const seg of segments) {
+    const text = (seg.text ?? '').trim();
+    if (!text) continue;
+    const rawSpeaker = seg.speaker ?? 'unknown';
+    let idx = speakerIdx.get(rawSpeaker);
+    if (idx === undefined) {
+      idx = nextIdx++;
+      speakerIdx.set(rawSpeaker, idx);
+    }
+    const label = `참가자${idx}`;
+    if (label === activeLabel) {
+      activeBuffer += ` ${text}`;
+    } else {
+      if (activeLabel !== undefined) lines.push(`${activeLabel}: ${activeBuffer}`);
+      activeLabel = label;
+      activeBuffer = text;
+    }
+  }
+  if (activeLabel !== undefined) lines.push(`${activeLabel}: ${activeBuffer}`);
+
+  if (lines.length === 0) {
+    throw new Error('OpenAI diarized transcription had segments but no usable text');
+  }
+  return lines.join('\n\n');
 }

--- a/src/configService.test.ts
+++ b/src/configService.test.ts
@@ -236,3 +236,66 @@ describe('ConfigService: saveConfig file mode + concurrent merge', () => {
     assert.equal(onDisk.globalShortcut, 'CommandOrControl+Shift+L', 'other A-keys must survive');
   });
 });
+
+describe('ConfigService: codexTranscriptionModel migration to diarize default', () => {
+  it('clears the legacy `gpt-4o-transcribe` value and stamps the marker', () => {
+    const dataPath = freshDataPath('migrate-legacy');
+    const configPath = path.join(dataPath, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({ codexTranscriptionModel: 'gpt-4o-transcribe' }));
+
+    new ConfigService(dataPath);
+
+    const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    assert.equal(
+      onDisk.codexTranscriptionModel,
+      undefined,
+      'legacy default must be cleared so the new default applies',
+    );
+    assert.equal(onDisk.codexTranscriptionMigratedToDiarize, true);
+  });
+
+  it('stamps the marker even for fresh installs that never had the legacy default', () => {
+    // Regression for the P2 review: if the marker only landed when the
+    // migration cleared something, a user who never had a stored value
+    // could later explicitly opt back into `gpt-4o-transcribe` and have
+    // their choice clobbered on the next restart.
+    const dataPath = freshDataPath('migrate-fresh');
+    const configPath = path.join(dataPath, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}));
+
+    new ConfigService(dataPath);
+
+    const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    assert.equal(onDisk.codexTranscriptionMigratedToDiarize, true);
+  });
+
+  it('preserves a deliberate `gpt-4o-transcribe` opt-out after the marker is set', () => {
+    const dataPath = freshDataPath('migrate-deliberate-optout');
+    // First launch: empty config -> marker gets stamped, no model cleared.
+    new ConfigService(dataPath);
+    // Second session: user deliberately picks the non-diarize model.
+    const second = new ConfigService(dataPath);
+    second.setCodexTranscriptionModel('gpt-4o-transcribe');
+    // Third launch must not re-migrate.
+    const third = new ConfigService(dataPath);
+    assert.equal(third.getCodexTranscriptionModel(), 'gpt-4o-transcribe');
+  });
+
+  it('does not re-run the migration once the marker is set', () => {
+    const dataPath = freshDataPath('migrate-idempotent');
+    const configPath = path.join(dataPath, 'config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        codexTranscriptionModel: 'gpt-4o-transcribe',
+        codexTranscriptionMigratedToDiarize: true,
+      }),
+    );
+
+    new ConfigService(dataPath);
+
+    const onDisk = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    // Marker already there -> user's explicit choice is preserved.
+    assert.equal(onDisk.codexTranscriptionModel, 'gpt-4o-transcribe');
+  });
+});

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -39,6 +39,10 @@ export interface AppConfig {
   lastSeenVersion?: string;
   slackWebhookUrl?: string;
   slackAutoShare?: boolean;
+  // Idempotency marker for `migrateLegacyDefaults` -- once set we never
+  // re-run the migration, so a user who deliberately re-selects the old
+  // model after upgrade keeps their choice.
+  codexTranscriptionMigratedToDiarize?: boolean;
 }
 
 export const DEFAULT_SUMMARY_PROMPT = `Based on this meeting transcript, provide:
@@ -85,6 +89,28 @@ export class ConfigService {
     }
     this.configPath = path.join(userDataPath, 'config.json');
     this.loadConfig();
+    this.migrateLegacyDefaults();
+  }
+
+  // One-shot upgrade hook for keys that older versions auto-persisted from
+  // their then-current default. The settings modal in those versions wrote
+  // back the full payload on save -- including fields the user never
+  // touched -- so the next default change can't reach existing installs.
+  // Today's case: `codexTranscriptionModel: 'gpt-4o-transcribe'` was the
+  // legacy default before gpt-4o-transcribe-diarize shipped; clearing it
+  // here lets `getCodexTranscriptionModel()` return the current default
+  // (diarize) without forcing every user to manually unset it.
+  private migrateLegacyDefaults(): void {
+    let touched = false;
+    if (
+      !this.config.codexTranscriptionMigratedToDiarize &&
+      this.config.codexTranscriptionModel === 'gpt-4o-transcribe'
+    ) {
+      this.setKey('codexTranscriptionModel', undefined);
+      this.setKey('codexTranscriptionMigratedToDiarize', true);
+      touched = true;
+    }
+    if (touched) this.saveConfig();
   }
 
   private loadConfig(): void {

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -100,17 +100,20 @@ export class ConfigService {
   // legacy default before gpt-4o-transcribe-diarize shipped; clearing it
   // here lets `getCodexTranscriptionModel()` return the current default
   // (diarize) without forcing every user to manually unset it.
+  //
+  // The marker semantics are "we've considered migrating this user" --
+  // it lands on EVERY install on first launch, not just the ones we
+  // actually had to migrate. That way if a user later opts back into
+  // `gpt-4o-transcribe` deliberately (e.g. for glossary support), the
+  // next ConfigService construction sees the marker and skips the
+  // migration entirely instead of clobbering their explicit choice.
   private migrateLegacyDefaults(): void {
-    let touched = false;
-    if (
-      !this.config.codexTranscriptionMigratedToDiarize &&
-      this.config.codexTranscriptionModel === 'gpt-4o-transcribe'
-    ) {
+    if (this.config.codexTranscriptionMigratedToDiarize) return;
+    if (this.config.codexTranscriptionModel === 'gpt-4o-transcribe') {
       this.setKey('codexTranscriptionModel', undefined);
-      this.setKey('codexTranscriptionMigratedToDiarize', true);
-      touched = true;
     }
-    if (touched) this.saveConfig();
+    this.setKey('codexTranscriptionMigratedToDiarize', true);
+    this.saveConfig();
   }
 
   private loadConfig(): void {

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -456,7 +456,13 @@ export class GeminiService {
     const baseName = path.basename(audioFilePath, path.extname(audioFilePath));
     const ext = path.extname(audioFilePath);
 
-    const segmentPath = path.join(outputDir, `${baseName}_segment_%03d${ext}`);
+    // When re-encoding to opus we MUST force a container that supports
+    // opus -- ffmpeg picks the muxer from the output extension, so leaving
+    // an imported `.mp3`/`.m4a`/`.wav` source as `.mp3` makes ffmpeg pick
+    // the MP3 muxer and reject the opus stream. `.webm` is in OpenAI's
+    // supported transcription extensions, so the segments still upload.
+    const segmentExt = reencode ? '.webm' : ext;
+    const segmentPath = path.join(outputDir, `${baseName}_segment_%03d${segmentExt}`);
 
     // Get the bundled FFmpeg path
     const ffmpegPath = await this.getFFmpegPath();
@@ -482,10 +488,12 @@ export class GeminiService {
         segmentPath,
       ]);
 
-      // Find all created segment files
+      // Find all created segment files. Match on the EXTENSION WE TOLD
+      // FFMPEG TO WRITE -- when re-encoding, that's `.webm` regardless of
+      // the source's original extension.
       const segmentFiles = fs
         .readdirSync(outputDir)
-        .filter((file) => file.startsWith(`${baseName}_segment_`) && file.endsWith(ext))
+        .filter((file) => file.startsWith(`${baseName}_segment_`) && file.endsWith(segmentExt))
         .map((file) => path.join(outputDir, file))
         .sort();
 

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -443,6 +443,14 @@ export class GeminiService {
   private async splitAudioIntoSegments(
     audioFilePath: string,
     segmentDuration = 300,
+    // re-encode segments instead of `-c copy`. ffmpeg's segment muxer can
+    // only cut at keyframes when copying, and webm-opus has near-zero
+    // keyframes by default -- so `-c copy -segment_time 300` silently
+    // produces 30+ minute segments that blow past gpt-4o-transcribe's
+    // 1400-second per-request limit. Caller passes `reencode: true` for
+    // the Codex transcription path; Gemini's API is tolerant of long
+    // inputs and stays on the faster `-c copy` path.
+    reencode = false,
   ): Promise<string[]> {
     const outputDir = path.dirname(audioFilePath);
     const baseName = path.basename(audioFilePath, path.extname(audioFilePath));
@@ -454,7 +462,13 @@ export class GeminiService {
     const ffmpegPath = await this.getFFmpegPath();
 
     try {
-      // Split audio into segments
+      const codecArgs = reencode ? ['-c:a', 'libopus', '-b:a', '48k'] : ['-c', 'copy'];
+      // Split audio into segments. `-reset_timestamps 1` makes each segment
+      // start at PTS 0 and gives it its own container duration. Without it,
+      // webm output keeps the source file's total duration in the header --
+      // and OpenAI rejects the request based on the header value even when
+      // the actual encoded audio is short (`audio duration N seconds is
+      // longer than 1400` errors on small last-segment files).
       await execFileAsync(ffmpegPath, [
         '-i',
         audioFilePath,
@@ -462,8 +476,9 @@ export class GeminiService {
         'segment',
         '-segment_time',
         String(segmentDuration),
-        '-c',
-        'copy',
+        '-reset_timestamps',
+        '1',
+        ...codecArgs,
         segmentPath,
       ]);
 
@@ -542,6 +557,13 @@ export class GeminiService {
       let fullTranscript = '';
       const stats = fs.statSync(audioFilePath);
       const fileSizeInMB = stats.size / (1024 * 1024);
+      // Segment intentionally for parallelism: even when the API would
+      // accept the whole file (Gemini long-context, gpt-4o-transcribe-diarize
+      // via chunking_strategy=auto), N parallel 5-min requests finish much
+      // faster than one big sequential pass. Trade-off for the diarize
+      // model: speaker IDs are mapped fresh per segment ("Speaker 0" in
+      // segment 1 may not be the same physical person as "Speaker 0" in
+      // segment 2). See docs/model-pricing.md.
       const shouldSegment = duration > 300 || (this.provider === 'codex' && fileSizeInMB > 24);
       const segmentDuration =
         this.provider === 'codex' && duration > 0 && fileSizeInMB > 20
@@ -696,7 +718,14 @@ Return as JSON:
           getToken: () => this.getCodexToken(),
           audioFilePath,
           model: this.codexTranscriptionModel,
+          // `prompt` is dropped inside transcribeCodexAudio when the
+          // diarize model is active. Keep passing it -- the helper picks
+          // the right shape per model.
           prompt: transcriptPrompt,
+          // Intentionally NOT passing `language: 'ko'`. Whisper-derived
+          // transcription auto-detects from the first ~30s, which handles
+          // bilingual/code-switched meetings (Korean primary, English
+          // acronyms/quotes) better than forcing a single language.
         });
       }
 
@@ -938,8 +967,15 @@ Return as JSON:
     segmentDuration = 300,
   ): Promise<string> {
     try {
-      // Split audio into 5-minute segments
-      const segmentFiles = await this.splitAudioIntoSegments(audioFilePath, segmentDuration);
+      // Split audio into 5-minute segments. Codex transcription requires
+      // accurate cut times (gpt-4o-transcribe rejects >1400s/segment), so
+      // force re-encode there; Gemini's API tolerates long inputs and we
+      // keep the cheaper `-c copy` path for it.
+      const segmentFiles = await this.splitAudioIntoSegments(
+        audioFilePath,
+        segmentDuration,
+        this.provider === 'codex',
+      );
 
       if (progressCallback) {
         progressCallback(20, `Processing ${segmentFiles.length} segments...`);

--- a/src/piAiClient.ts
+++ b/src/piAiClient.ts
@@ -50,15 +50,75 @@ export async function getModel(provider: AiProvider, modelId: string): Promise<P
   return m.getModel(piId as never, modelId as never) as unknown as PiAiModel;
 }
 
+function summarizeContextSize(context: Context): string {
+  let chars = 0;
+  let toolCalls = 0;
+  let toolResults = 0;
+  for (const msg of context.messages) {
+    if (msg.role === 'user') {
+      chars +=
+        typeof msg.content === 'string'
+          ? msg.content.length
+          : msg.content.reduce((n, b) => n + (b.type === 'text' ? b.text.length : 0), 0);
+    } else if (msg.role === 'assistant') {
+      for (const b of msg.content) {
+        if (b.type === 'text') chars += b.text.length;
+        else if (b.type === 'toolCall') toolCalls++;
+      }
+    } else if (msg.role === 'toolResult') {
+      toolResults++;
+      for (const b of msg.content) if (b.type === 'text') chars += b.text.length;
+    }
+  }
+  const systemChars = context.systemPrompt?.length ?? 0;
+  return `messages=${context.messages.length} chars=${chars + systemChars} (system=${systemChars}) toolCalls=${toolCalls} toolResults=${toolResults} tools=${context.tools?.length ?? 0}`;
+}
+
+// Strip options the target provider doesn't accept. OpenAI Codex routes
+// through GPT-5.x reasoning models which reject sampling parameters
+// (`Unsupported parameter: temperature`). pi-ai forwards options verbatim,
+// so the adjustment has to happen at our boundary -- doing it here keeps
+// callsites free of provider conditionals.
+function adjustOptionsForModel(
+  model: PiAiModel,
+  options: StreamOptions | undefined,
+): Record<string, unknown> | undefined {
+  if (!options) return undefined;
+  const isCodex = model.api === 'openai-codex-responses' || model.provider === 'openai-codex';
+  if (isCodex) {
+    const { temperature: _t, ...rest } = options;
+    return { ...rest };
+  }
+  return { ...options };
+}
+
 export async function complete(
   model: PiAiModel,
   context: Context,
   options?: StreamOptions,
 ): Promise<AssistantMessage> {
   const m = await loadPiAi();
-  // pi-ai's ProviderStreamOptions is `StreamOptions & Record<string, unknown>`;
-  // spread to satisfy the index-signature constraint.
-  return await m.complete(model, context, options ? { ...options } : undefined);
+  const tag = `[pi-ai ${model.provider}/${model.id}]`;
+  const startedAt = Date.now();
+  console.log(`${tag} -> ${summarizeContextSize(context)}`);
+  const adjustedOptions = adjustOptionsForModel(model, options);
+  const response = await m.complete(model, context, adjustedOptions);
+  const elapsed = Date.now() - startedAt;
+  const stop = response.stopReason ?? 'unknown';
+  const textChars = extractFinalText(response).length;
+  console.log(
+    `${tag} <- ${elapsed}ms stop=${stop} textChars=${textChars} usage=in:${response.usage?.input ?? '?'}/out:${response.usage?.output ?? '?'}${response.errorMessage ? ` errorMessage=${response.errorMessage.slice(0, 300)}` : ''}`,
+  );
+  // pi-ai surfaces upstream failures via stopReason='error' rather than
+  // throwing. Without this, geminiService.generateSummary returns "" and
+  // agentService.run returns "(no answer)" with no breadcrumb. Promote the
+  // diagnostic into a thrown error so it reaches the renderer / CLI surface.
+  if (response.stopReason === 'error') {
+    throw new Error(
+      `Pi-ai ${model.provider}/${model.id} failed: ${response.errorMessage ?? 'no errorMessage'}`,
+    );
+  }
+  return response;
 }
 
 export async function getTypeBox(): Promise<PiAiModule['Type']> {


### PR DESCRIPTION
## Summary

Live-testing the v2.7.0 Codex OAuth release surfaced three bugs and one behavior gap relative to the Gemini path. This PR fixes them as one cohesive Codex-quality push, plus a docs reference for the model pricing table.

## Bug fixes

1. **Segmentation: every chunk hit `audio duration longer than 1400s`.** ffmpeg's `-c copy` mode can only cut at keyframes, and webm-opus has near-zero keyframes — so our `-segment_time 300` silently produced 30+ minute chunks that blow past `gpt-4o-transcribe`'s per-request limit. Fixed by re-encoding via `-c:a libopus -b:a 48k` on the Codex path (Gemini stays on `-c copy` since its API is tolerant of long inputs) and adding `-reset_timestamps 1` so each chunk's container header reports its own duration instead of the source's.

2. **Codex chat rejected `temperature` on every call.** `gpt-5.5` is a reasoning model and returns `400 Unsupported parameter: temperature`. Summary + agent calls hard-coded `0.2`/`0.3`. Stripped at the `piAiClient.complete()` boundary via `adjustOptionsForModel` so callsites stay free of provider conditionals.

3. **Empty responses got silently saved.** pi-ai surfaces upstream failures through `stopReason: 'error'` rather than throwing. Promoted into a thrown error inside `piAiClient.complete()` so the renderer / CLI see actionable text instead of a blank transcript.

## Feature

4. **Default `codexTranscriptionModel` flips to `gpt-4o-transcribe-diarize`** (released by OpenAI 2025-10-18). Same endpoint, same `$0.006/min`, native speaker labels — closes the Gemini-vs-Codex experience gap. New `formatDiarizedSegments` remaps OpenAI's `Speaker N` onto the existing `참가자N` convention so the rest of the pipeline (summary prompt, transcript.md, Notion upload) doesn't need provider awareness.

   `ConfigService` has a one-shot migration: previous versions of the settings UI auto-persisted `gpt-4o-transcribe` even when the user never touched the field, so without it, existing installs would silently stick to the no-diarize path. Idempotency marker (`codexTranscriptionMigratedToDiarize`) prevents re-migration if a user deliberately picks the older model post-upgrade.

## Trade-offs (documented in `docs/model-pricing.md`)

- `prompt` param is rejected by diarize → `knownWords` glossaries are dropped on this path. Users who depend on vocabulary hints can fall back via `listener config set codexTranscriptionModel gpt-4o-transcribe`.
- We keep our 5-minute parallel-upload segmentation (intentional speed win) → speaker IDs are coherent **per chunk** but not necessarily across chunks. Each chunk's `참가자1` might be a different physical person from the next chunk's.
- No forced `language: 'ko'` — Whisper auto-detects from the first ~30s, which handles bilingual / code-switched meetings (Korean primary, English acronyms) better than hard-coding Korean.

## Diagnostic logs (kept in)

- `[pi-ai <provider>/<model>] -> messages=N chars=N ...` / `<- Nms stop=X usage=in:N/out:N`
- `[codex-transcribe] -> <file> <sizeMB> model=<m> [diarize=true|prompt=Ncharrs]` / `<- Nms status=<HTTP>`

Low volume (one pair per request). These surfaced each of the bugs above and stay useful for future debugging.

## New: `docs/model-pricing.md`

Per-token / per-minute rates for every model Listener.AI uses or might reasonably switch to, verified 2026-05-13. Includes Gemini, OpenAI chat (gpt-5.5 / 5.4 family + legacy 4o), OpenAI transcription (transcribe / mini / diarize / whisper-1), and third-party Korean-diarization-capable services (AssemblyAI / Deepgram / Rev.ai / Speechmatics).

## Testing

- pnpm test: 130 passing (113 base + 9 new diarize parser + 8 existing Codex/agent integration)
- pnpm run lint clean, pnpm run format:check clean
- npx tsc + pnpm run build:check-renderer clean
- Live tested in dev: 53-minute 24.5MB Korean meeting recording → 11 parallel 5-min chunks → all 200 OK in ~15s each → speaker-labeled transcript + summary saved

## Test plan

- [x] Unit tests for the diarize parser (\`formatDiarizedSegments\`)
- [x] Live transcription of a long Korean meeting with the diarize default
- [x] Live transcription with \`gpt-4o-transcribe\` fallback (no diarize, glossary works)
- [x] Migration: existing config.json with \`codexTranscriptionModel: 'gpt-4o-transcribe'\` → migrated on next launch
- [x] Re-migration safety: setting \`gpt-4o-transcribe\` deliberately after migration is preserved across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)