### PR TITLE
Settings: curated model dropdown with Custom option

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -187,18 +187,20 @@
               </div>
               <div class="form-group">
                 <div class="prompt-label-row">
-                  <label for="geminiModel">Pro Model (summarization) <span class="config-optional">optional</span></label>
+                  <label for="geminiModelSelect">Pro Model (summarization) <span class="config-optional">optional</span></label>
                   <button type="button" id="resetGeminiModel" class="reset-prompt-button">Reset to Default</button>
                 </div>
-                <input type="text" id="geminiModel" placeholder="gemini-2.5-pro">
+                <select id="geminiModelSelect"></select>
+                <input type="text" id="geminiModel" placeholder="gemini-2.5-pro" hidden>
                 <small>Default: gemini-2.5-pro</small>
               </div>
               <div class="form-group">
                 <div class="prompt-label-row">
-                  <label for="geminiFlashModel">Flash Model (transcription) <span class="config-optional">optional</span></label>
+                  <label for="geminiFlashModelSelect">Flash Model (transcription) <span class="config-optional">optional</span></label>
                   <button type="button" id="resetGeminiFlashModel" class="reset-prompt-button">Reset to Default</button>
                 </div>
-                <input type="text" id="geminiFlashModel" placeholder="gemini-2.5-flash">
+                <select id="geminiFlashModelSelect"></select>
+                <input type="text" id="geminiFlashModel" placeholder="gemini-2.5-flash" hidden>
                 <small>Default: gemini-2.5-flash</small>
               </div>
             </fieldset>
@@ -214,14 +216,22 @@
                 <small>Uses your ChatGPT Plus/Pro account via browser sign-in. If the browser tab closes before sign-in completes, just click Sign in again.</small>
               </div>
               <div class="form-group">
-                <label for="codexModel">Model <span class="config-optional">optional</span></label>
-                <input type="text" id="codexModel" placeholder="gpt-5.5">
+                <div class="prompt-label-row">
+                  <label for="codexModelSelect">Model <span class="config-optional">optional</span></label>
+                  <button type="button" id="resetCodexModel" class="reset-prompt-button">Reset to Default</button>
+                </div>
+                <select id="codexModelSelect"></select>
+                <input type="text" id="codexModel" placeholder="gpt-5.5" hidden>
                 <small>Used for summaries and Ask Listener. Default: gpt-5.5</small>
               </div>
               <div class="form-group">
-                <label for="codexTranscriptionModel">Transcription Model <span class="config-optional">optional</span></label>
-                <input type="text" id="codexTranscriptionModel" placeholder="gpt-4o-transcribe">
-                <small>Default: gpt-4o-transcribe</small>
+                <div class="prompt-label-row">
+                  <label for="codexTranscriptionModelSelect">Transcription Model <span class="config-optional">optional</span></label>
+                  <button type="button" id="resetCodexTranscriptionModel" class="reset-prompt-button">Reset to Default</button>
+                </div>
+                <select id="codexTranscriptionModelSelect"></select>
+                <input type="text" id="codexTranscriptionModel" placeholder="gpt-4o-transcribe-diarize" hidden>
+                <small>Default: gpt-4o-transcribe-diarize</small>
               </div>
             </fieldset>
           </section>

--- a/renderer/services/model-options.ts
+++ b/renderer/services/model-options.ts
@@ -1,0 +1,52 @@
+// Curated model lists for the Settings -> AI Provider tab. Each field
+// renders one of these arrays as a <select>, followed by a "Custom..."
+// option that reveals a free-form input for advanced users who want to type
+// a model id we haven't curated yet.
+
+export type ModelField =
+  | 'geminiModel'
+  | 'geminiFlashModel'
+  | 'codexModel'
+  | 'codexTranscriptionModel';
+
+export const CUSTOM_MODEL_SENTINEL = '__custom__';
+
+export const CURATED_MODELS: Record<ModelField, readonly string[]> = {
+  geminiModel: ['gemini-3.5-flash', 'gemini-2.5-pro', 'gemini-2.5-flash'],
+  geminiFlashModel: ['gemini-2.5-flash', 'gemini-3.5-flash'],
+  codexModel: ['gpt-5.5', 'gpt-5'],
+  codexTranscriptionModel: ['gpt-4o-transcribe-diarize', 'gpt-4o-transcribe'],
+} as const;
+
+// Mirrors DEFAULT_*_MODEL in src/aiProvider.ts. Surfaced as the "Default (X)"
+// dropdown entry so the user can see what gets used when no override is set,
+// and so Reset to Default has a stable visible target.
+export const BACKEND_DEFAULTS: Record<ModelField, string> = {
+  geminiModel: 'gemini-2.5-pro',
+  geminiFlashModel: 'gemini-2.5-flash',
+  codexModel: 'gpt-5.5',
+  codexTranscriptionModel: 'gpt-4o-transcribe-diarize',
+} as const;
+
+export type SelectChoice = { kind: 'curated'; value: string } | { kind: 'custom'; value: string };
+
+// Given a saved value, decide whether to pre-select a curated option or fall
+// into Custom mode. Empty string means "no override" -- the renderer maps
+// that to the "Default (X)" sentinel option at the top of the dropdown.
+//
+// `getAllConfig()` resolves empty -> backend default before sending to the
+// renderer, so a freshly-installed user whose `geminiModel` is unset arrives
+// here with `saved === 'gemini-2.5-pro'`. Treating that as "no override"
+// keeps the Default entry visible instead of snapping to the curated entry
+// of the same name. The two are functionally identical anyway -- if the
+// user picks the curated entry explicitly, the backend resolves to the same
+// model.
+export function chooseInitial(field: ModelField, saved: string | undefined): SelectChoice {
+  const trimmed = (saved ?? '').trim();
+  if (trimmed.length === 0 || trimmed === BACKEND_DEFAULTS[field]) {
+    return { kind: 'curated', value: '' };
+  }
+  const curated = CURATED_MODELS[field];
+  if (curated.includes(trimmed)) return { kind: 'curated', value: trimmed };
+  return { kind: 'custom', value: trimmed };
+}

