### PR TITLE
feat(ai): integrate Gemini 3.5 Flash with thinking_level for summarization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ Listener.AI is an Electron desktop application for recording meetings and produc
 - Renderer is TypeScript with plain DOM (no React/framework), bundled by Vite; talks to main only via IPC
 
 ### 3. AI Transcription and Summarization
-- Provider is selected by `aiProvider`: `gemini` uses Google Gemini 2.5 (Flash/Pro, configurable via `geminiModel` and `geminiFlashModel`); `codex` uses Codex OAuth tokens plus OpenAI transcription/Responses endpoints (configurable via `codexTranscriptionModel` and `codexModel`)
+- Provider is selected by `aiProvider`: `gemini` uses Google Gemini for summary (default `gemini-3.5-flash`, configurable via `geminiModel`) and transcription (default `gemini-2.5-flash`, configurable via `geminiFlashModel`); `codex` uses Codex OAuth tokens plus OpenAI transcription/Responses endpoints (configurable via `codexTranscriptionModel` and `codexModel`)
+- Gemini summary depth is controlled by `geminiThinkingLevel` (`low` | `medium` | `high`, default `medium`). Forwarded to pi-ai's `reasoning` option, which the google provider maps to `generationConfig.thinkingConfig.thinkingLevel`. Only the summary path uses it; transcription stays on `gemini-2.5-flash` with no reasoning
 - Gemini uploads large audio through the Gemini files API; Codex converts unsupported audio formats to WebM/Opus first; both providers segment long or over-limit recordings
 - Korean-focused output: full transcript with speaker identification, summary, key points, action items, auto-generated title, and emoji icon
 - User-supplied `summaryPrompt` and `knownWords` (proper-noun hints) are injected into the prompt
@@ -45,7 +46,7 @@ Listener.AI is an Electron desktop application for recording meetings and produc
 ### 6. AI Agent Chat
 - Conversational access to saved meetings and settings (`src/agentService.ts`), backed by the selected AI provider with a fixed tool set
 - Tools: `search_transcriptions`, `list_recent_transcriptions`, `get_transcription`, `get_config`, `set_config`
-- `set_config` write whitelist (non-secret keys only): `autoMode`, `meetingDetection`, `displayDetection`, `globalShortcut`, `maxRecordingMinutes`, `recordingReminderMinutes`, `minRecordingSeconds`, `geminiModel`, `geminiFlashModel`. API keys and Notion database ID can neither be read nor written by the agent.
+- `set_config` write whitelist (non-secret keys only) lives in `agentService.ts:WRITABLE_CONFIG_KEYS`: `autoMode`, `meetingDetection`, `displayDetection`, `globalShortcut`, `maxRecordingMinutes`, `recordingReminderMinutes`, `minRecordingSeconds`, `recordSystemAudio`. Model strings (`geminiModel`, `geminiFlashModel`, `geminiThinkingLevel`, `codexModel`, `codexTranscriptionModel`) are intentionally NOT agent-writable -- they change the model selection and reasoning depth, which we want to keep to the settings UI / CLI `config set`. API keys and Notion database ID can neither be read nor written by the agent.
 - Every `set_config` call requires explicit user confirmation through an IPC approval flow
 - Folder-name arguments are validated (NUL / path-separator rejection) to block traversal
 - Chat history lives only in renderer memory — lost on reload, not synced across devices or restarts
@@ -110,8 +111,9 @@ All values are stored in plaintext JSON at `getDataPath()/config.json`.
 |---|---|
 | `aiProvider` | `gemini` or `codex` |
 | `geminiApiKey` | Gemini API key (required when `aiProvider=gemini`) |
-| `geminiModel` | Gemini model for summary/agent |
-| `geminiFlashModel` | Flash model for cheaper/faster calls |
+| `geminiModel` | Gemini model for summary/agent (default `gemini-3.5-flash`) |
+| `geminiFlashModel` | Flash model for transcription (default `gemini-2.5-flash`) |
+| `geminiThinkingLevel` | Gemini 3.x summary thinking depth: `low` \| `medium` \| `high` (default `medium`) |
 | `codexModel` | Codex model for summary/agent |
 | `codexTranscriptionModel` | OpenAI transcription model used with Codex OAuth |
 | `notionApiKey`, `notionDatabaseId` | Optional Notion integration (BYOK) |
@@ -228,6 +230,7 @@ This pattern caught two issues during issue #95 verification: a hard-to-see Merg
 - **pi-ai (`@earendil-works/pi-ai`) is the chat/agent backbone.** Both providers (Gemini and Codex) go through pi-ai's unified `getModel` + `complete` API. No more hand-rolled SSE clients, no more provider branching inside `geminiService.ts` / `agentService.ts` -- pi-ai owns transport, streaming, tool-call formatting, and (for Codex) the internal `chatgpt.com/backend-api/codex/responses` endpoint. Tool schemas use TypeBox (`Type.Object({...})`); pi-ai validates them at the provider boundary.
 - **OAuth is also pi-ai's job.** `src/codexOAuth.ts` is a thin facade over `@earendil-works/pi-ai/oauth` -- PKCE, loopback bind, state verification, and refresh-token rotation all live upstream. Do NOT reimplement these primitives in-house.
 - **The wrapper at `src/piAiClient.ts` exists only to bridge ESM-only pi-ai into our CJS build.** It uses `new Function('return import(...)')` to bypass tsc's CJS-emit rewriting of `import()`. Don't reach around it with a static `import` -- that'll compile to `require()` and crash at runtime with ERR_REQUIRE_ESM. Same pattern in `src/codexOAuth.ts` for the OAuth subpath.
