### PR TITLE
feat(ui): inline transcription progress, cancel, and unified row actions

### DIFF
--- a/renderer/electronAPI.d.ts
+++ b/renderer/electronAPI.d.ts
@@ -113,9 +113,7 @@ export type ElectronAPI = {
     errorDetails?: TranscriptionErrorPayload;
     cancelled?: boolean;
   }>;
-  cancelTranscription: (
-    filePath: string,
-  ) => Promise<{ success: boolean; reason?: 'not-running' }>;
+  cancelTranscription: (filePath: string) => Promise<{ success: boolean; reason?: 'not-running' }>;
   uploadToNotion: (data: {
     title: string;
     transcriptionData: any;

--- a/renderer/electronAPI.d.ts
+++ b/renderer/electronAPI.d.ts
@@ -111,7 +111,11 @@ export type ElectronAPI = {
     transcriptionPath?: string;
     error?: string;
     errorDetails?: TranscriptionErrorPayload;
+    cancelled?: boolean;
   }>;
+  cancelTranscription: (
+    filePath: string,
+  ) => Promise<{ success: boolean; reason?: 'not-running' }>;
   uploadToNotion: (data: {
     title: string;
     transcriptionData: any;
@@ -144,7 +148,9 @@ export type ElectronAPI = {
   sendAgentConfirmResponse: (payload: { id: string; approved: boolean }) => Promise<void>;
   cancelAgentPending: () => Promise<void>;
   onConfigChanged: (cb: (config: unknown) => void) => void;
-  onTranscriptionProgress: (cb: (progress: { percent: number; message: string }) => void) => void;
+  onTranscriptionProgress: (
+    cb: (progress: { percent: number; message: string; filePath?: string }) => void,
+  ) => void;
   checkFFmpeg: () => Promise<{ available: boolean; path?: string }>;
   downloadFFmpeg: () => Promise<{ success: boolean; error?: string }>;
   cancelFFmpegDownload: () => Promise<void>;

--- a/renderer/main.ts
+++ b/renderer/main.ts
@@ -97,13 +97,18 @@ window.addEventListener('DOMContentLoaded', async () => {
     setupDragAndDrop();
     setupPasteListener();
 
-    // Cross-cutting IPC listeners that aren't owned by a single feature module.
+    // Modal progress bar. Drag-drop transcribe (handleTranscribe) and merge
+    // both drive their progress through this listener. Gate on the modal's
+    // progress container being VISIBLE -- inline row transcribes never show
+    // the modal, so updates land while hidden and waste DOM mutations; worse,
+    // they'd leak the inline message into the modal next time it opens.
+    // recordings-list.ts owns the inline dispatch via its own subscription.
     window.electronAPI.onTranscriptionProgress((progress) => {
       const dom = getDom();
-      if (dom.progressContainer && dom.progressFill && dom.progressText) {
-        dom.progressFill.style.width = `${progress.percent}%`;
-        dom.progressText.textContent = progress.message;
-      }
+      if (!dom.progressContainer || !dom.progressFill || !dom.progressText) return;
+      if (dom.progressContainer.style.display === 'none') return;
+      dom.progressFill.style.width = `${progress.percent}%`;
+      dom.progressText.textContent = progress.message;
     });
 
     window.electronAPI.onOpenConfig(() => {

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -1767,40 +1767,27 @@ h1 {
   flex-shrink: 0;
 }
 
-/* Reveal-on-hover for utility actions: keep rows quiet by default, surface
-   secondary actions only when the user shows intent. The chevron and
-   primary CTA (Transcribe) stay visible. */
+/* Secondary actions (Merge / Show / M4A / Regenerate) are visible at all
+   times but visually de-emphasized -- lighter text, slightly muted -- so the
+   primary CTA (Transcribe pill, or chevron on transcribed rows) reads as the
+   main anchor without the row needing to "wake up" on hover. Hovering the
+   button itself brightens it; hovering the row alone does NOT change layout
+   so there is no shifting motion. */
 .recording-item .merge-btn,
 .recording-item .reveal-btn,
 .recording-item .export-m4a-btn,
 .recording-item .regenerate-btn {
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.12s ease;
-  /* Reserve no space when hidden so the title can grow. */
-  width: 0;
-  padding-inline: 0;
-  overflow: hidden;
+  color: #94a3b8;
+  font-weight: 400;
+  transition: color 0.12s ease, background-color 0.12s ease;
 }
 
-.recording-item:hover .merge-btn,
-.recording-item:hover .reveal-btn,
-.recording-item:hover .export-m4a-btn,
-.recording-item:hover .regenerate-btn,
-.recording-item:focus-within .merge-btn,
-.recording-item:focus-within .reveal-btn,
-.recording-item:focus-within .export-m4a-btn,
-.recording-item:focus-within .regenerate-btn {
-  opacity: 1;
-  pointer-events: auto;
-  width: auto;
-  padding-inline: 9px;
-  overflow: visible;
-}
-
-.recording-item:hover .regenerate-btn,
-.recording-item:focus-within .regenerate-btn {
-  padding-inline: 8px;
+.recording-item .merge-btn:hover,
+.recording-item .reveal-btn:hover,
+.recording-item .export-m4a-btn:hover,
+.recording-item .regenerate-btn:hover {
+  color: #0f172a;
+  background-color: #eef2f6;
 }
 
 /* Default: subtle ghost style. Utility actions (Merge/Show/M4A/regenerate)

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -608,6 +608,98 @@ h1 {
   transform: translateX(2px);
 }
 
+/* Inline transcription progress: replaces the meta line + actions while a
+   transcribe-audio call is in flight. The row keeps the same height so the
+   list doesn't reflow. The thin progress strip sits along the bottom edge. */
+.recording-item[data-transcribing="true"] {
+  background-color: #f8fafc;
+  border-color: #e2e8f0;
+  cursor: default;
+}
+
+.recording-item[data-transcribing="true"] .recording-meta {
+  display: none;
+}
+
+.recording-item[data-transcribing="true"] .recording-chevron {
+  display: none;
+}
+
+.recording-item[data-transcribing="true"] .recording-status {
+  background-color: #3498db;
+  border-color: #3498db;
+  animation: recording-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes recording-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+.recording-progress {
+  font-size: 12px;
+  color: #475569;
+  line-height: 1.35;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.recording-progress-percent {
+  color: #94a3b8;
+  font-variant-numeric: tabular-nums;
+  margin-left: 6px;
+}
+
+.recording-progress-bar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background-color: #e2e8f0;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+  overflow: hidden;
+}
+
+.recording-progress-fill {
+  height: 100%;
+  width: 0%;
+  background-color: #3498db;
+  transition: width 0.25s ease;
+}
+
+/* Cancel-only action while transcribing: hide every other action, keep the
+   cancel button visible without hover. */
+.recording-item[data-transcribing="true"] .recording-actions > *:not(.cancel-transcribe-btn) {
+  display: none;
+}
+
+.cancel-transcribe-btn {
+  padding: 5px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #b91c1c;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background-color: transparent;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.cancel-transcribe-btn:hover {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.cancel-transcribe-btn:disabled {
+  color: #cbd5e1;
+  cursor: not-allowed;
+  background-color: transparent;
+}
+
 .no-recordings {
   text-align: center;
   color: #94a3b8;

--- a/renderer/ui/drag-drop.ts
+++ b/renderer/ui/drag-drop.ts
@@ -9,8 +9,7 @@
 import { getFileHandler } from '../services/file-handler';
 import { getDom } from '../state';
 import { showToast } from './notifications';
-import { refreshRecordingsList } from './recordings-list';
-import { handleTranscribe } from './transcription-modal';
+import { refreshRecordingsList, transcribeByPath } from './recordings-list';
 
 let dragDropZone: HTMLElement | null = null;
 
@@ -54,7 +53,11 @@ async function handleFileSuccess(filePath: string, fileName: string): Promise<vo
   // Ask if user wants to transcribe immediately
   if (confirm(`Audio file "${title}" has been added. Would you like to transcribe it now?`)) {
     try {
-      await handleTranscribe(filePath, title);
+      // refreshRecordingsList just ran above, so the newly imported row is in
+      // the DOM and `transcribeByPath` can drive the same inline progress UI
+      // that the list buttons use. Modal fallback handles the rare case where
+      // the row didn't make it in.
+      await transcribeByPath(filePath, title);
     } catch (transcribeError) {
       console.error('Error starting transcription:', transcribeError);
       showToast('Failed to start transcription', 'error');

--- a/renderer/ui/recordings-list.ts
+++ b/renderer/ui/recordings-list.ts
@@ -10,10 +10,11 @@ import { getDom } from '../state';
 import { showToast } from './notifications';
 import {
   _setCurrentTranscription,
-  handleTranscribe,
   populateTranscriptionUI,
   prepareTranscriptionModal,
+  requireAiAuth,
   showSavedTranscript,
+  transcribeWithFfmpegRetry,
 } from './transcription-modal';
 
 type Recording = {
@@ -151,7 +152,13 @@ export async function createRecordingItem(recording: Recording): Promise<HTMLEle
     item.querySelectorAll<HTMLButtonElement>('.action-button').forEach((btn) => {
       btn.addEventListener('click', (e) => e.stopPropagation());
     });
-    const open = () => showSavedTranscript(recording.path, recording.title, metadataResult.data);
+    const open = () => {
+      // Suspend whole-row entry while the row is showing an inline transcribe.
+      // Otherwise a stray click on the progress area opens the stale (pre-
+      // regenerate) transcript while a regenerate is mid-flight.
+      if (item.dataset.transcribing) return;
+      showSavedTranscript(recording.path, recording.title, metadataResult.data);
+    };
     item.addEventListener('click', open);
     item.addEventListener('keydown', (e) => {
       // Only act on key presses targeting the row itself; ignore bubbling
@@ -171,13 +178,13 @@ export async function createRecordingItem(recording: Recording): Promise<HTMLEle
           'Are you sure you want to regenerate the transcript? This will overwrite the existing one.',
         )
       ) {
-        void handleTranscribe(recording.path, recording.title);
+        void runInlineTranscription(item, recording.path);
       }
     });
   } else {
     const transcribeBtn = item.querySelector('.transcribe-btn') as HTMLButtonElement | null;
     transcribeBtn?.addEventListener('click', () => {
-      void handleTranscribe(recording.path, recording.title);
+      void runInlineTranscription(item, recording.path);
     });
   }
 
@@ -541,10 +548,180 @@ export async function refreshRecordingsList(): Promise<void> {
   await loadRecordings();
 }
 
+// --- Inline transcription progress ----------------------------------------
+//
+// Per-row progress UI: replaces the item's action buttons and meta line while
+// a transcribe-audio call is in flight, with a Cancel control. No modal opens
+// during transcription; on success the list refreshes so the row gains its
+// "View Transcript" affordance. The user then clicks the row to open the
+// modal viewer.
+
+type ProgressListener = (progress: { percent: number; message: string }) => void;
+const inlineProgressListeners = new Map<string, ProgressListener>();
+
+function mountInlineProgressUI(item: HTMLElement): {
+  setProgress: ProgressListener;
+  restore: () => void;
+} {
+  // Snapshot the existing children so we can put them back when transcription
+  // ends, regardless of outcome. The row keeps its grid layout: status |
+  // info (title + progress) | actions (just Cancel).
+  const info = item.querySelector('.recording-info') as HTMLElement | null;
+  const actions = item.querySelector('.recording-actions') as HTMLElement | null;
+  const originalActions = actions ? Array.from(actions.children) : [];
+  const meta = info?.querySelector('.recording-meta') as HTMLElement | null;
+  const savedHasTranscript = item.dataset.hasTranscript;
+  const savedRole = item.getAttribute('role');
+  const savedTabindex = item.getAttribute('tabindex');
+  const savedAriaLabel = item.getAttribute('aria-label');
+
+  // Suspend whole-row click-to-open while transcribing so misclicks don't open
+  // an older transcript mid-regenerate. role/tabindex restoration on `restore`
+  // brings the keyboard affordances back.
+  if (savedHasTranscript === 'true') {
+    item.removeAttribute('role');
+    item.removeAttribute('tabindex');
+    item.removeAttribute('aria-label');
+  }
+  item.dataset.transcribing = 'true';
+
+  const progressLine = document.createElement('p');
+  progressLine.className = 'recording-progress';
+  const messageSpan = document.createElement('span');
+  messageSpan.className = 'recording-progress-message';
+  messageSpan.textContent = 'Starting transcription…';
+  const percentSpan = document.createElement('span');
+  percentSpan.className = 'recording-progress-percent';
+  percentSpan.textContent = '';
+  progressLine.append(messageSpan, percentSpan);
+  if (meta) meta.insertAdjacentElement('afterend', progressLine);
+  else info?.appendChild(progressLine);
+
+  const bar = document.createElement('div');
+  bar.className = 'recording-progress-bar';
+  const fill = document.createElement('div');
+  fill.className = 'recording-progress-fill';
+  bar.appendChild(fill);
+  item.appendChild(bar);
+
+  let cancelBtn: HTMLButtonElement | null = null;
+  if (actions) {
+    cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'cancel-transcribe-btn';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.setAttribute('aria-label', 'Cancel transcription');
+    // Stop the click from bubbling to the row -- transcript-bearing rows have
+    // a click handler that opens the modal viewer, which would race against
+    // our cancel/restore flow and show a stale transcript while the row
+    // reverts. Mirrors the stopPropagation wired onto `.action-button`.
+    cancelBtn.addEventListener('click', (e) => e.stopPropagation());
+    actions.appendChild(cancelBtn);
+  }
+
+  const setProgress: ProgressListener = ({ percent, message }) => {
+    const clamped = Math.max(0, Math.min(100, percent));
+    fill.style.width = `${clamped}%`;
+    if (message) messageSpan.textContent = message;
+    percentSpan.textContent = clamped > 0 ? `${Math.round(clamped)}%` : '';
+  };
+
+  const restore = (): void => {
+    item.removeAttribute('data-transcribing');
+    progressLine.remove();
+    bar.remove();
+    if (actions) {
+      // Strip whatever the inline flow appended, restore the original children
+      // in their original order so hover-reveal CSS keeps working.
+      while (actions.firstChild) actions.removeChild(actions.firstChild);
+      for (const child of originalActions) actions.appendChild(child);
+    }
+    if (savedHasTranscript === 'true') {
+      if (savedRole) item.setAttribute('role', savedRole);
+      if (savedTabindex) item.setAttribute('tabindex', savedTabindex);
+      if (savedAriaLabel) item.setAttribute('aria-label', savedAriaLabel);
+    }
+  };
+
+  return {
+    setProgress,
+    restore: () => {
+      restore();
+      cancelBtn = null;
+    },
+  };
+}
+
+async function runInlineTranscription(item: HTMLElement, filePath: string): Promise<void> {
+  // Synchronous double-fire guard. The `data-transcribing` attribute is set
+  // inside `mountInlineProgressUI` *after* awaits, so a rapid double-click on
+  // Transcribe/Regenerate would have both invocations pass that check and then
+  // mount twice. Slam the marker on now, before any await; the renderer's
+  // event loop guarantees a second click in the same tick is the only race
+  // window, and DOM dataset writes are synchronous.
+  if (item.dataset.transcribing) return;
+  item.dataset.transcribing = 'pending';
+
+  if (!(await requireAiAuth())) {
+    item.removeAttribute('data-transcribing');
+    return;
+  }
+
+  const { setProgress, restore } = mountInlineProgressUI(item);
+  inlineProgressListeners.set(filePath, setProgress);
+
+  const cancelBtn = item.querySelector('.cancel-transcribe-btn') as HTMLButtonElement | null;
+  let cancelled = false;
+  cancelBtn?.addEventListener('click', () => {
+    if (cancelled) return;
+    cancelled = true;
+    cancelBtn.disabled = true;
+    cancelBtn.textContent = 'Cancelling…';
+    void window.electronAPI.cancelTranscription(filePath);
+  });
+
+  try {
+    // `transcribeWithFfmpegRetry` issues the IPC immediately on the first
+    // line, so by the time the user could click Cancel the abort controller
+    // is already registered in main.
+    const result = await transcribeWithFfmpegRetry(filePath);
+    if (result.cancelled) {
+      // Row goes back to its pre-transcribe state; no toast — user chose this.
+      return;
+    }
+    if (!result.success) {
+      const message = (result as { error?: string }).error || 'Unknown error';
+      showToast(`Failed to transcribe: ${message}`, 'error');
+      return;
+    }
+    // Success: refresh so the row picks up its renamed filePath (if any) and
+    // the "View Transcript" / chevron affordance. The renderer's row entry no
+    // longer auto-opens the modal — the user clicks to view.
+    await refreshRecordingsList();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    showToast(`Error transcribing: ${message}`, 'error');
+  } finally {
+    inlineProgressListeners.delete(filePath);
+    // If we refreshed the list on success the original `item` is detached;
+    // calling restore on a detached node is a no-op but harmless.
+    restore();
+  }
+}
+
 export function setupRecordingsList(): void {
   if (window.electronAPI.onRecordingsChanged) {
     window.electronAPI.onRecordingsChanged(() => {
       void refreshRecordingsList();
     });
   }
+
+  // Single subscription, dispatched per-filePath to the right row. Events
+  // without a filePath (legacy callers like merge) or without a registered
+  // listener are dropped silently.
+  window.electronAPI.onTranscriptionProgress((progress) => {
+    if (!progress.filePath) return;
+    const listener = inlineProgressListeners.get(progress.filePath);
+    listener?.(progress);
+  });
 }

--- a/renderer/ui/recordings-list.ts
+++ b/renderer/ui/recordings-list.ts
@@ -88,6 +88,10 @@ export async function createRecordingItem(recording: Recording): Promise<HTMLEle
   );
 
   item.dataset.hasTranscript = hasTranscript ? 'true' : 'false';
+  // Identifier so external callers (drag-drop, file-import) can locate a row
+  // by audio path after a list refresh and trigger the inline progress flow
+  // on it instead of falling back to the modal.
+  item.dataset.filepath = recording.path;
   if (hasTranscript) {
     item.setAttribute('role', 'button');
     item.setAttribute('tabindex', '0');
@@ -112,17 +116,9 @@ export async function createRecordingItem(recording: Recording): Promise<HTMLEle
   const actions = document.createElement('div');
   actions.className = 'recording-actions';
 
-  if (hasTranscript) {
-    actions.appendChild(
-      createActionButton('regenerate-btn', '↻', {
-        title: 'Regenerate transcript',
-        ariaLabel: 'Regenerate transcript',
-      }),
-    );
-  } else {
-    actions.appendChild(createActionButton('transcribe-btn', 'Transcribe'));
-  }
-
+  // Hide-on-hover utility buttons go FIRST so hover-reveal grows the actions
+  // block to the left. The primary CTA (Transcribe / chevron entry) sits last
+  // at the right edge and doesn't shift when the row is hovered.
   actions.appendChild(
     createActionButton('merge-btn', 'Merge', {
       title: 'Merge this with other recordings into a single note',
@@ -137,11 +133,19 @@ export async function createRecordingItem(recording: Recording): Promise<HTMLEle
   );
 
   if (hasTranscript) {
+    actions.appendChild(
+      createActionButton('regenerate-btn', '↻', {
+        title: 'Regenerate transcript',
+        ariaLabel: 'Regenerate transcript',
+      }),
+    );
     const chevron = document.createElement('span');
     chevron.className = 'recording-chevron';
     chevron.setAttribute('aria-hidden', 'true');
     chevron.textContent = '›';
     actions.appendChild(chevron);
+  } else {
+    actions.appendChild(createActionButton('transcribe-btn', 'Transcribe'));
   }
 
   item.appendChild(actions);
@@ -707,6 +711,25 @@ async function runInlineTranscription(item: HTMLElement, filePath: string): Prom
     // calling restore on a detached node is a no-op but harmless.
     restore();
   }
+}
+
+// Public entry point for callers that have a file path but no row reference
+// (drag-drop, file-import, paste). Locates the row by `data-filepath` and
+// drives it through the inline transcribe flow so every user-initiated
+// transcription looks the same. Falls back to the modal flow when the row
+// isn't in the DOM (e.g. caller didn't refresh the list, the file isn't in
+// the recordings dir).
+export async function transcribeByPath(filePath: string, fallbackTitle: string): Promise<void> {
+  const selector = `.recording-item[data-filepath="${CSS.escape(filePath)}"]`;
+  const row = document.querySelector(selector) as HTMLElement | null;
+  if (row) {
+    await runInlineTranscription(row, filePath);
+    return;
+  }
+  // Lazy import keeps the static dep graph free of the modal flow for callers
+  // that only ever go through `runInlineTranscription`.
+  const { handleTranscribe } = await import('./transcription-modal');
+  await handleTranscribe(filePath, fallbackTitle);
 }
 
 export function setupRecordingsList(): void {

--- a/renderer/ui/transcription-modal.ts
+++ b/renderer/ui/transcription-modal.ts
@@ -158,22 +158,44 @@ export function showSavedTranscript(
   }
 }
 
+// Gate transcription on AI provider auth being configured. Returns true when
+// the caller can proceed; false when the user needs to configure first (and
+// the appropriate UI has already been surfaced). Shared by the modal and the
+// inline-row transcribe flows.
+export async function requireAiAuth(): Promise<boolean> {
+  const configCheck = await window.electronAPI.checkConfig();
+  if (configCheck.hasAiAuth) return true;
+  if (document.getElementById('configModal')) {
+    void showConfigModal();
+  } else {
+    alert('Please configure your AI provider first');
+  }
+  return false;
+}
+
+// Retry `transcribeAudio` once after the ffmpeg-missing download dialog if the
+// first call surfaced that specific failure. Returns the (possibly retried)
+// result so callers don't need to know about the recovery path.
+export async function transcribeWithFfmpegRetry(
+  filePath: string,
+): Promise<Awaited<ReturnType<typeof window.electronAPI.transcribeAudio>>> {
+  let result = await window.electronAPI.transcribeAudio(filePath);
+  if (!result.success && (result as { code?: string }).code === 'ffmpeg-missing') {
+    const { showFFmpegDownloadDialog } = await import('./ffmpeg-dialog');
+    const dlResult = await showFFmpegDownloadDialog();
+    if (dlResult.success) {
+      result = await window.electronAPI.transcribeAudio(filePath);
+    }
+  }
+  return result;
+}
+
 export async function handleTranscribe(filePath: string, title: string): Promise<void> {
   console.log('handleTranscribe called with:', { filePath, title });
 
   // Transcription only needs the AI provider auth; Notion is for the optional
   // upload step and shouldn't gate the recording -> transcript flow.
-  const configCheck = await window.electronAPI.checkConfig();
-  console.log('Has config:', configCheck);
-
-  if (!configCheck.hasAiAuth) {
-    if (document.getElementById('configModal')) {
-      void showConfigModal();
-    } else {
-      alert('Please configure your AI provider first');
-    }
-    return;
-  }
+  if (!(await requireAiAuth())) return;
 
   if (!prepareTranscriptionModal(`Transcription - ${title}`, 'Initializing transcription...')) {
     return;
@@ -188,19 +210,7 @@ export async function handleTranscribe(filePath: string, title: string): Promise
   }
 
   try {
-    // Call the transcription API
-    let result = await window.electronAPI.transcribeAudio(filePath);
-
-    // FFmpeg is required for transcription. If it's missing, prompt the user
-    // to download it via the dialog and then retry once. The dialog handles
-    // its own progress UI; we just await its outcome.
-    if (!result.success && (result as { code?: string }).code === 'ffmpeg-missing') {
-      const { showFFmpegDownloadDialog } = await import('./ffmpeg-dialog');
-      const dlResult = await showFFmpegDownloadDialog();
-      if (dlResult.success) {
-        result = await window.electronAPI.transcribeAudio(filePath);
-      }
-    }
+    const result = await transcribeWithFfmpegRetry(filePath);
 
     if (result.success) {
       // Hide progress bar

--- a/src/audioFormats.test.ts
+++ b/src/audioFormats.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isTranscriptionTempFile } from './audioFormats';
+
+// The recordings watcher and `get-recordings` both rely on this helper to
+// suppress transient transcription artifacts. A loose match would let user
+// recordings get suppressed; too tight a match would let a temp file fire a
+// list refresh that wipes the inline progress row.
+describe('isTranscriptionTempFile', () => {
+  it('matches ffmpeg segment files (`_segment_NNN.<ext>`)', () => {
+    assert.equal(isTranscriptionTempFile('Meeting_segment_000.webm'), true);
+    assert.equal(isTranscriptionTempFile('Meeting_segment_123.mp3'), true);
+    assert.equal(isTranscriptionTempFile('Talk_segment_999.m4a'), true);
+  });
+
+  it('matches codex pre-conversion temps (`_codex_<timestamp>.webm`)', () => {
+    assert.equal(isTranscriptionTempFile('Meeting_codex_1715923200000.webm'), true);
+    assert.equal(isTranscriptionTempFile('Talk_codex_1.webm'), true);
+  });
+
+  it('does not match user recordings that share the prefix', () => {
+    assert.equal(isTranscriptionTempFile('Meeting_segment_notes.webm'), false);
+    assert.equal(isTranscriptionTempFile('Meeting_segment_1.webm'), false);
+    assert.equal(isTranscriptionTempFile('Codex_demo.webm'), false);
+    assert.equal(isTranscriptionTempFile('Meeting.webm'), false);
+  });
+
+  it('requires a single extension after the suffix (no nested dots)', () => {
+    assert.equal(isTranscriptionTempFile('Meeting_segment_001.txt.webm'), false);
+    assert.equal(isTranscriptionTempFile('Meeting_codex_123.tar.gz'), false);
+  });
+});

--- a/src/audioFormats.ts
+++ b/src/audioFormats.ts
@@ -49,3 +49,17 @@ export function isSupportedAudioExtension(ext: string): boolean {
   const normalized = ext.startsWith('.') ? ext.toLowerCase() : `.${ext.toLowerCase()}`;
   return (SUPPORTED_AUDIO_EXTENSIONS as readonly string[]).includes(normalized);
 }
+
+// Transient files the transcription pipeline writes alongside user recordings:
+//   - `<base>_segment_NNN.<ext>` from ffmpeg's segment muxer (NNN = `%03d`)
+//   - `<base>_codex_<Date.now()>.webm` from `prepareAudioForProvider` when a
+//     non-OpenAI-supported source extension (.ogg/.flac/.aac/.opus) needs to
+//     be remuxed before hitting `/v1/audio/transcriptions`
+// Used by the recordings watcher to suppress mid-transcription refreshes that
+// would wipe the inline progress row, and by `get-recordings` so these temp
+// files don't appear as ghost recordings while a transcribe is in flight.
+const TRANSCRIPTION_TEMP_FILE_PATTERN = /(?:_segment_\d{3}|_codex_\d+)\.[A-Za-z0-9]+$/;
+
+export function isTranscriptionTempFile(filename: string): boolean {
+  return TRANSCRIPTION_TEMP_FILE_PATTERN.test(filename);
+}

--- a/src/codexTranscription.test.ts
+++ b/src/codexTranscription.test.ts
@@ -6,9 +6,16 @@
 //   - No segments / no usable text throws (so the renderer sees an error,
 //     not a blank transcript that gets quietly saved)
 
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
-import { formatDiarizedSegments, isDiarizeModel } from './codexTranscription';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import {
+  formatDiarizedSegments,
+  isDiarizeModel,
+  transcribeCodexAudio,
+} from './codexTranscription';
 
 describe('isDiarizeModel', () => {
   it('matches the diarize model id', () => {
@@ -87,6 +94,58 @@ describe('formatDiarizedSegments', () => {
           { speaker: 'Speaker 1', text: '   ' },
         ]),
       /no usable text/,
+    );
+  });
+});
+
+// Signal forwarding: the inline Cancel button only feels responsive when the
+// OpenAI multipart POST aborts on the same signal. Without this propagation,
+// the upload completes in the background after the user cancelled.
+describe('transcribeCodexAudio signal propagation', () => {
+  const originalFetch = globalThis.fetch;
+  let audioPath = '';
+
+  beforeEach(() => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-signal-'));
+    audioPath = path.join(dir, 'clip.webm');
+    fs.writeFileSync(audioPath, Buffer.alloc(16, 1));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (audioPath) fs.rmSync(path.dirname(audioPath), { recursive: true, force: true });
+  });
+
+  it('aborts the in-flight fetch when the caller signal fires', async () => {
+    // Fake fetch that resolves only when the signal aborts.
+    globalThis.fetch = ((_url: string, init?: RequestInit) =>
+      new Promise((_, reject) => {
+        const sig = init?.signal as AbortSignal | undefined;
+        if (!sig) {
+          reject(new Error('expected signal to be forwarded into fetch init'));
+          return;
+        }
+        if (sig.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'));
+          return;
+        }
+        sig.addEventListener(
+          'abort',
+          () => reject(new DOMException('Aborted', 'AbortError')),
+          { once: true },
+        );
+      })) as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 20);
+    await assert.rejects(
+      transcribeCodexAudio({
+        getToken: async () => 'fake-token',
+        audioFilePath: audioPath,
+        model: 'gpt-4o-transcribe',
+        signal: controller.signal,
+      }),
+      (err: unknown) => (err as { name?: unknown } | null)?.name === 'AbortError',
     );
   });
 });

--- a/src/codexTranscription.test.ts
+++ b/src/codexTranscription.test.ts
@@ -11,11 +11,7 @@ import * as os from 'os';
 import * as path from 'path';
 import assert from 'node:assert/strict';
 import { afterEach, beforeEach, describe, it } from 'node:test';
-import {
-  formatDiarizedSegments,
-  isDiarizeModel,
-  transcribeCodexAudio,
-} from './codexTranscription';
+import { formatDiarizedSegments, isDiarizeModel, transcribeCodexAudio } from './codexTranscription';
 
 describe('isDiarizeModel', () => {
   it('matches the diarize model id', () => {
@@ -129,11 +125,9 @@ describe('transcribeCodexAudio signal propagation', () => {
           reject(new DOMException('Aborted', 'AbortError'));
           return;
         }
-        sig.addEventListener(
-          'abort',
-          () => reject(new DOMException('Aborted', 'AbortError')),
-          { once: true },
-        );
+        sig.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), {
+          once: true,
+        });
       })) as unknown as typeof fetch;
 
     const controller = new AbortController();

--- a/src/codexTranscription.ts
+++ b/src/codexTranscription.ts
@@ -93,8 +93,10 @@ export interface TranscribeCodexAudioParams {
   prompt?: string;
   /** ISO 639-1 language code (e.g. "ko"). Improves accuracy when set. */
   language?: string;
-  /** Aborts the in-flight fetch -- used to cancel sibling concurrent segments
-   *  when one fails fast and the whole transcription is doomed anyway. */
+  /** Cancellation signal. Forwarded into the fetch so the in-flight upload
+   *  aborts immediately. Two callers fire this: the user-driven cancel button
+   *  in the renderer, and the segment-loop's sibling controller that fails
+   *  fast when one segment hits a 4xx (no point burning quota on the rest). */
   signal?: AbortSignal;
 }
 

--- a/src/geminiService.test.ts
+++ b/src/geminiService.test.ts
@@ -10,8 +10,9 @@ const ffmpegPath = findFfmpegSync();
 let workDir: string;
 
 type GeminiServiceFfmpegHelpers = {
-  getAudioDuration(audioFilePath: string): Promise<number>;
+  getAudioDuration(audioFilePath: string, signal?: AbortSignal): Promise<number>;
   splitAudioIntoSegments(audioFilePath: string, segmentDurationSeconds: number): Promise<string[]>;
+  findSegmentFiles(audioFilePath: string, ext?: string): string[];
 };
 
 before(() => {
@@ -51,6 +52,117 @@ describe(
         assert.equal(path.dirname(segmentFile), workDir);
         assert.ok(fs.existsSync(segmentFile), `segment should exist: ${segmentFile}`);
       }
+    });
+  },
+);
+
+// Abort plumbing: transcribeAudio honors `options.signal` at its very top,
+// before the LISTENER_TEST_MODE stub branch. The renderer cancel-button flow
+// depends on this -- without it, a pre-aborted signal would still return a
+// stubbed transcript and the inline UI would treat cancel as success.
+describe('GeminiService transcribeAudio abort plumbing', () => {
+  it('throws synchronously when the signal is already aborted', async () => {
+    process.env.LISTENER_TEST_MODE = '1';
+    process.env.NODE_ENV = 'test';
+    try {
+      const service = new GeminiService({
+        apiKey: 'test-key',
+        dataPath: workDir,
+        proModel: 'gemini-test-pro',
+        flashModel: 'gemini-test-flash',
+      });
+      const controller = new AbortController();
+      controller.abort();
+      await assert.rejects(
+        () =>
+          service.transcribeAudio('/tmp/doesnt-matter.webm', undefined, undefined, undefined, {
+            signal: controller.signal,
+          }),
+        (err: unknown) => {
+          const e = err as { name?: unknown } | null;
+          return Boolean(e && (e.name === 'AbortError' || /aborted/i.test(String(err))));
+        },
+      );
+    } finally {
+      delete process.env.LISTENER_TEST_MODE;
+      delete process.env.NODE_ENV;
+    }
+  });
+});
+
+// findSegmentFiles must be strict on the exact `_segment_NNN.<ext>` pattern.
+// A loose prefix match would let cleanup delete real recordings whose user-
+// chosen names happen to contain `_segment_` (e.g. `Meeting_segment_notes
+// .webm`).
+describe('GeminiService.findSegmentFiles bounds', () => {
+  it('only matches ffmpeg-formatted segment files, not user-named lookalikes', () => {
+    const dir = makeTempDir('seg-bounds');
+    try {
+      const sourceAudio = path.join(dir, 'Meeting.webm');
+      fs.writeFileSync(sourceAudio, '');
+      // Real ffmpeg-formatted segments (should match).
+      fs.writeFileSync(path.join(dir, 'Meeting_segment_000.webm'), '');
+      fs.writeFileSync(path.join(dir, 'Meeting_segment_007.webm'), '');
+      // User-named files that share a prefix but are NOT segments.
+      fs.writeFileSync(path.join(dir, 'Meeting_segment_notes.webm'), '');
+      fs.writeFileSync(path.join(dir, 'Meeting_segment_001.txt.webm'), '');
+      fs.writeFileSync(path.join(dir, 'Meeting_segment_1.webm'), '');
+      // Unrelated recording with similar name (different base).
+      fs.writeFileSync(path.join(dir, 'MeetingX_segment_000.webm'), '');
+
+      const helpers = new GeminiService({
+        apiKey: 'test-key',
+        dataPath: workDir,
+        proModel: 'gemini-test-pro',
+        flashModel: 'gemini-test-flash',
+      }) as unknown as GeminiServiceFfmpegHelpers;
+      const matches = helpers.findSegmentFiles(sourceAudio).map((p) => path.basename(p));
+      assert.deepEqual(matches.sort(), ['Meeting_segment_000.webm', 'Meeting_segment_007.webm']);
+    } finally {
+      rmDir(dir);
+    }
+  });
+
+  it('respects the extension filter when supplied', () => {
+    const dir = makeTempDir('seg-ext');
+    try {
+      const sourceAudio = path.join(dir, 'Talk.mp3');
+      fs.writeFileSync(sourceAudio, '');
+      fs.writeFileSync(path.join(dir, 'Talk_segment_000.webm'), '');
+      fs.writeFileSync(path.join(dir, 'Talk_segment_000.mp3'), '');
+
+      const helpers = new GeminiService({
+        apiKey: 'test-key',
+        dataPath: workDir,
+        proModel: 'gemini-test-pro',
+        flashModel: 'gemini-test-flash',
+      }) as unknown as GeminiServiceFfmpegHelpers;
+      const onlyWebm = helpers.findSegmentFiles(sourceAudio, '.webm').map((p) => path.basename(p));
+      assert.deepEqual(onlyWebm, ['Talk_segment_000.webm']);
+    } finally {
+      rmDir(dir);
+    }
+  });
+});
+
+// getAudioDuration's catch blocks normally swallow ffmpeg failures to keep
+// the pipeline moving on a malformed file. They must NOT swallow aborts --
+// the surrounding cancel flow depends on a thrown AbortError to short-circuit.
+describe(
+  'GeminiService.getAudioDuration re-throws aborts',
+  { skip: !ffmpegPath ? 'ffmpeg not installed' : undefined },
+  () => {
+    it('throws when called with a pre-aborted signal', async () => {
+      const audioPath = await makeOpusWebm(ffmpegPath!, workDir, 'duration-abort.webm', 440);
+      const controller = new AbortController();
+      controller.abort();
+      await assert.rejects(
+        () => makeService().getAudioDuration(audioPath, controller.signal),
+        (err: unknown) => {
+          const e = err as { name?: unknown } | null;
+          return Boolean(e && e.name === 'AbortError');
+        },
+      );
     });
   },
 );

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -550,11 +550,9 @@ export class GeminiService {
       // This will output file info to stderr which we can parse
       console.error('Running ffmpeg for duration:', ffmpegPath, audioFilePath);
 
-      const { stderr } = await execFileAsync(
-        ffmpegPath,
-        ['-i', audioFilePath, '-f', 'null', '-'],
-        { signal },
-      ).catch((error: unknown) => {
+      const { stderr } = await execFileAsync(ffmpegPath, ['-i', audioFilePath, '-f', 'null', '-'], {
+        signal,
+      }).catch((error: unknown) => {
         // Re-throw aborts so the surrounding transcribeAudio catch sees a
         // proper AbortError instead of swallowing it into "duration=0".
         if (signal?.aborted) throw error;
@@ -611,9 +609,7 @@ export class GeminiService {
     const outputDir = path.dirname(audioFilePath);
     const baseName = path.basename(audioFilePath, path.extname(audioFilePath));
     const escaped = baseName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const extPattern = ext
-      ? ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      : '\\.[A-Za-z0-9]+';
+    const extPattern = ext ? ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : '\\.[A-Za-z0-9]+';
     const pattern = new RegExp(`^${escaped}_segment_\\d{3}${extPattern}$`);
     try {
       return fs
@@ -1238,9 +1234,7 @@ Return as JSON:
       // via AbortSignal.any so a user-driven cancel also fans out to every
       // in-flight segment.
       const aborter = new AbortController();
-      const combinedSignal = signal
-        ? AbortSignal.any([signal, aborter.signal])
-        : aborter.signal;
+      const combinedSignal = signal ? AbortSignal.any([signal, aborter.signal]) : aborter.signal;
 
       const transcriptionPromises = segmentFiles.map((segmentFile, i) => {
         const segmentStartTime = i * segmentDuration;

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -447,11 +447,26 @@ export class GeminiService {
       `${path.basename(audioFilePath, ext)}_codex_${Date.now()}.webm`,
     );
     const ffmpegPath = await this.getFFmpegPath();
-    await execFileAsync(
-      ffmpegPath,
-      ['-i', audioFilePath, '-vn', '-c:a', 'libopus', '-b:a', '48k', outputPath],
-      { signal },
-    );
+    try {
+      await execFileAsync(
+        ffmpegPath,
+        ['-i', audioFilePath, '-vn', '-c:a', 'libopus', '-b:a', '48k', outputPath],
+        { signal },
+      );
+    } catch (err) {
+      // Abort or ffmpeg failure can leave a partial `_codex_<ts>.webm` on
+      // disk. Because we threw before returning the `cleanup` closure, the
+      // outer `transcribeAudio` finally never sees this path -- the new
+      // watcher filter only HIDES it from the list, it does not delete it.
+      // Unlink best-effort so the file doesn't accumulate, then rethrow so
+      // cancellation/error semantics are unchanged.
+      try {
+        fs.unlinkSync(outputPath);
+      } catch {
+        /* probably ENOENT -- ffmpeg failed before writing anything */
+      }
+      throw err;
+    }
     return {
       audioFilePath: outputPath,
       cleanup: () => {

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -22,6 +22,24 @@ import { FFmpegManager } from './services/ffmpegManager';
 
 const execFileAsync = promisify(execFile);
 
+// Promise-based sleep that rejects with AbortError if the signal fires during
+// the wait. Without this, polling loops swallow the cancel for up to one full
+// interval before the next signal check runs.
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) return reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new DOMException('Aborted', 'AbortError'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 // Append a section to the summary prompt instructing Gemini to enrich each
 // user-flagged moment with a subtitle + categorized bullets, returned as a
 // `highlights` array on the JSON response. Returns '' when there's nothing to
@@ -121,6 +139,13 @@ export interface TranscriptionOptions {
    * per-segment positional prefix are still applied automatically.
    */
   transcriptionPrompt?: string;
+  /**
+   * Cancellation signal. The pipeline checks `signal.aborted` at every stage
+   * boundary and forwards it to the underlying provider SDKs (pi-ai, Gemini
+   * files/generateContent, OpenAI transcription fetch). On abort the in-flight
+   * call rejects with the signal's reason and the surrounding wrapper rethrows.
+   */
+  signal?: AbortSignal;
 }
 
 function transcriptOnlyResult(transcript: string): TranscriptionResult {
@@ -363,7 +388,11 @@ export class GeminiService {
   // knob, so models may wrap the JSON in ```json``` fences. The summary-text
   // consumer strips fences before parsing (see stripJsonFences in
   // transcribeWithTwoSteps).
-  private async generateSummary(promptText: string, transcript: string): Promise<string> {
+  private async generateSummary(
+    promptText: string,
+    transcript: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
     const modelId = this.provider === 'codex' ? this.codexModel : this.proModel;
     const apiKey =
       this.provider === 'codex' ? await this.getCodexToken() : this.requireGeminiApiKey();
@@ -396,11 +425,15 @@ export class GeminiService {
       // xhigh -> "max". Verbosity stays at pi-ai's "low" default (terse output
       // is fine; reasoning depth is what was missing).
       reasoningEffort: 'xhigh',
+      signal,
     });
     return extractFinalText(response);
   }
 
-  private async prepareAudioForProvider(audioFilePath: string): Promise<{
+  private async prepareAudioForProvider(
+    audioFilePath: string,
+    signal?: AbortSignal,
+  ): Promise<{
     audioFilePath: string;
     cleanup?: () => void;
   }> {
@@ -414,16 +447,11 @@ export class GeminiService {
       `${path.basename(audioFilePath, ext)}_codex_${Date.now()}.webm`,
     );
     const ffmpegPath = await this.getFFmpegPath();
-    await execFileAsync(ffmpegPath, [
-      '-i',
-      audioFilePath,
-      '-vn',
-      '-c:a',
-      'libopus',
-      '-b:a',
-      '48k',
-      outputPath,
-    ]);
+    await execFileAsync(
+      ffmpegPath,
+      ['-i', audioFilePath, '-vn', '-c:a', 'libopus', '-b:a', '48k', outputPath],
+      { signal },
+    );
     return {
       audioFilePath: outputPath,
       cleanup: () => {
@@ -449,6 +477,9 @@ export class GeminiService {
     liveNotes?: LiveNote[],
     options: TranscriptionOptions = {},
   ): Promise<TranscriptionResult> {
+    const signal = options.signal;
+    signal?.throwIfAborted();
+
     // Integration-test escape hatch: avoid the real Gemini call so tests can
     // exercise the surrounding pipeline (CLI parsing, IPC, ffmpeg, save) for
     // free and offline. Gated on NODE_ENV=test so a stray LISTENER_TEST_MODE
@@ -468,8 +499,9 @@ export class GeminiService {
       };
     }
 
-    const prepared = await this.prepareAudioForProvider(audioFilePath);
+    const prepared = await this.prepareAudioForProvider(audioFilePath, signal);
     try {
+      signal?.throwIfAborted();
       // Check file size
       const stats = fs.statSync(prepared.audioFilePath);
       const fileSizeInMB = stats.size / (1024 * 1024);
@@ -480,7 +512,7 @@ export class GeminiService {
       }
 
       // Get audio duration using ffmpeg
-      const duration = await this.getAudioDuration(prepared.audioFilePath);
+      const duration = await this.getAudioDuration(prepared.audioFilePath, signal);
       console.error(`Audio duration: ${duration} seconds`);
 
       // If duration is 0, log a warning but continue processing
@@ -490,6 +522,7 @@ export class GeminiService {
         );
       }
 
+      signal?.throwIfAborted();
       // Always use the two-step approach for consistency
       console.error('Using two-step transcription approach...');
       return await this.transcribeWithTwoSteps(
@@ -509,7 +542,7 @@ export class GeminiService {
   }
 
   // Get audio duration using ffmpeg
-  private async getAudioDuration(audioFilePath: string): Promise<number> {
+  private async getAudioDuration(audioFilePath: string, signal?: AbortSignal): Promise<number> {
     try {
       const ffmpegPath = await this.getFFmpegPath();
 
@@ -517,13 +550,14 @@ export class GeminiService {
       // This will output file info to stderr which we can parse
       console.error('Running ffmpeg for duration:', ffmpegPath, audioFilePath);
 
-      const { stderr } = await execFileAsync(ffmpegPath, [
-        '-i',
-        audioFilePath,
-        '-f',
-        'null',
-        '-',
-      ]).catch((error: unknown) => {
+      const { stderr } = await execFileAsync(
+        ffmpegPath,
+        ['-i', audioFilePath, '-f', 'null', '-'],
+        { signal },
+      ).catch((error: unknown) => {
+        // Re-throw aborts so the surrounding transcribeAudio catch sees a
+        // proper AbortError instead of swallowing it into "duration=0".
+        if (signal?.aborted) throw error;
         const execError = error as { stdout?: string; stderr?: string };
         // FFmpeg exits with non-zero code when output is null, but still provides info in stderr
         // This is expected behavior, so we return the error object which contains stdout/stderr
@@ -556,9 +590,39 @@ export class GeminiService {
       console.warn('Could not determine audio duration from stderr:', stderr);
       return 0;
     } catch (error) {
+      // Don't swallow aborts -- let them propagate so the caller can short-
+      // circuit the rest of the transcription pipeline.
+      if (signal?.aborted) throw error;
       console.error('Error getting audio duration:', error);
       // Return 0 as fallback to continue processing
       return 0;
+    }
+  }
+
+  // List existing `<base>_segment_NNN.<ext>` files for an audio path. Used by
+  // both the split step (collecting newly written segments) and the cleanup
+  // step (sweeping leftovers when ffmpeg was killed mid-split). Optional
+  // extension filter -- omit to match any segment file regardless of ext.
+  //
+  // Pattern is strict on purpose: ffmpeg's `%03d` formatter emits exactly
+  // three digits, and a loose prefix match would let user-named recordings
+  // like `Meeting_segment_notes.webm` get caught by cleanup and deleted.
+  private findSegmentFiles(audioFilePath: string, ext?: string): string[] {
+    const outputDir = path.dirname(audioFilePath);
+    const baseName = path.basename(audioFilePath, path.extname(audioFilePath));
+    const escaped = baseName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const extPattern = ext
+      ? ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      : '\\.[A-Za-z0-9]+';
+    const pattern = new RegExp(`^${escaped}_segment_\\d{3}${extPattern}$`);
+    try {
+      return fs
+        .readdirSync(outputDir)
+        .filter((file) => pattern.test(file))
+        .map((file) => path.join(outputDir, file))
+        .sort();
+    } catch {
+      return [];
     }
   }
 
@@ -574,6 +638,7 @@ export class GeminiService {
     // the Codex transcription path; Gemini's API is tolerant of long
     // inputs and stays on the faster `-c copy` path.
     reencode = false,
+    signal?: AbortSignal,
   ): Promise<string[]> {
     const outputDir = path.dirname(audioFilePath);
     const baseName = path.basename(audioFilePath, path.extname(audioFilePath));
@@ -598,27 +663,27 @@ export class GeminiService {
       // and OpenAI rejects the request based on the header value even when
       // the actual encoded audio is short (`audio duration N seconds is
       // longer than 1400` errors on small last-segment files).
-      await execFileAsync(ffmpegPath, [
-        '-i',
-        audioFilePath,
-        '-f',
-        'segment',
-        '-segment_time',
-        String(segmentDuration),
-        '-reset_timestamps',
-        '1',
-        ...codecArgs,
-        segmentPath,
-      ]);
+      await execFileAsync(
+        ffmpegPath,
+        [
+          '-i',
+          audioFilePath,
+          '-f',
+          'segment',
+          '-segment_time',
+          String(segmentDuration),
+          '-reset_timestamps',
+          '1',
+          ...codecArgs,
+          segmentPath,
+        ],
+        { signal },
+      );
 
       // Find all created segment files. Match on the EXTENSION WE TOLD
       // FFMPEG TO WRITE -- when re-encoding, that's `.webm` regardless of
       // the source's original extension.
-      const segmentFiles = fs
-        .readdirSync(outputDir)
-        .filter((file) => file.startsWith(`${baseName}_segment_`) && file.endsWith(segmentExt))
-        .map((file) => path.join(outputDir, file))
-        .sort();
+      const segmentFiles = this.findSegmentFiles(audioFilePath, segmentExt);
 
       console.error(`Split audio into ${segmentFiles.length} segments`);
       return segmentFiles;
@@ -684,6 +749,7 @@ export class GeminiService {
     liveNotes?: LiveNote[],
     options: TranscriptionOptions = {},
   ): Promise<TranscriptionResult> {
+    const signal = options.signal;
     try {
       let fullTranscript = '';
       const stats = fs.statSync(audioFilePath);
@@ -711,6 +777,7 @@ export class GeminiService {
           progressCallback,
           options.transcriptionPrompt,
           segmentDuration,
+          signal,
         );
       } else {
         // Get transcript for short audio
@@ -719,8 +786,11 @@ export class GeminiService {
           audioFilePath,
           progressCallback,
           options.transcriptionPrompt,
+          signal,
         );
       }
+
+      signal?.throwIfAborted();
 
       if (options.transcriptOnly) {
         if (progressCallback) {
@@ -757,7 +827,7 @@ Return as JSON:
       const highlightsBlock = buildHighlightsPromptBlock(enrichableNotes);
       const summaryPrompt = highlightsBlock ? `${basePrompt}\n\n${highlightsBlock}` : basePrompt;
 
-      const summaryText = await this.generateSummary(summaryPrompt, fullTranscript);
+      const summaryText = await this.generateSummary(summaryPrompt, fullTranscript, signal);
 
       let summaryData = {
         suggestedTitle: '',
@@ -834,6 +904,7 @@ Return as JSON:
     audioFilePath: string,
     progressCallback?: (percent: number, message: string) => void,
     customPrompt?: string,
+    signal?: AbortSignal,
   ): Promise<string> {
     try {
       const stats = fs.statSync(audioFilePath);
@@ -857,6 +928,7 @@ Return as JSON:
           // transcription auto-detects from the first ~30s, which handles
           // bilingual/code-switched meetings (Korean primary, English
           // acronyms/quotes) better than forcing a single language.
+          signal,
         });
       }
 
@@ -876,17 +948,25 @@ Return as JSON:
         const fileData = fs.readFileSync(audioFilePath);
         const uploadResult = await ai.files.upload({
           file: new Blob([fileData], { type: mimeType }),
+          config: { abortSignal: signal },
         });
 
         fileUri = uploadResult.uri || '';
 
         // Wait for file to be active
-        let file = await ai.files.get({ name: uploadResult.name || '' });
+        let file = await ai.files.get({
+          name: uploadResult.name || '',
+          config: { abortSignal: signal },
+        });
         let retries = 0;
         while (file.state === 'PROCESSING' && retries < 30) {
+          signal?.throwIfAborted();
           console.error(`Waiting for file to be processed... (attempt ${retries + 1}/30)`);
-          await new Promise((resolve) => setTimeout(resolve, 2000));
-          file = await ai.files.get({ name: uploadResult.name || '' });
+          await abortableDelay(2000, signal);
+          file = await ai.files.get({
+            name: uploadResult.name || '',
+            config: { abortSignal: signal },
+          });
           retries++;
         }
 
@@ -922,6 +1002,7 @@ Return as JSON:
           config: {
             temperature: 0.2,
             maxOutputTokens: 32768,
+            abortSignal: signal,
           },
         });
       } else {
@@ -948,6 +1029,7 @@ Return as JSON:
           config: {
             temperature: 0.2,
             maxOutputTokens: 32768,
+            abortSignal: signal,
           },
         });
       }
@@ -1004,6 +1086,7 @@ Return as JSON:
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       attemptsMade = attempt;
+      signal?.throwIfAborted();
       try {
         console.error(
           `Starting transcription for segment ${segmentIndex + 1}/${totalSegments} (attempt ${attempt}/${maxRetries})...`,
@@ -1048,6 +1131,7 @@ Return as JSON:
           config: {
             temperature: 0.2,
             maxOutputTokens: 32768,
+            abortSignal: signal,
           },
         });
 
@@ -1067,6 +1151,10 @@ Return as JSON:
           content: segmentHeader + transcript,
         };
       } catch (segmentError) {
+        // Abort surfaces here too; don't burn through retries when the caller
+        // cancelled. Re-throw so getSegmentedTranscript's Promise.all rejects
+        // immediately.
+        if (signal?.aborted) throw segmentError;
         lastError = segmentError;
         console.error(
           `Error transcribing segment ${segmentIndex + 1} (attempt ${attempt}/${maxRetries}):`,
@@ -1119,17 +1207,26 @@ Return as JSON:
     progressCallback?: (percent: number, message: string) => void,
     customPrompt?: string,
     segmentDuration = 300,
+    signal?: AbortSignal,
   ): Promise<string> {
+    // Track segments outside the try so the finally can clean them up on
+    // abort / mid-pipeline failure too. Without this, cancelled transcribes
+    // leave `<base>_segment_NNN.<ext>` files piling up in recordings/.
+    let segmentFiles: string[] = [];
     try {
+      signal?.throwIfAborted();
       // Split audio into 5-minute segments. Codex transcription requires
       // accurate cut times (gpt-4o-transcribe rejects >1400s/segment), so
       // force re-encode there; Gemini's API tolerates long inputs and we
       // keep the cheaper `-c copy` path for it.
-      const segmentFiles = await this.splitAudioIntoSegments(
+      segmentFiles = await this.splitAudioIntoSegments(
         audioFilePath,
         segmentDuration,
         this.provider === 'codex',
+        signal,
       );
+
+      signal?.throwIfAborted();
 
       if (progressCallback) {
         progressCallback(20, `Processing ${segmentFiles.length} segments...`);
@@ -1137,8 +1234,13 @@ Return as JSON:
 
       // Shared abort: when one segment fails fast (e.g. 4xx on segment 0),
       // cancel the sibling fetches so we don't burn the user's quota on
-      // results that will be thrown away.
+      // results that will be thrown away. Combined with the caller's signal
+      // via AbortSignal.any so a user-driven cancel also fans out to every
+      // in-flight segment.
       const aborter = new AbortController();
+      const combinedSignal = signal
+        ? AbortSignal.any([signal, aborter.signal])
+        : aborter.signal;
 
       const transcriptionPromises = segmentFiles.map((segmentFile, i) => {
         const segmentStartTime = i * segmentDuration;
@@ -1150,7 +1252,7 @@ Return as JSON:
           segmentStartTime,
           segmentEndTime,
           customPrompt,
-          aborter.signal,
+          combinedSignal,
         ).catch((err) => {
           aborter.abort();
           throw err;
@@ -1210,6 +1312,24 @@ Return as JSON:
     } catch (error) {
       console.error('Error in segmented transcription:', error);
       throw error;
+    } finally {
+      // Clean up segment files regardless of outcome (success, error, abort).
+      // On the happy path `segmentFiles` is authoritative; on abort/error
+      // before split returned we re-scan because ffmpeg may have written
+      // partial segments that never made it into the array. Best-effort:
+      // missing/locked files shouldn't crash the pipeline.
+      const toDelete =
+        segmentFiles.length > 0 ? segmentFiles : this.findSegmentFiles(audioFilePath);
+      for (const segmentFile of toDelete) {
+        try {
+          fs.unlinkSync(segmentFile);
+        } catch (e) {
+          const code = (e as NodeJS.ErrnoException | null)?.code;
+          if (code !== 'ENOENT') {
+            console.error(`Failed to delete segment file: ${segmentFile}`, e);
+          }
+        }
+      }
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -298,7 +298,15 @@ function startRecordingsWatcher(): void {
   const dir = path.join(app.getPath('userData'), 'recordings');
   fs.mkdirSync(dir, { recursive: true });
   try {
-    recordingsWatcher = fs.watch(dir, () => {
+    recordingsWatcher = fs.watch(dir, (_eventType, filename) => {
+      // Skip transient ffmpeg segments created/cleaned up during transcription
+      // (`<base>_segment_NNN.<ext>`). Without this, every segment write fires
+      // `recordings-changed`, the renderer re-renders the list, and the
+      // transcribing row's inline progress UI is wiped from the DOM mid-run.
+      // Match ffmpeg's exact `%03d` format so a user-named recording like
+      // `Meeting_segment_notes.webm` (legal filename) doesn't get suppressed.
+      // Falsy filename (which some platforms emit) falls through to emit.
+      if (typeof filename === 'string' && /_segment_\d{3}\.[A-Za-z0-9]+$/.test(filename)) return;
       if (recordingsWatcherTimer) clearTimeout(recordingsWatcherTimer);
       recordingsWatcherTimer = setTimeout(() => {
         recordingsWatcherTimer = null;
@@ -1458,8 +1466,28 @@ ipcMain.handle('get-meeting-status', async () => {
   };
 });
 
+// In-flight transcriptions keyed by audio filePath. Each entry holds an
+// AbortController whose signal is plumbed through geminiService and the
+// underlying provider SDKs. `cancel-transcription` aborts the controller; the
+// transcribe-audio handler catches the abort and resolves with
+// `{ cancelled: true }` so the renderer can clean up without an alert.
+const activeTranscriptions = new Map<string, AbortController>();
+
 // Transcription handler
 ipcMain.handle('transcribe-audio', async (_, filePath: string, liveNotesRaw?: unknown) => {
+  // Replace any prior controller for the same file so a re-trigger (e.g.
+  // Regenerate) supersedes the previous run.
+  activeTranscriptions.get(filePath)?.abort();
+  const controller = new AbortController();
+  activeTranscriptions.set(filePath, controller);
+  const signal = controller.signal;
+
+  const sendProgress = (percent: number, message: string) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('transcription-progress', { percent, message, filePath });
+    }
+  };
+
   try {
     console.log('Transcription requested for:', filePath);
     let liveNotes = sanitizeLiveNotes(liveNotesRaw);
@@ -1477,13 +1505,7 @@ ipcMain.handle('transcribe-audio', async (_, filePath: string, liveNotesRaw?: un
       }
     }
 
-    // Send progress update
-    if (mainWindow) {
-      mainWindow.webContents.send('transcription-progress', {
-        percent: 0,
-        message: 'Initializing AI service...',
-      });
-    }
+    sendProgress(0, 'Initializing AI service...');
 
     // Initialize AI service if not already initialized
     if (!geminiService) {
@@ -1495,29 +1517,17 @@ ipcMain.handle('transcribe-audio', async (_, filePath: string, liveNotesRaw?: un
       geminiService = createGeminiService()!;
     }
 
-    // Send progress update
-    if (mainWindow) {
-      mainWindow.webContents.send('transcription-progress', {
-        percent: 10,
-        message: 'Starting transcription...',
-      });
-    }
+    sendProgress(10, 'Starting transcription...');
 
     console.log('Starting transcription...');
-
-    // Set up progress callback
-    const progressCallback = (percent: number, message: string) => {
-      if (mainWindow) {
-        mainWindow.webContents.send('transcription-progress', { percent, message });
-      }
-    };
 
     const summaryPrompt = configService.getSummaryPrompt();
     const result = await geminiService.transcribeAudio(
       filePath,
-      progressCallback,
+      sendProgress,
       summaryPrompt,
       liveNotes,
+      { signal },
     );
     console.log('Transcription completed successfully');
     console.log('Saving metadata for:', filePath);
@@ -1593,6 +1603,16 @@ ipcMain.handle('transcribe-audio', async (_, filePath: string, liveNotesRaw?: un
 
     return { success: true, data: result, transcriptionPath };
   } catch (error) {
+    // Cancellation is a normal outcome -- skip the failure notification and
+    // signal it cleanly so the renderer collapses the inline progress without
+    // an error toast. Since every cancellation originates from `controller
+    // .abort()` in this file, `signal.aborted` is the canonical check; matching
+    // on error name/message would risk mis-classifying legitimate provider
+    // failures whose body happens to contain "aborted".
+    if (signal.aborted) {
+      console.log('Transcription cancelled for:', filePath);
+      return { success: false, cancelled: true as const };
+    }
     console.error('Error transcribing audio:', error);
     notificationService.notifyTranscriptionFailed(
       'Transcription failed. Check the app for details.',
@@ -1602,7 +1622,20 @@ ipcMain.handle('transcribe-audio', async (_, filePath: string, liveNotesRaw?: un
       error: error instanceof Error ? error.message : String(error),
       errorDetails: serializeTranscriptionError(error),
     };
+  } finally {
+    // Only clear if we're still the live controller for this file; a
+    // superseding run will have replaced us already.
+    if (activeTranscriptions.get(filePath) === controller) {
+      activeTranscriptions.delete(filePath);
+    }
   }
+});
+
+ipcMain.handle('cancel-transcription', async (_, filePath: string) => {
+  const controller = activeTranscriptions.get(filePath);
+  if (!controller) return { success: false, reason: 'not-running' as const };
+  controller.abort();
+  return { success: true };
 });
 
 // Notion upload handler

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,11 @@ import {
   AgentService,
   type ConfigProposal,
 } from './agentService';
-import { extensionForMimeType, isSupportedAudioExtension } from './audioFormats';
+import {
+  extensionForMimeType,
+  isSupportedAudioExtension,
+  isTranscriptionTempFile,
+} from './audioFormats';
 import { type AppConfig, ConfigService } from './configService';
 import { loginCodexOAuth } from './codexOAuth';
 import { getDataPath } from './dataPath';
@@ -299,14 +303,12 @@ function startRecordingsWatcher(): void {
   fs.mkdirSync(dir, { recursive: true });
   try {
     recordingsWatcher = fs.watch(dir, (_eventType, filename) => {
-      // Skip transient ffmpeg segments created/cleaned up during transcription
-      // (`<base>_segment_NNN.<ext>`). Without this, every segment write fires
+      // Skip transient files created during transcription (ffmpeg segments and
+      // codex pre-conversion temps). Without this, every temp write fires
       // `recordings-changed`, the renderer re-renders the list, and the
       // transcribing row's inline progress UI is wiped from the DOM mid-run.
-      // Match ffmpeg's exact `%03d` format so a user-named recording like
-      // `Meeting_segment_notes.webm` (legal filename) doesn't get suppressed.
       // Falsy filename (which some platforms emit) falls through to emit.
-      if (typeof filename === 'string' && /_segment_\d{3}\.[A-Za-z0-9]+$/.test(filename)) return;
+      if (typeof filename === 'string' && isTranscriptionTempFile(filename)) return;
       if (recordingsWatcherTimer) clearTimeout(recordingsWatcherTimer);
       recordingsWatcherTimer = setTimeout(() => {
         recordingsWatcherTimer = null;
@@ -1932,7 +1934,7 @@ ipcMain.handle('get-recordings', async () => {
       modifiedAt: Date;
     }> = [];
     for (const file of files) {
-      if (file.includes('_segment_')) continue;
+      if (isTranscriptionTempFile(file)) continue;
       if (!isSupportedAudioExtension(path.extname(file))) continue;
 
       const filePath = path.join(recordingsDir, file);

--- a/src/piAiClient.ts
+++ b/src/piAiClient.ts
@@ -120,6 +120,15 @@ export async function complete(
       `Pi-ai ${model.provider}/${model.id} failed: ${response.errorMessage ?? 'no errorMessage'}`,
     );
   }
+  // 'aborted' is the cooperative-cancel terminal state when the caller's
+  // signal fired. Returning the partial message would let downstream consumers
+  // (geminiService.generateSummary) parse an empty/truncated JSON body and
+  // persist a corrupt summary. Re-throw as an AbortError so the surrounding
+  // catch (which already classifies aborts) drops the result.
+  if (response.stopReason === 'aborted') {
+    if (options?.signal) options.signal.throwIfAborted();
+    throw new DOMException('Pi-ai request aborted', 'AbortError');
+  }
   return response;
 }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -41,8 +41,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   clearCodexOAuth: () => ipcRenderer.invoke('codex-oauth-clear'),
   transcribeAudio: (filePath: string, liveNotes?: LiveNote[]) =>
     ipcRenderer.invoke('transcribe-audio', filePath, liveNotes),
-  cancelTranscription: (filePath: string) =>
-    ipcRenderer.invoke('cancel-transcription', filePath),
+  cancelTranscription: (filePath: string) => ipcRenderer.invoke('cancel-transcription', filePath),
   uploadToNotion: (data: {
     title: string;
     transcriptionData: any;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -41,6 +41,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   clearCodexOAuth: () => ipcRenderer.invoke('codex-oauth-clear'),
   transcribeAudio: (filePath: string, liveNotes?: LiveNote[]) =>
     ipcRenderer.invoke('transcribe-audio', filePath, liveNotes),
+  cancelTranscription: (filePath: string) =>
+    ipcRenderer.invoke('cancel-transcription', filePath),
   uploadToNotion: (data: {
     title: string;
     transcriptionData: any;
@@ -90,7 +92,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onConfigChanged: (callback: (config: unknown) => void) => {
     ipcRenderer.on('config-changed', (_, config) => callback(config));
   },
-  onTranscriptionProgress: (callback: (progress: { percent: number; message: string }) => void) => {
+  onTranscriptionProgress: (
+    callback: (progress: { percent: number; message: string; filePath?: string }) => void,
+  ) => {
     ipcRenderer.on('transcription-progress', (_, progress) => callback(progress));
   },
   // FFmpeg management


### PR DESCRIPTION
## Summary

Moves transcription progress out of the modal and into each recording row. A pulse dot, status message with percentage, progress bar, and Cancel button appear inline on the `.recording-item` during Transcribe, Regenerate, drag-drop, file-import, and paste runs; the modal stays closed so the user doesn't lose their place. After a successful run the row shows the "View Transcript" chevron and the user clicks to open the modal viewer.

AbortSignal is plumbed end-to-end so Cancel stops work within ~1s at every layer (pi-ai `complete()`, Gemini Files API + `generateContent`, OpenAI multipart `fetch`, ffmpeg `execFile` via Node's `{signal}` option). The merge flow continues to use the existing modal progress path because the target row doesn't exist yet at progress time.

## Changes

### Inline progress + cancel

- Inline progress UI (`pulse dot / message+% / bar / Cancel`) replaces modal-driven progress for Transcribe and Regenerate; modal progress subscriber now gates on container visibility rather than filePath absence so legacy modal callers (merge) still update normally.
- `cancel-transcription` IPC added; main holds a per-filePath `AbortController` map and honours cancellation at every async boundary.
- Per-segment sibling-cancel `AbortController` (from #134) and user-cancel signal composed via `AbortSignal.any()` so either source fans out to all in-flight fetches.
- pi-ai client now throws `AbortError` on `stopReason: 'aborted'` to prevent a cancelled summary from being persisted as partial output.

### Unified entry points

- New `transcribeByPath(filePath, fallbackTitle)` helper locates the row by `data-filepath` and runs the inline flow on it; falls back to the modal only if the row isn't in the DOM. Drag-drop / file-import / paste all use it after `refreshRecordingsList`, so every user-initiated transcribe looks the same regardless of how the file got into the list.
- `requireAiAuth` and `transcribeWithFfmpegRetry` extracted from `handleTranscribe` and shared on the inline path so the ffmpeg-missing download dialog still appears.

### Row layout

- Replaced hover-reveal (Merge / Show / M4A / ↻ collapsed to `width: 0` until row hover) with always-visible de-emphasized utility buttons. The primary CTA (Transcribe pill, or chevron) is anchored to the right edge so it never shifts when the mouse enters or leaves the row.

### Cleanup + safety

- `fs.watch` recordings filter and `get-recordings` both gate through a shared `isTranscriptionTempFile` helper. The strict regex catches ffmpeg `_segment_NNN.<ext>` artifacts AND codex pre-conversion `_codex_<ts>.webm` temps; user recordings like `Meeting_segment_notes.webm` continue to pass through. Without this, every temp write triggered a list re-render and wiped the row's inline progress UI.
- `findSegmentFiles` helper extracted and reused in both the split-step glob and `finally`-block cleanup (success / error / abort); same strict regex guards cleanup from deleting user recordings.

### Tests

- 9 new tests across `src/geminiService.test.ts`, `src/codexTranscription.test.ts`, and `src/audioFormats.test.ts`: pre-aborted-signal short-circuit, `findSegmentFiles` strictness (match + ext filter), `getAudioDuration` abort re-throw, `transcribeCodexAudio` signal forwarding, `isTranscriptionTempFile` boundary (segment match, codex match, user lookalike rejection, nested-extension rejection).

## Test plan

- [ ] Click Transcribe on an un-transcribed row → row shows inline progress, modal stays closed.
- [ ] Click Regenerate on a transcribed row, confirm dialog → inline progress on the row.
- [ ] Drag-drop / file dialog / paste a new audio file → confirm "transcribe now?" → inline progress on the newly imported row (no modal).
- [ ] Merge two recordings → modal progress still updates normally.
- [ ] Click Cancel mid-transcribe on a long file → stops within ~1s, row reverts to original state, no toast.
- [ ] After a successful transcribe, row shows the "View Transcript" chevron; clicking opens the modal viewer.
- [ ] Cancel a just-started transcribe → no leftover `_segment_*` or `_codex_*` files in the recordings directory.
- [ ] Drag-drop a `.ogg` / `.flac` / `.opus` / `.aac` file with the Codex provider configured → row stays in inline progress through the codex pre-conversion step (no row replacement).
- [ ] Hover any recording row → no sideways motion of Transcribe / chevron; utility buttons stay in place and just brighten on their own hover.

## Notes

- `pnpm run build` (tsc + vite), `pnpm run build:check-renderer` — clean.
- `pnpm test` — 163/163 passing.
- `pnpm run format:check` — clean.
- Smoke-launched the Electron app and exercised inline progress, cancel, drag-drop unification, and the new row layout manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)