--- a/renderer/ui/config-modal.ts
+++ b/renderer/ui/config-modal.ts
@@ -3,6 +3,13 @@
 // settingsButton handler in setupEventListeners).
 // Behavior preserved verbatim.
 
+import {
+  BACKEND_DEFAULTS,
+  CURATED_MODELS,
+  CUSTOM_MODEL_SENTINEL,
+  type ModelField,
+  chooseInitial,
+} from '../services/model-options';
 import { DEFAULT_SUMMARY_PROMPT } from '../state';
 
 let configModal: HTMLDialogElement | null = null;
@@ -10,10 +17,6 @@ let saveConfigBtn: HTMLButtonElement | null = null;
 let cancelConfigBtn: HTMLButtonElement | null = null;
 let aiProviderSelect: HTMLSelectElement | null = null;
 let geminiApiKeyInput: HTMLInputElement | null = null;
-let geminiModelInput: HTMLInputElement | null = null;
-let geminiFlashModelInput: HTMLInputElement | null = null;
-let codexModelInput: HTMLInputElement | null = null;
-let codexTranscriptionModelInput: HTMLInputElement | null = null;
 let loginCodexOAuthBtn: HTMLButtonElement | null = null;
 let clearCodexOAuthBtn: HTMLButtonElement | null = null;
 let codexOAuthStatus: HTMLElement | null = null;
@@ -33,6 +36,90 @@ let aiPane: HTMLElement | null = null;
 // token against the current one after `await`, discarding stale results from
 // prior attempts that were aborted by a newer click.
 let codexLoginToken = 0;