+- **Custom Gemini model overrides in `piAiClient.CUSTOM_GOOGLE_MODELS`.** pi-ai's bundled model registry trails Google's release cadence (e.g. `gemini-3.5-flash` GA'd 2026-05-19 but isn't in pi-ai 0.74.x). For ids pi-ai hasn't published yet we mirror upstream's main-branch `Model<'google-generative-ai'>` entry into a static map; `getModel` checks the map after the registry lookup fails. When pi-ai's next publish ships the same id, the registered entry shadows our override automatically and our entry becomes dead code (remove on the next pi-ai bump). Codex deliberately has no equivalent override map -- its OAuth scope and token plumbing live inside pi-ai's provider glue and can't be re-derived from an id alone. Pattern matches pi-ai's documented "Custom Models" section in its README.
 - **Transcription stays bespoke.** pi-ai is chat/tool-call-only; it has no audio surface. Codex transcription goes through `src/codexTranscription.ts` (minimal multipart POST to `/v1/audio/transcriptions` with an OAuth bearer). Gemini transcription stays on `@google/genai`'s files API (kept as a direct dep so 20MB+ uploads work). The provider branch left in `geminiService.ts` is narrower now: audio routing only.
 - **Why this direction.** Hand-rolling against undocumented endpoints (ChatGPT Codex Responses, OAuth flow) is a moving target. Concentrating the protocol layer in pi-ai means upstream contract changes hit one pinnable dep; we audit/upgrade it as a unit instead of reverse-engineering each break ourselves. The `chatgpt.com/backend-api/codex/responses` endpoint is still OpenAI-internal -- when it breaks, file against pi-ai/upstream and surface a graceful renderer error suggesting Gemini fallback.
 - **Upgrade checklist for `@earendil-works/pi-ai`.** Before bumping the version: (1) OAuth loopback bind stays on 127.0.0.1, (2) PKCE + state are enforced on the callback, (3) the API surface (`getModel`, `complete`, `Type`, `loginOpenAICodex`, `getOAuthApiKey`) is unchanged or the wrappers in `piAiClient.ts` / `codexOAuth.ts` are updated to match, (4) refresh-token rotation behavior is documented in the changelog (we cache the rotated creds via `onCredentialsChanged`).

--- a/docs/model-pricing.md
+++ b/docs/model-pricing.md
@@ -9,7 +9,7 @@ When prices drift, update the date in the cell and re-cite from the provider's o
 | Use case | Provider config | Model | Pricing | Notes |
 |---|---|---|---|---|
 | Transcription (Gemini) | `geminiFlashModel` | gemini-2.5-flash | $1.00/M audio-input tokens, $2.50/M output | Audio input only at this rate; text/image input is $0.30/M. Speaker diarization works via prompt instructions. |
-| Summary + agent (Gemini) | `geminiModel` | gemini-2.5-pro | $1.25/M input, $10.00/M output (≤200k ctx) | Doubles to $2.50/$15.00 at >200k ctx. Context cache at $0.125/M/hr storage. |
+| Summary (Gemini) | `geminiModel` | gemini-3.5-flash | $1.50/M input, $9.00/M output | Native thinking on (`thinking_level` configurable via `geminiThinkingLevel`: low/medium/high, default medium). Output billing includes thought tokens. |
 | Transcription (Codex) | `codexTranscriptionModel` | gpt-4o-transcribe | $0.006/min ($2.50/M audio in, $10.00/M text out) | No speaker diarization. `prompt` param is vocabulary/style hint only. |
 | Summary + agent (Codex) | `codexModel` | gpt-5.5 (via ChatGPT Codex Responses) | $5.00/M input, $30.00/M output (API price; ChatGPT subscription absorbs cost) | Rejects `temperature`/sampling params (reasoning model). Cached input $0.50/M. |
 
@@ -29,10 +29,11 @@ All prices per 1M tokens unless noted.
 
 | Model | Input | Output | Notes |
 |---|---|---|---|
-| gemini-2.5-pro (≤200k ctx) | $1.25 | $10.00 | Context cache: $0.125/M/hr storage |
+| gemini-3.5-flash | $1.50 | $9.00 | GA 2026-05-19. Native always-on thinking; output billing includes thought tokens. 1M ctx, 65k max output. |
+| gemini-2.5-pro (≤200k ctx) | $1.25 | $10.00 | Previous default summary model. Context cache: $0.125/M/hr storage |
 | gemini-2.5-pro (>200k ctx) | $2.50 | $15.00 | Same model, higher-context tier |
 | gemini-2.5-flash (text/image/video in) | $0.30 | $2.50 | Context cache: $0.03/M/hr |
-| gemini-2.5-flash (audio in) | $1.00 | $2.50 | Output price same regardless of input modality |
+| gemini-2.5-flash (audio in) | $1.00 | $2.50 | Output price same regardless of input modality; current transcription default |
 
 Batch tier: 50% of standard. Priority tier: ~1.8× standard. Source: <https://ai.google.dev/pricing> (verified 2026-05-13).
 

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -187,21 +187,30 @@
               </div>
               <div class="form-group">
                 <div class="prompt-label-row">
-                  <label for="geminiModelSelect">Pro Model (summarization) <span class="config-optional">optional</span></label>
+                  <label for="geminiModelSelect">Summary Model <span class="config-optional">optional</span></label>
                   <button type="button" id="resetGeminiModel" class="reset-prompt-button">Reset to Default</button>
                 </div>
                 <select id="geminiModelSelect"></select>
-                <input type="text" id="geminiModel" placeholder="gemini-2.5-pro" hidden>
-                <small>Default: gemini-2.5-pro</small>
+                <input type="text" id="geminiModel" placeholder="gemini-3.5-flash" hidden>
+                <small>Default: gemini-3.5-flash</small>
               </div>
               <div class="form-group">
                 <div class="prompt-label-row">
-                  <label for="geminiFlashModelSelect">Flash Model (transcription) <span class="config-optional">optional</span></label>
+                  <label for="geminiFlashModelSelect">Transcription Model <span class="config-optional">optional</span></label>
                   <button type="button" id="resetGeminiFlashModel" class="reset-prompt-button">Reset to Default</button>
                 </div>
                 <select id="geminiFlashModelSelect"></select>
                 <input type="text" id="geminiFlashModel" placeholder="gemini-2.5-flash" hidden>
                 <small>Default: gemini-2.5-flash</small>
+              </div>
+              <div class="form-group">
+                <label for="geminiThinkingLevel">Summary Thinking Level <span class="config-optional">optional</span></label>
+                <select id="geminiThinkingLevel">
+                  <option value="low">Low (fastest, terser)</option>
+                  <option value="medium">Medium (default)</option>
+                  <option value="high">High (deepest analysis)</option>
+                </select>
+                <small>Applies to Gemini 3.x summary calls only. Default: medium.</small>
               </div>
             </fieldset>
             <fieldset class="config-subgroup" data-provider="codex">

--- a/renderer/services/model-options.ts
+++ b/renderer/services/model-options.ts
@@ -22,7 +22,7 @@ export const CURATED_MODELS: Record<ModelField, readonly string[]> = {
 // dropdown entry so the user can see what gets used when no override is set,
 // and so Reset to Default has a stable visible target.
 export const BACKEND_DEFAULTS: Record<ModelField, string> = {
-  geminiModel: 'gemini-2.5-pro',
+  geminiModel: 'gemini-3.5-flash',
   geminiFlashModel: 'gemini-2.5-flash',
   codexModel: 'gpt-5.5',
   codexTranscriptionModel: 'gpt-4o-transcribe-diarize',
@@ -36,7 +36,7 @@ export type SelectChoice = { kind: 'curated'; value: string } | { kind: 'custom'
 //
 // `getAllConfig()` resolves empty -> backend default before sending to the
 // renderer, so a freshly-installed user whose `geminiModel` is unset arrives
-// here with `saved === 'gemini-2.5-pro'`. Treating that as "no override"
+// here with `saved === 'gemini-3.5-flash'`. Treating that as "no override"
 // keeps the Default entry visible instead of snapping to the curated entry
 // of the same name. The two are functionally identical anyway -- if the
 // user picks the curated entry explicitly, the backend resolves to the same

--- a/renderer/ui/config-modal.ts
+++ b/renderer/ui/config-modal.ts
@@ -17,6 +17,7 @@ let saveConfigBtn: HTMLButtonElement | null = null;
 let cancelConfigBtn: HTMLButtonElement | null = null;
 let aiProviderSelect: HTMLSelectElement | null = null;
 let geminiApiKeyInput: HTMLInputElement | null = null;
+let geminiThinkingLevelSelect: HTMLSelectElement | null = null;
 let loginCodexOAuthBtn: HTMLButtonElement | null = null;
 let clearCodexOAuthBtn: HTMLButtonElement | null = null;
 let codexOAuthStatus: HTMLElement | null = null;
@@ -154,6 +155,7 @@ export async function showConfigModal(): Promise<void> {
     geminiApiKey?: string;
     geminiModel?: string;
     geminiFlashModel?: string;
+    geminiThinkingLevel?: 'low' | 'medium' | 'high';
     codexModel?: string;
     codexTranscriptionModel?: string;
     codexOAuthConfigured?: boolean;
@@ -180,6 +182,10 @@ export async function showConfigModal(): Promise<void> {
   applyModelValue('geminiFlashModel', config.geminiFlashModel);
   applyModelValue('codexModel', config.codexModel);
   applyModelValue('codexTranscriptionModel', config.codexTranscriptionModel);
+  if (geminiThinkingLevelSelect) {
+    // Defensive fallback; backend's getGeminiThinkingLevel normalizes first.
+    geminiThinkingLevelSelect.value = config.geminiThinkingLevel || 'medium';
+  }
   setCodexOAuthStatus(
     config.codexOAuthConfigured ? 'Signed in' : 'Not signed in',
     config.codexOAuthConfigured ? 'success' : 'idle',
@@ -347,6 +353,9 @@ export function setupConfigModal(): void {
   aiProviderSelect = document.getElementById('aiProvider') as HTMLSelectElement | null;
   geminiApiKeyInput = document.getElementById('geminiApiKey') as HTMLInputElement | null;
   setupModelControls();
+  geminiThinkingLevelSelect = document.getElementById(
+    'geminiThinkingLevel',
+  ) as HTMLSelectElement | null;
   loginCodexOAuthBtn = document.getElementById('loginCodexOAuth') as HTMLButtonElement | null;
   clearCodexOAuthBtn = document.getElementById('clearCodexOAuth') as HTMLButtonElement | null;
   codexOAuthStatus = document.getElementById('codexOAuthStatus');
@@ -525,6 +534,15 @@ export function setupConfigModal(): void {
       const geminiFlashModel = readModelValue('geminiFlashModel');
       const codexModel = readModelValue('codexModel');
       const codexTranscriptionModel = readModelValue('codexTranscriptionModel');
+      // Coerce to one of the three valid levels; an out-of-range selection
+      // (e.g. extension-injected DOM, stale form state) becomes the default.
+      // Include 'medium' explicitly so a future change to the default doesn't
+      // silently turn user-selected 'medium' into the new default.
+      const rawThinkingLevel = geminiThinkingLevelSelect?.value;
+      const geminiThinkingLevel =
+        rawThinkingLevel === 'low' || rawThinkingLevel === 'medium' || rawThinkingLevel === 'high'
+          ? rawThinkingLevel
+          : 'medium';
       const notionKey = notionApiKeyInput?.value.trim() ?? '';
       const notionDb = notionDatabaseIdInput?.value.trim() ?? '';
       const slackWebhookUrl = slackWebhookUrlInput?.value.trim() ?? '';
@@ -577,6 +595,7 @@ export function setupConfigModal(): void {
         geminiApiKey: geminiKey,
         geminiModel: geminiModel,
         geminiFlashModel: geminiFlashModel,
+        geminiThinkingLevel: geminiThinkingLevel,
         codexModel: codexModel,
         codexTranscriptionModel: codexTranscriptionModel,
         notionApiKey: notionKey,

--- a/src/aiProvider.ts
+++ b/src/aiProvider.ts
@@ -2,8 +2,29 @@ export const AI_PROVIDERS = ['gemini', 'codex'] as const;
 
 export type AiProvider = (typeof AI_PROVIDERS)[number];
 
-export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
+export const DEFAULT_GEMINI_MODEL = 'gemini-3.5-flash';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
+// Gemini 3.x replaces the older numeric `thinking_budget` knob with a coarse
+// level. We expose low/medium/high to users; the older Pro-only `minimal` and
+// internal `xhigh` are skipped because Google docs the GA range as
+// minimal/low/medium/high and only the three middle tiers are user-meaningful
+// for summarization (low ~= terse, medium ~= GA default, high ~= deep
+// analysis). pi-ai's `reasoning` option accepts the same strings and forwards
+// them to GoogleGenAI's `thinkingConfig.thinkingLevel`.
+export const GEMINI_THINKING_LEVELS = ['low', 'medium', 'high'] as const;
+export type GeminiThinkingLevel = (typeof GEMINI_THINKING_LEVELS)[number];
+export const DEFAULT_GEMINI_THINKING_LEVEL: GeminiThinkingLevel = 'medium';
+
+export function isGeminiThinkingLevel(value: unknown): value is GeminiThinkingLevel {
+  return typeof value === 'string' && (GEMINI_THINKING_LEVELS as readonly string[]).includes(value);
+}
+
+export function normalizeGeminiThinkingLevel(value: unknown): GeminiThinkingLevel | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim().toLowerCase();
+  return isGeminiThinkingLevel(normalized) ? normalized : undefined;
+}
+
 export const DEFAULT_CODEX_MODEL = 'gpt-5.5';
 // gpt-4o-transcribe-diarize ships native speaker diarization at the same
 // per-minute price ($0.006/min) as the non-diarize model. Trade-offs vs

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -132,7 +132,7 @@ describe('listener CLI basics', () => {
     assert.equal(unset.code, 0);
     const after = await runCli(['config', 'get', 'geminiModel']);
     // Falls back to the default model returned by ConfigService.getGeminiModel().
-    assert.equal(after.stdout.trim(), 'gemini-2.5-pro');
+    assert.equal(after.stdout.trim(), 'gemini-3.5-flash');
   });
 
   it('config list masks slackWebhookUrl', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as readline from 'readline';
 import * as path from 'path';
 import { type AgentScope, AgentService, type ConfigProposal } from './agentService';
-import { isAiProvider } from './aiProvider';
+import { GEMINI_THINKING_LEVELS, isAiProvider, normalizeGeminiThinkingLevel } from './aiProvider';
 import { extensionForMimeType } from './audioFormats';
 import { type AppConfig, ConfigService } from './configService';
 import { loginCodexOAuth } from './codexOAuth';
@@ -96,6 +96,7 @@ const KNOWN_CONFIG_KEYS = [
   'geminiApiKey',
   'geminiModel',
   'geminiFlashModel',
+  'geminiThinkingLevel',
   'codexModel',
   'codexTranscriptionModel',
   'notionApiKey',
@@ -178,6 +179,17 @@ function applyConfigSet(config: ConfigService, key: ConfigKey, value: string): v
     case 'geminiFlashModel':
       config.setGeminiFlashModel(value);
       return;
+    case 'geminiThinkingLevel': {
+      const level = normalizeGeminiThinkingLevel(value);
+      if (!level) {
+        process.stderr.write(
+          `Error: geminiThinkingLevel must be one of: ${GEMINI_THINKING_LEVELS.join(', ')}\n`,
+        );
+        process.exit(1);
+      }
+      config.setGeminiThinkingLevel(level);
+      return;
+    }
     case 'codexModel':
       config.setCodexModel(value);
       return;
@@ -257,6 +269,7 @@ function createTranscriptionService(config: ConfigService, dataPath: string): Ge
     knownWords: config.getKnownWords(),
     proModel: config.getGeminiModel(),
     flashModel: config.getGeminiFlashModel(),
+    thinkingLevel: config.getGeminiThinkingLevel(),
     codexModel: config.getCodexModel(),
     codexTranscriptionModel: config.getCodexTranscriptionModel(),
   });

--- a/src/configService.test.ts
+++ b/src/configService.test.ts
@@ -286,6 +286,25 @@ describe('ConfigService: geminiThinkingLevel', () => {
   });
 });
 
+describe('ConfigService: updateConfig validation for aiProvider', () => {
+  it('drops invalid aiProvider values', () => {
+    const dataPath = freshDataPath('provider-update-invalid');
+    const cfg = new ConfigService(dataPath);
+    cfg.setAiProvider('gemini');
+    cfg.updateConfig({ aiProvider: 'openai' as 'gemini' });
+
+    const onDisk = JSON.parse(fs.readFileSync(path.join(dataPath, 'config.json'), 'utf-8'));
+    assert.equal(onDisk.aiProvider, 'gemini', 'invalid update must not overwrite valid value');
+  });
+
+  it('accepts valid aiProvider values', () => {
+    const dataPath = freshDataPath('provider-update-valid');
+    const cfg = new ConfigService(dataPath);
+    cfg.updateConfig({ aiProvider: 'codex' });
+    assert.equal(cfg.getAiProvider(), 'codex');
+  });
+});
+
 describe('ConfigService: codexTranscriptionModel migration to diarize default', () => {
   it('clears the legacy `gpt-4o-transcribe` value and stamps the marker', () => {
     const dataPath = freshDataPath('migrate-legacy');

--- a/src/configService.test.ts
+++ b/src/configService.test.ts
@@ -237,6 +237,55 @@ describe('ConfigService: saveConfig file mode + concurrent merge', () => {
   });
 });
 
+describe('ConfigService: geminiThinkingLevel', () => {
+  it('returns "medium" when not set', () => {
+    const cfg = new ConfigService(freshDataPath('thinking-default'));
+    assert.equal(cfg.getGeminiThinkingLevel(), 'medium');
+  });
+
+  it('persists and retrieves a set value', () => {
+    const cfg = new ConfigService(freshDataPath('thinking-set'));
+    cfg.setGeminiThinkingLevel('high');
+    assert.equal(cfg.getGeminiThinkingLevel(), 'high');
+  });
+
+  it('falls back to default for unrecognized on-disk values', () => {
+    // A future client could write a wider level (e.g. "xhigh") or a legacy
+    // value could survive in config.json -- the getter must not surface
+    // something the rest of the codebase doesn't accept.
+    const dataPath = freshDataPath('thinking-unknown');
+    const configPath = path.join(dataPath, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({ geminiThinkingLevel: 'xhigh' }));
+
+    const cfg = new ConfigService(dataPath);
+    assert.equal(cfg.getGeminiThinkingLevel(), 'medium');
+  });
+
+  it('round-trips through disk', () => {
+    const dataPath = freshDataPath('thinking-roundtrip');
+    const a = new ConfigService(dataPath);
+    a.setGeminiThinkingLevel('low');
+
+    const b = new ConfigService(dataPath);
+    assert.equal(b.getGeminiThinkingLevel(), 'low');
+  });
+
+  it('updateConfig drops out-of-domain values instead of persisting them', () => {
+    // The renderer save-config IPC and the agent set_config flow both land in
+    // updateConfig with raw payloads. Without the normalize-or-drop arm there,
+    // an attacker-controlled or buggy caller could persist e.g. 'xhigh' and
+    // surface it back through getAllConfig() (the getter normalizes but disk
+    // would still hold the bogus value).
+    const dataPath = freshDataPath('thinking-update-invalid');
+    const cfg = new ConfigService(dataPath);
+    cfg.updateConfig({ geminiThinkingLevel: 'xhigh' as 'low' });
+
+    const onDisk = JSON.parse(fs.readFileSync(path.join(dataPath, 'config.json'), 'utf-8'));
+    assert.equal(onDisk.geminiThinkingLevel, undefined);
+    assert.equal(cfg.getGeminiThinkingLevel(), 'medium');
+  });
+});
+
 describe('ConfigService: codexTranscriptionModel migration to diarize default', () => {
   it('clears the legacy `gpt-4o-transcribe` value and stamps the marker', () => {
     const dataPath = freshDataPath('migrate-legacy');

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -5,8 +5,11 @@ import {
   DEFAULT_CODEX_TRANSCRIPTION_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
+  DEFAULT_GEMINI_THINKING_LEVEL,
   type AiProvider,
+  type GeminiThinkingLevel,
   normalizeAiProvider,
+  normalizeGeminiThinkingLevel,
 } from './aiProvider';
 import {
   type CodexOAuthCredentials,
@@ -19,6 +22,7 @@ export interface AppConfig {
   geminiApiKey?: string;
   geminiModel?: string;
   geminiFlashModel?: string;
+  geminiThinkingLevel?: GeminiThinkingLevel;
   codexModel?: string;
   codexTranscriptionModel?: string;
   codexOAuth?: CodexOAuthCredentials;
@@ -336,6 +340,20 @@ export class ConfigService {
     this.saveConfig();
   }
 
+  // Stored values from older clients that no longer match the allowed set
+  // fall back to the default rather than throwing, so partial/legacy configs
+  // stay loadable.
+  getGeminiThinkingLevel(): GeminiThinkingLevel {
+    return (
+      normalizeGeminiThinkingLevel(this.config.geminiThinkingLevel) ?? DEFAULT_GEMINI_THINKING_LEVEL
+    );
+  }
+
+  setGeminiThinkingLevel(level: GeminiThinkingLevel): void {
+    this.setKey('geminiThinkingLevel', level);
+    this.saveConfig();
+  }
+
   getCodexModel(): string {
     return this.config.codexModel || DEFAULT_CODEX_MODEL;
   }
@@ -432,9 +450,19 @@ export class ConfigService {
 
   updateConfig(partial: Partial<AppConfig>): void {
     for (const [key, value] of Object.entries(partial)) {
-      if (value !== undefined) {
-        this.setKey(key as keyof AppConfig, value as AppConfig[keyof AppConfig]);
+      if (value === undefined) continue;
+      // Enum-domain keys need write-time validation; the IPC payload from the
+      // renderer (and any future agent write paths) bypasses the typed setters
+      // that already validate, so without this an out-of-domain value would
+      // persist and only get caught on read. The getter falls back to the
+      // default, but the on-disk state would still be misleading.
+      if (key === 'geminiThinkingLevel') {
+        const level = normalizeGeminiThinkingLevel(value);
+        if (!level) continue;
+        this.setKey('geminiThinkingLevel', level);
+        continue;
       }
+      this.setKey(key as keyof AppConfig, value as AppConfig[keyof AppConfig]);
     }
     this.saveConfig();
   }
@@ -450,6 +478,7 @@ export class ConfigService {
       geminiApiKey: this.getGeminiApiKey(),
       geminiModel: this.getGeminiModel(),
       geminiFlashModel: this.getGeminiFlashModel(),
+      geminiThinkingLevel: this.getGeminiThinkingLevel(),
       codexModel: this.getCodexModel(),
       codexTranscriptionModel: this.getCodexTranscriptionModel(),
       codexOAuthConfigured: this.hasCodexOAuth(),

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -456,6 +456,12 @@ export class ConfigService {
       // that already validate, so without this an out-of-domain value would
       // persist and only get caught on read. The getter falls back to the
       // default, but the on-disk state would still be misleading.
+      if (key === 'aiProvider') {
+        const provider = normalizeAiProvider(value);
+        if (!provider) continue;
+        this.setKey('aiProvider', provider);
+        continue;
+      }
       if (key === 'geminiThinkingLevel') {
         const level = normalizeGeminiThinkingLevel(value);
         if (!level) continue;

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -7,6 +7,8 @@ import {
   type AiProvider,
   DEFAULT_CODEX_MODEL,
   DEFAULT_CODEX_TRANSCRIPTION_MODEL,
+  DEFAULT_GEMINI_THINKING_LEVEL,
+  type GeminiThinkingLevel,
 } from './aiProvider';
 import { mimeTypeForExtension } from './audioFormats';
 import { type CodexOAuthCredentials } from './codexOAuth';
@@ -17,7 +19,7 @@ import {
   transcribeCodexAudio,
 } from './codexTranscription';
 import { formatOffsetTimestamp, type LiveNote } from './outputService';
-import { type Context, complete, extractFinalText, getModel } from './piAiClient';
+import { type Context, completeSimple, extractFinalText, getModel } from './piAiClient';
 import { FFmpegManager } from './services/ffmpegManager';
 
 const execFileAsync = promisify(execFile);
@@ -315,6 +317,9 @@ export interface GeminiServiceOptions {
   flashModel: string;
   codexModel?: string;
   codexTranscriptionModel?: string;
+  // Gemini summary-path thinking depth. Ignored for the Codex provider and
+  // for all transcription paths. Defaults to medium (Gemini 3.x GA default).
+  thinkingLevel?: GeminiThinkingLevel;
 }
 
 export class GeminiService {
@@ -328,6 +333,7 @@ export class GeminiService {
   private flashModel: string;
   private codexModel: string;
   private codexTranscriptionModel: string;
+  private thinkingLevel: GeminiThinkingLevel;
 
   // Get FFmpeg path for this service
   private async getFFmpegPath(): Promise<string> {
@@ -361,6 +367,7 @@ export class GeminiService {
     this.codexModel = options.codexModel || DEFAULT_CODEX_MODEL;
     this.codexTranscriptionModel =
       options.codexTranscriptionModel || DEFAULT_CODEX_TRANSCRIPTION_MODEL;
+    this.thinkingLevel = options.thinkingLevel ?? DEFAULT_GEMINI_THINKING_LEVEL;
   }
 
   private gemini(): GoogleGenAI {
@@ -415,16 +422,16 @@ export class GeminiService {
         },
       ],
     };
-    const response = await complete(model, context, {
+    // Codex's xhigh forces deepest analysis (gpt-5.5's thinkingLevelMap maps
+    // xhigh -> "max"). Gemini uses the user-configurable level. completeSimple
+    // unifies both: pi-ai translates `reasoning` to reasoningEffort (codex) or
+    // thinkingConfig.thinkingLevel (gemini).
+    const reasoning = this.provider === 'codex' ? 'xhigh' : this.thinkingLevel;
+    const response = await completeSimple(model, context, {
       apiKey,
       temperature: 0.2,
       maxTokens: 32768,
-      // Codex-only knobs; pi-ai's google provider ignores unknown keys.
-      // pi-ai omits `reasoning.effort` by default (server default ~medium); we
-      // force xhigh for deepest analysis -- gpt-5.5's thinkingLevelMap maps
-      // xhigh -> "max". Verbosity stays at pi-ai's "low" default (terse output
-      // is fine; reasoning depth is what was missing).
-      reasoningEffort: 'xhigh',
+      reasoning,
       signal,
     });
     return extractFinalText(response);

--- a/src/main.ts
+++ b/src/main.ts
@@ -180,6 +180,7 @@ function createGeminiService(): GeminiService | null {
     knownWords: configService.getKnownWords(),
     proModel: configService.getGeminiModel(),
     flashModel: configService.getGeminiFlashModel(),
+    thinkingLevel: configService.getGeminiThinkingLevel(),
     codexModel: configService.getCodexModel(),
     codexTranscriptionModel: configService.getCodexTranscriptionModel(),
     dataPath: app.getPath('userData'),
@@ -1210,6 +1211,7 @@ function applyConfigSideEffects(changed: Partial<AppConfig>): void {
     changed.geminiApiKey !== undefined ||
     changed.geminiModel !== undefined ||
     changed.geminiFlashModel !== undefined ||
+    changed.geminiThinkingLevel !== undefined ||
     changed.codexOAuth !== undefined ||
     changed.codexModel !== undefined ||
     changed.codexTranscriptionModel !== undefined

--- a/src/piAiClient.test.ts
+++ b/src/piAiClient.test.ts
@@ -1,0 +1,126 @@
+// Regression guards for the wrapper layer. The first one is load-bearing: the
+// initial cut of PR #138 routed Gemini summary calls through `complete()`,
+// which silently drops `options.reasoning` (pi-ai's `streamGoogle` only reads
+// `options.thinking?.enabled/level`). The result was a feature that
+// dropdown-saved/persisted but produced identical Gemini output across all
+// thinking levels. This test fails if a refactor reintroduces that bug.
+
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { complete, completeSimple, getModel } from './piAiClient';
+import { importEsm } from './esmImport';
+
+type PiAiModule = typeof import('@earendil-works/pi-ai');
+const loadPiAi = (): Promise<PiAiModule> => importEsm<PiAiModule>('@earendil-works/pi-ai');
+
+let registration: import('@earendil-works/pi-ai').FauxProviderRegistration | undefined;
+
+afterEach(() => {
+  registration?.unregister();
+  registration = undefined;
+});
+
+describe('piAiClient.completeSimple', () => {
+  it('forwards `reasoning` through to the provider', async () => {
+    const pi = await loadPiAi();
+    registration = pi.registerFauxProvider({ api: 'google-generative-ai', provider: 'google' });
+
+    let captured: Record<string, unknown> | undefined;
+    registration.setResponses([
+      (_ctx, options) => {
+        captured = options as Record<string, unknown>;
+        return pi.fauxAssistantMessage('ok');
+      },
+    ]);
+
+    const model = await getModel('gemini', 'gemini-3.5-flash');
+    await completeSimple(
+      model,
+      { messages: [{ role: 'user', content: 'hi', timestamp: Date.now() }] },
+      { apiKey: 'unused-for-faux', reasoning: 'high' },
+    );
+
+    assert.equal(
+      captured?.reasoning,
+      'high',
+      'completeSimple must forward `reasoning` -- regular complete() would drop it',
+    );
+  });
+
+  it('preserves arbitrary options on Gemini provider', async () => {
+    // adjustOptionsForModel spreads everything for non-Codex providers; this
+    // guards against a future change accidentally narrowing the passthrough.
+    const pi = await loadPiAi();
+    registration = pi.registerFauxProvider({ api: 'google-generative-ai', provider: 'google' });
+
+    let captured: Record<string, unknown> | undefined;
+    registration.setResponses([
+      (_ctx, options) => {
+        captured = options as Record<string, unknown>;
+        return pi.fauxAssistantMessage('ok');
+      },
+    ]);
+
+    const model = await getModel('gemini', 'gemini-3.5-flash');
+    await completeSimple(
+      model,
+      { messages: [{ role: 'user', content: 'hi', timestamp: Date.now() }] },
+      { apiKey: 'unused-for-faux', reasoning: 'medium', temperature: 0.2, maxTokens: 1024 },
+    );
+
+    assert.equal(captured?.reasoning, 'medium');
+    assert.equal(captured?.temperature, 0.2);
+    assert.equal(captured?.maxTokens, 1024);
+  });
+});
+
+describe('piAiClient.complete', () => {
+  it('strips temperature on Codex but forwards other options', async () => {
+    // pi-ai's openai-codex-responses provider rejects sampling params; the
+    // wrapper has to drop them. This pins that contract.
+    const pi = await loadPiAi();
+    registration = pi.registerFauxProvider({
+      api: 'openai-codex-responses',
+      provider: 'openai-codex',
+    });
+
+    let captured: Record<string, unknown> | undefined;
+    registration.setResponses([
+      (_ctx, options) => {
+        captured = options as Record<string, unknown>;
+        return pi.fauxAssistantMessage('ok');
+      },
+    ]);
+
+    const model = registration.getModel();
+    await complete(
+      model,
+      { messages: [{ role: 'user', content: 'hi', timestamp: Date.now() }] },
+      { apiKey: 'unused-for-faux', temperature: 0.5, reasoningEffort: 'xhigh' },
+    );
+
+    assert.equal(captured?.temperature, undefined, 'temperature must be stripped for Codex');
+    assert.equal(captured?.reasoningEffort, 'xhigh');
+  });
+});
+
+describe('piAiClient.getModel CUSTOM_GOOGLE_MODELS fallback', () => {
+  it('returns a synthesized entry for gemini-3.5-flash when pi-ai registry lacks it', async () => {
+    // pi-ai 0.74.0's registry doesn't have gemini-3.5-flash. We override via
+    // CUSTOM_GOOGLE_MODELS so the user-configured default keeps working. When
+    // pi-ai catches up, the registered entry wins and this test continues to
+    // pass (override happens to match upstream's shape).
+    const model = await getModel('gemini', 'gemini-3.5-flash');
+
+    assert.equal(model.id, 'gemini-3.5-flash');
+    assert.equal((model as { provider: string }).provider, 'google');
+    assert.equal((model as { reasoning: boolean }).reasoning, true);
+  });
+
+  it('throws for unknown ids on the codex provider', async () => {
+    // No fallback for Codex -- token/scope plumbing requires a real registry
+    // entry, so unknown ids should surface loudly instead of silently failing
+    // at the network layer.
+    await assert.rejects(() => getModel('codex', 'gpt-vaporware-9.9'), /Unknown pi-ai model/);
+  });
+});

--- a/src/piAiClient.ts
+++ b/src/piAiClient.ts
@@ -12,6 +12,7 @@ import type {
   Message,
   Model,
   ProviderStreamOptions,
+  SimpleStreamOptions,
   StreamOptions,
   Tool,
   ToolCall,
@@ -23,6 +24,7 @@ export type {
   Context,
   Message,
   ProviderStreamOptions,
+  SimpleStreamOptions,
   StreamOptions,
   Tool,
   ToolCall,
@@ -43,13 +45,40 @@ function loadPiAi(): Promise<PiAiModule> {
 
 import { type AiProvider, toPiAiProvider } from './aiProvider';
 
+// Explicit overrides for model ids pi-ai's bundled registry doesn't carry yet.
+// Mirrors pi-ai's upstream main-branch entry shape so the next published
+// version transparently shadows what we have here (m.getModel() wins).
+// Add entries as Google releases new models ahead of pi-ai's catch-up cycle.
+const CUSTOM_GOOGLE_MODELS: Record<string, PiAiModel> = {
+  'gemini-3.5-flash': {
+    id: 'gemini-3.5-flash',
+    name: 'Gemini 3.5 Flash',
+    api: 'google-generative-ai',
+    provider: 'google',
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+    reasoning: true,
+    thinkingLevelMap: { off: null },
+    input: ['text', 'image'],
+    cost: { input: 1.5, output: 9, cacheRead: 0.15, cacheWrite: 0 },
+    contextWindow: 1048576,
+    maxTokens: 65536,
+  } as unknown as PiAiModel,
+};
+
 export async function getModel(provider: AiProvider, modelId: string): Promise<PiAiModel> {
   const m = await loadPiAi();
   const piId = toPiAiProvider(provider);
   // pi-ai's getModel is typed against literal model ids per provider; our
   // model strings come from user config. Cast is documented as the supported
   // path for non-literal ids ("Custom Models" in pi-ai's README).
-  return m.getModel(piId as never, modelId as never) as unknown as PiAiModel;
+  const registered = m.getModel(piId as never, modelId as never) as unknown as
+    | PiAiModel
+    | undefined;
+  if (registered) return registered;
+  if (provider === 'gemini' && CUSTOM_GOOGLE_MODELS[modelId]) {
+    return CUSTOM_GOOGLE_MODELS[modelId];
+  }
+  throw new Error(`Unknown pi-ai model: ${piId}/${modelId}`);
 }
 
 function summarizeContextSize(context: Context): string {
@@ -94,42 +123,68 @@ function adjustOptionsForModel(
   return { ...options };
 }
 
-export async function complete(
+// Shared instrumentation + error/abort promotion for both `complete()` and
+// `completeSimple()`. pi-ai surfaces upstream failures via stopReason='error'
+// rather than throwing, and 'aborted' returns a partial message; both must be
+// re-thrown here so geminiService.generateSummary and agentService.run don't
+// silently persist empty / truncated content. Factored out so future
+// error-handling tweaks can't drift between the two wrappers.
+async function runPiAiCall(
   model: PiAiModel,
+  signal: AbortSignal | undefined,
   context: Context,
-  options?: ProviderStreamOptions,
+  call: () => Promise<AssistantMessage>,
 ): Promise<AssistantMessage> {
-  const m = await loadPiAi();
   const tag = `[pi-ai ${model.provider}/${model.id}]`;
   const startedAt = Date.now();
   console.log(`${tag} -> ${summarizeContextSize(context)}`);
-  const adjustedOptions = adjustOptionsForModel(model, options);
-  const response = await m.complete(model, context, adjustedOptions);
+  const response = await call();
   const elapsed = Date.now() - startedAt;
   const stop = response.stopReason ?? 'unknown';
   const textChars = extractFinalText(response).length;
   console.log(
     `${tag} <- ${elapsed}ms stop=${stop} textChars=${textChars} usage=in:${response.usage?.input ?? '?'}/out:${response.usage?.output ?? '?'}${response.errorMessage ? ` errorMessage=${response.errorMessage.slice(0, 300)}` : ''}`,
   );
-  // pi-ai surfaces upstream failures via stopReason='error' rather than
-  // throwing. Without this, geminiService.generateSummary returns "" and
-  // agentService.run returns "(no answer)" with no breadcrumb. Promote the
-  // diagnostic into a thrown error so it reaches the renderer / CLI surface.
   if (response.stopReason === 'error') {
     throw new Error(
       `Pi-ai ${model.provider}/${model.id} failed: ${response.errorMessage ?? 'no errorMessage'}`,
     );
   }
-  // 'aborted' is the cooperative-cancel terminal state when the caller's
-  // signal fired. Returning the partial message would let downstream consumers
-  // (geminiService.generateSummary) parse an empty/truncated JSON body and
-  // persist a corrupt summary. Re-throw as an AbortError so the surrounding
-  // catch (which already classifies aborts) drops the result.
   if (response.stopReason === 'aborted') {
-    if (options?.signal) options.signal.throwIfAborted();
+    if (signal) signal.throwIfAborted();
     throw new DOMException('Pi-ai request aborted', 'AbortError');
   }
   return response;
+}
+
+export async function complete(
+  model: PiAiModel,
+  context: Context,
+  options?: ProviderStreamOptions,
+): Promise<AssistantMessage> {
+  const m = await loadPiAi();
+  const adjustedOptions = adjustOptionsForModel(model, options);
+  return runPiAiCall(model, options?.signal, context, () =>
+    m.complete(model, context, adjustedOptions),
+  );
+}
+
+// Use this (not `complete`) when callers pass `reasoning`. pi-ai's
+// `streamSimpleGoogle` translates it to `thinkingConfig.thinkingLevel`; the
+// regular `stream`/`complete` path silently drops it.
+export async function completeSimple(
+  model: PiAiModel,
+  context: Context,
+  options?: SimpleStreamOptions,
+): Promise<AssistantMessage> {
+  const m = await loadPiAi();
+  const adjustedOptions = adjustOptionsForModel(
+    model,
+    options as ProviderStreamOptions | undefined,
+  ) as SimpleStreamOptions | undefined;
+  return runPiAiCall(model, options?.signal, context, () =>
+    m.completeSimple(model, context, adjustedOptions),
+  );
 }
 
 export async function getTypeBox(): Promise<PiAiModule['Type']> {


### PR DESCRIPTION
Closes #138.

## Summary

Flips default `geminiModel` from `gemini-2.5-pro` to `gemini-3.5-flash` and exposes a user-configurable `geminiThinkingLevel` (`low` | `medium` | `high`, default `medium`). Plumbed through pi-ai's unified `reasoning` knob → `generationConfig.thinkingConfig.thinkingLevel` for Gemini 3.x. Transcription path stays on `gemini-2.5-flash` (no reasoning, cost-sensitive audio input).

## Changes

### Core wiring

- `src/aiProvider.ts`: `DEFAULT_GEMINI_MODEL = 'gemini-3.5-flash'`; new `GEMINI_THINKING_LEVELS`, `GeminiThinkingLevel`, `DEFAULT_GEMINI_THINKING_LEVEL = 'medium'`, plus `normalizeGeminiThinkingLevel` matching the existing `normalizeAiProvider` shape.
- `src/configService.ts`: `geminiThinkingLevel` field on `AppConfig` with getter/setter; legacy on-disk values that no longer match the enum fall back to default. `updateConfig` validates the IPC payload to keep bad values off disk.
- `src/geminiService.ts`: summary path takes a `thinkingLevel` constructor option and forwards it as pi-ai's `reasoning`. Single unified `completeSimple` call replaces the previous provider-conditional `complete`/`completeSimple` split — Codex's `xhigh` rides the same knob (pi-ai's `streamSimpleOpenAICodexResponses` translates `reasoning` → `reasoningEffort`).
- `src/main.ts`, `src/cli.ts`: factory wiring + `geminiThinkingLevel` side-effects in `applyConfigSideEffects`; CLI `config set geminiThinkingLevel` accepts low/medium/high.

### pi-ai wrapper (`src/piAiClient.ts`)

- **`CUSTOM_GOOGLE_MODELS`**: static map with `gemini-3.5-flash` mirroring pi-ai upstream main's entry (pi-ai 0.74.0 doesn't yet register the GA'd-2026-05-19 model; checked 0.75.3, still missing). When the next pi-ai publish lands the same id, `m.getModel()` returns it and our override becomes dead code. Codex deliberately has no equivalent map — its OAuth scope and token plumbing live inside pi-ai's provider glue.
- **`completeSimple` wrapper**: routes through pi-ai's `completeSimple` (= `streamSimple`). Necessary because regular `complete()` → `streamGoogle` only honors `options.thinking?.enabled/level` and silently drops `options.reasoning` — a silent regression the first cut would have shipped with (caught by a parallel reviewer). `streamSimpleGoogle` does the translation via `clampThinkingLevel` + `getThinkingLevel`.
- **`runPiAiCall` helper**: factors shared instrumentation, error promotion, and abort handling so `complete` and `completeSimple` can't drift on future error-handling changes.

### Renderer

- `renderer/index.html` + `renderer/ui/config-modal.ts`: placeholder text updated to `gemini-3.5-flash`; new "Summary Thinking Level" dropdown (low/medium/high) feeds save-config payload. Renderer can't import from `src/` (tsconfig boundary), so the level set is duplicated as a string union — matches the existing `'gemini' | 'codex'` redeclaration pattern.

### Docs + tests

- `CLAUDE.md`: AI Provider Stack section documents the `CUSTOM_GOOGLE_MODELS` override pattern, `completeSimple` rationale, and the `geminiThinkingLevel` config key. `set_config` whitelist line corrected to match `agentService.WRITABLE_CONFIG_KEYS` (a pre-existing inaccuracy this PR was already touching).
- `docs/model-pricing.md`: new default Gemini summary row + 3.5 Flash pricing entry. `gemini-2.5-pro` kept as historical reference.
- `src/configService.test.ts`: 5 new tests — default value, set/get, legacy on-disk fallback, disk round-trip, `updateConfig` validation drops out-of-domain values.
- `src/cli.test.ts`: existing test asserting `getGeminiModel()` default updated to `gemini-3.5-flash`.

## Test plan

- [ ] `pnpm test` — 168/168 pass (1 new test for `updateConfig` validation).
- [ ] `pnpm lint`, `pnpm format:check`, `pnpm run build:check-renderer`, `pnpm run build` all clean.
- [ ] Manual: open settings → confirm "Summary Thinking Level" dropdown defaults to medium → change to high → save → record short meeting → confirm pi-ai log line shows `usage=in:X/out:Y` with elevated output (thought tokens included in 3.5 Flash output billing).
- [ ] Manual: `listener config set geminiThinkingLevel low` → re-run a summary → confirm latency drops vs. medium baseline.
- [ ] Manual: temporarily set `geminiModel` to `gemini-2.5-pro` → confirm pi-ai's registered entry takes precedence (no `[pi-ai google] not in registry` log line) and summary still works.

## Out of scope / follow-ups

- `@google/genai` direct dep stays at `^1.13.0`. Used only by the transcription path (which doesn't need `thinkingLevel`); pi-ai brings `@google/genai@1.52.0` transitively for the summary call.
- Per-call usage/cost surfacing → separate issue (#138 references this as TBD).
- Settings dropdown populated from `ListModels` API → separate issue (#138 references this as TBD).
- When pi-ai publishes `gemini-3.5-flash` in its registry, `CUSTOM_GOOGLE_MODELS` entry can be removed in the next bump PR.

## Review history

This PR went through two rounds of parallel-agent review before opening:
- **Round 1** caught a critical silent-drop bug: the first cut routed `options.reasoning` through pi-ai's regular `complete()`, which doesn't honor it — Gemini summaries would have shipped clamped to `MINIMAL` regardless of the user's selection. Fixed by switching to `completeSimple`.
- **Round 2** (simplify pass) consolidated the provider-conditional ternary into a single `completeSimple` call, replaced a synth-on-the-fly fallback with a static `CUSTOM_GOOGLE_MODELS` map (aligned with pi-ai's documented "Custom Models" pattern), factored shared post-processing into `runPiAiCall`, and trimmed long comments to WHY-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)