+
+const MODEL_FIELDS: readonly ModelField[] = [
+  'geminiModel',
+  'geminiFlashModel',
+  'codexModel',
+  'codexTranscriptionModel',
+];
+
+const RESET_BUTTON_IDS: Record<ModelField, string> = {
+  geminiModel: 'resetGeminiModel',
+  geminiFlashModel: 'resetGeminiFlashModel',
+  codexModel: 'resetCodexModel',
+  codexTranscriptionModel: 'resetCodexTranscriptionModel',
+};
+
+function getModelEls(
+  field: ModelField,
+): { select: HTMLSelectElement; input: HTMLInputElement } | null {
+  const select = document.getElementById(`${field}Select`) as HTMLSelectElement | null;
+  const input = document.getElementById(field) as HTMLInputElement | null;
+  return select && input ? { select, input } : null;
+}
+
+function buildModelOptions(field: ModelField, select: HTMLSelectElement): void {
+  select.innerHTML = '';
+  // First entry uses an empty value as the "no override" sentinel. Save
+  // persists empty, the backend falls through to DEFAULT_*_MODEL. Without
+  // this entry, Reset to Default would snap to a real curated id and Save
+  // would persist that as an explicit override.
+  const defaultOpt = document.createElement('option');
+  defaultOpt.value = '';
+  defaultOpt.textContent = `Default (${BACKEND_DEFAULTS[field]})`;
+  select.appendChild(defaultOpt);
+
+  for (const id of CURATED_MODELS[field]) {
+    const opt = document.createElement('option');
+    opt.value = id;
+    opt.textContent = id;
+    select.appendChild(opt);
+  }
+
+  const customOpt = document.createElement('option');
+  customOpt.value = CUSTOM_MODEL_SENTINEL;
+  customOpt.textContent = 'Custom...';
+  select.appendChild(customOpt);
+}
+
+function applyModelValue(field: ModelField, savedValue: string | undefined): void {
+  const els = getModelEls(field);
+  if (!els) return;
+  const choice = chooseInitial(field, savedValue);
+  if (choice.kind === 'custom') {
+    els.select.value = CUSTOM_MODEL_SENTINEL;
+    els.input.value = choice.value;
+    els.input.hidden = false;
+  } else {
+    els.select.value = choice.value;
+    els.input.value = '';
+    els.input.hidden = true;
+  }
+}
+
+function readModelValue(field: ModelField): string {
+  const els = getModelEls(field);
+  if (!els) return '';
+  if (els.select.value === CUSTOM_MODEL_SENTINEL) return els.input.value.trim();
+  return els.select.value;
+}
+
+function setupModelControls(): void {
+  for (const field of MODEL_FIELDS) {
+    const els = getModelEls(field);
+    if (!els) continue;
+    buildModelOptions(field, els.select);
+    els.select.addEventListener('change', () => {
+      const isCustom = els.select.value === CUSTOM_MODEL_SENTINEL;
+      els.input.hidden = !isCustom;
+      if (isCustom) els.input.focus();
+    });
+
+    const resetBtn = document.getElementById(RESET_BUTTON_IDS[field]) as HTMLButtonElement | null;
+    if (resetBtn) resetBtn.onclick = () => applyModelValue(field, '');
+  }
+}
 
 function setCodexOAuthStatus(text: string, state: 'idle' | 'success' | 'error' = 'idle'): void {
   if (!codexOAuthStatus) return;
@@ -89,18 +176,10 @@ export async function showConfigModal(): Promise<void> {
   if (geminiApiKeyInput && config.geminiApiKey) {
     geminiApiKeyInput.value = config.geminiApiKey;
   }
-  if (geminiModelInput) {
-    geminiModelInput.value = config.geminiModel || '';
-  }
-  if (geminiFlashModelInput) {
-    geminiFlashModelInput.value = config.geminiFlashModel || '';
-  }
-  if (codexModelInput) {
-    codexModelInput.value = config.codexModel || '';
-  }
-  if (codexTranscriptionModelInput) {
-    codexTranscriptionModelInput.value = config.codexTranscriptionModel || '';
-  }
+  applyModelValue('geminiModel', config.geminiModel);
+  applyModelValue('geminiFlashModel', config.geminiFlashModel);
+  applyModelValue('codexModel', config.codexModel);
+  applyModelValue('codexTranscriptionModel', config.codexTranscriptionModel);
   setCodexOAuthStatus(
     config.codexOAuthConfigured ? 'Signed in' : 'Not signed in',
     config.codexOAuthConfigured ? 'success' : 'idle',
@@ -154,23 +233,6 @@ export async function showConfigModal(): Promise<void> {
     summaryPromptInput.value = config.summaryPrompt || DEFAULT_SUMMARY_PROMPT;
   }
 
-  // Reset to default buttons
-  const resetGeminiModelBtn = document.getElementById(
-    'resetGeminiModel',
-  ) as HTMLButtonElement | null;
-  if (resetGeminiModelBtn) {
-    resetGeminiModelBtn.onclick = () => {
-      if (geminiModelInput) geminiModelInput.value = '';
-    };
-  }
-  const resetGeminiFlashModelBtn = document.getElementById(
-    'resetGeminiFlashModel',
-  ) as HTMLButtonElement | null;
-  if (resetGeminiFlashModelBtn) {
-    resetGeminiFlashModelBtn.onclick = () => {
-      if (geminiFlashModelInput) geminiFlashModelInput.value = '';
-    };
-  }
   const resetPromptBtn = document.getElementById('resetPrompt') as HTMLButtonElement | null;
   if (resetPromptBtn) {
     resetPromptBtn.onclick = () => {
@@ -284,12 +346,7 @@ export function setupConfigModal(): void {
   cancelConfigBtn = document.getElementById('cancelConfig') as HTMLButtonElement | null;
   aiProviderSelect = document.getElementById('aiProvider') as HTMLSelectElement | null;
   geminiApiKeyInput = document.getElementById('geminiApiKey') as HTMLInputElement | null;
-  geminiModelInput = document.getElementById('geminiModel') as HTMLInputElement | null;
-  geminiFlashModelInput = document.getElementById('geminiFlashModel') as HTMLInputElement | null;
-  codexModelInput = document.getElementById('codexModel') as HTMLInputElement | null;
-  codexTranscriptionModelInput = document.getElementById(
-    'codexTranscriptionModel',
-  ) as HTMLInputElement | null;
+  setupModelControls();
   loginCodexOAuthBtn = document.getElementById('loginCodexOAuth') as HTMLButtonElement | null;
   clearCodexOAuthBtn = document.getElementById('clearCodexOAuth') as HTMLButtonElement | null;
   codexOAuthStatus = document.getElementById('codexOAuthStatus');
@@ -464,12 +521,10 @@ export function setupConfigModal(): void {
     saveConfigBtn.addEventListener('click', async () => {
       const aiProvider = aiProviderSelect?.value === 'codex' ? 'codex' : 'gemini';
       const geminiKey = geminiApiKeyInput?.value.trim() ?? '';
-      const geminiModel = geminiModelInput ? geminiModelInput.value.trim() : '';
-      const geminiFlashModel = geminiFlashModelInput ? geminiFlashModelInput.value.trim() : '';
-      const codexModel = codexModelInput ? codexModelInput.value.trim() : '';
-      const codexTranscriptionModel = codexTranscriptionModelInput
-        ? codexTranscriptionModelInput.value.trim()
-        : '';
+      const geminiModel = readModelValue('geminiModel');
+      const geminiFlashModel = readModelValue('geminiFlashModel');
+      const codexModel = readModelValue('codexModel');
+      const codexTranscriptionModel = readModelValue('codexTranscriptionModel');
       const notionKey = notionApiKeyInput?.value.trim() ?? '';
       const notionDb = notionDatabaseIdInput?.value.trim() ?? '';
       const slackWebhookUrl = slackWebhookUrlInput?.value.trim() ?? '';


### PR DESCRIPTION
## Summary

Closes #140.

Replaces the four free-text model ID `<input>` fields in Settings → AI Provider with curated `<select>` dropdowns plus a "Custom..." escape hatch. Each select also leads with a "Default (X)" entry (value = empty string) so Reset to Default truly clears the override and the backend falls through to `DEFAULT_*_MODEL`.

Fields affected: `geminiModel`, `geminiFlashModel`, `codexModel`, `codexTranscriptionModel`.

## What landed

- New module [`renderer/services/model-options.ts`](renderer/services/model-options.ts) — curated lists, backend-default mirror, `chooseInitial` selection logic.
- [`renderer/ui/config-modal.ts`](renderer/ui/config-modal.ts) — `MODEL_FIELDS` / `RESET_BUTTON_IDS` typed maps + `getModelEls` / `buildModelOptions` / `applyModelValue` / `readModelValue` / `setupModelControls`. Reset buttons bind once in `setupConfigModal`, not per modal open.
- [`renderer/index.html`](renderer/index.html) — each of the 4 fields becomes `<select>` + hidden `<input>`; Reset to Default buttons added for the two Codex fields to match the Gemini pattern.

## What did NOT land (scope decision)

The issue spec had an **Optional: live ListModels fetch** section. We prototyped it (IPC handler with 24h disk cache + atomic write + nextPageToken pagination + `x-goog-api-key` header + 10s timeout + 16 unit tests + a real-API integration test) and then **deleted it** after empirical verification:

- The live `generativelanguage.googleapis.com/v1beta/models` endpoint returns 52 entries mixing chat, embedding, music (Lyria), robotics, image generation, TTS, computer-use, deep-research, and internal code-named families.
- Even an aggressive filter (16 exclusion patterns) leaves a confusing dropdown — every new Google family ships requires another pattern.
- Custom + a tight curated list covers the 90% case; users wanting bleeding-edge can paste an ID from ai.google.dev/models.

Decision: keep the dropdown+Custom UX (the core ask), drop the moving target.

## Notable design choices

- **"Default (X)" sentinel option** with value=`''`. Persisting empty lets the backend default resolver (`config.geminiModel || DEFAULT_GEMINI_MODEL` in [src/configService.ts](src/configService.ts:322)) take over. Without this, Reset to Default would snap to the first curated entry and persist *that* as an explicit override.
- **`chooseInitial` collapses "no override" and "saved == backend default"** into the same Default entry. `getAllConfig()` already resolves empty → default before sending to the renderer, so without this collapse the Default option would never be visible after a Save. Documented inline.
- **`BACKEND_DEFAULTS` mirrors `DEFAULT_*_MODEL`** in [src/aiProvider.ts](src/aiProvider.ts). Renderer can't import from `src/`; two-place duplication is intentional but `aiProvider.ts` is the source of truth.

## Test plan

- [x] `pnpm test` — 163/163 pass
- [x] `pnpm run build` — clean (Vite + tsc)
- [x] `pnpm run build:check-renderer` — clean
- [x] `pnpm run lint` — 0 warnings/errors
- [x] `pnpm run format:check` — clean
- [ ] Manual: open Settings, verify each of 4 fields shows curated options + "Default (X)" first + "Custom..." last
- [ ] Manual: click Reset to Default → select snaps to "Default (X)" → Save → reopen → still on "Default (X)"
- [ ] Manual: pick "Custom..." → input appears with focus → type ID → Save → reopen → "Custom..." remains selected with the typed ID
- [ ] Manual: pick a curated entry → Save → reopen → that entry remains selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)