### PR TITLE
feat(usage): track per-call API spend and surface monthly totals

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "dist/searchService.js",
     "dist/agentService.js",
     "dist/audioFormats.js",
+    "dist/usageFormat.js",
     "dist/services/ffmpegManager.js",
     "dist/services/audioConcatService.js",
     "dist/services/googleDriveService.js",
-    "dist/services/syncEngine.js"
+    "dist/services/syncEngine.js",
+    "dist/services/usageTracker.js"
   ],
   "scripts": {
     "start": "pnpm run build && electron .",
@@ -39,7 +41,7 @@
     "lint:fix": "oxlint --fix src renderer scripts",
     "format": "oxfmt 'src/**/*.ts' 'renderer/**/*.ts' 'renderer/**/*.tsx' 'scripts/**/*.js' 'scripts/**/*.ts'",
     "format:check": "oxfmt --check 'src/**/*.ts' 'renderer/**/*.ts' 'renderer/**/*.tsx' 'scripts/**/*.js' 'scripts/**/*.ts'",
-    "test": "tsc && node --test \"dist/**/*.test.js\"",
+    "test": "tsc && NODE_ENV=test node --test \"dist/**/*.test.js\"",
     "dist": "pnpm run build && electron-builder",
     "dist:mac": "pnpm run build && electron-builder --mac",
     "dist:mac-x64": "pnpm run build && electron-builder --mac --x64",

--- a/renderer/electronAPI.d.ts
+++ b/renderer/electronAPI.d.ts
@@ -237,6 +237,31 @@ export type ElectronAPI = {
   getFileInfo: (filePath: string) => Promise<{ exists: boolean; size?: number; name?: string }>;
   getMetadata: (filePath: string) => Promise<Record<string, any> | null>;
   saveMetadata: (filePath: string, metadata: any) => Promise<{ success: boolean }>;
+  getUsageSummary: (opts?: { month?: string }) => Promise<
+    | {
+        success: true;
+        month: string;
+        summary: {
+          totalUsd: number;
+          count: number;
+          modelUnknownCount: number;
+          byModel: Array<{
+            modelId: string;
+            kind: 'summary' | 'transcription' | 'agent';
+            usd: number;
+            count: number;
+            tokens: {
+              input?: number;
+              output?: number;
+              cacheRead?: number;
+              cacheWrite?: number;
+              audioSeconds?: number;
+            };
+          }>;
+        };
+      }
+    | { success: false; error: string }
+  >;
   onUpdateStatus: (cb: (updateInfo: { event: string; data?: any }) => void) => void;
   getUpdateState: () => Promise<{ type: string; version?: string; percent?: number }>;
   downloadUpdate: () => Promise<{ success: boolean; error?: string }>;

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -345,6 +345,14 @@
 
           <section class="config-pane" id="config-pane-advanced" data-pane="advanced" role="tabpanel" aria-labelledby="config-tab-advanced">
             <p class="config-pane-hint">All optional. Tune transcription accuracy and summary style.</p>
+            <fieldset class="config-subgroup" id="usageSummaryCard">
+              <legend>Usage this month</legend>
+              <div class="usage-summary" role="status" aria-live="polite" aria-atomic="true">
+                <div class="usage-summary-total" id="usageSummaryTotal">$0.00</div>
+                <ul class="usage-summary-breakdown" id="usageSummaryBreakdown"></ul>
+                <small id="usageSummaryFootnote">Best-effort estimate from logged API calls. Your provider invoice is the source of truth.</small>
+              </div>
+            </fieldset>
             <div class="form-group">
               <label for="knownWordsField">Known Words</label>
               <div class="chip-input" id="knownWordsChips">

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -1759,6 +1759,50 @@ h1 {
   text-overflow: ellipsis;
 }
 
+.recording-cost {
+  color: #64748b;
+  font-variant-numeric: tabular-nums;
+}
+
+.usage-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.usage-summary-total {
+  font-size: 22px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.usage-summary-breakdown {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.usage-summary-breakdown li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: #475569;
+  font-variant-numeric: tabular-nums;
+}
+
+.usage-summary-amount {
+  font-variant-numeric: tabular-nums;
+}
+
+.usage-summary-empty,
+.usage-summary-error {
+  color: #94a3b8;
+  font-style: italic;
+}
+
 .recording-actions {
   display: flex;
   align-items: center;

--- a/renderer/ui/config-modal.ts
+++ b/renderer/ui/config-modal.ts
@@ -11,6 +11,7 @@ import {
   chooseInitial,
 } from '../services/model-options';
 import { DEFAULT_SUMMARY_PROMPT } from '../state';
+import { formatUsd } from '../../src/usageFormat';
 
 let configModal: HTMLDialogElement | null = null;
 let saveConfigBtn: HTMLButtonElement | null = null;
@@ -308,10 +309,65 @@ export async function showConfigModal(): Promise<void> {
 
   applyAiProviderVisibility();
 
+  // Refresh "Usage this month" card on each open so the totals stay current
+  // even if the user has been recording in the same session. Fire-and-forget;
+  // missing data renders as zeros.
+  void refreshUsageSummaryCard();
+
   // AI Provider tab carries the required-credentials state; open there so the
   // user sees setup status first.
   activateConfigTab('ai');
   if (configModal && !configModal.open) configModal.showModal();
+}
+
+async function refreshUsageSummaryCard(): Promise<void> {
+  const totalEl = document.getElementById('usageSummaryTotal');
+  const listEl = document.getElementById('usageSummaryBreakdown');
+  if (!totalEl || !listEl) return;
+  totalEl.textContent = '…';
+  listEl.innerHTML = '';
+  try {
+    const res = await window.electronAPI.getUsageSummary();
+    if (!res.success) {
+      totalEl.textContent = '$0.00';
+      const li = document.createElement('li');
+      li.textContent = `Couldn't load: ${res.error}`;
+      li.className = 'usage-summary-error';
+      listEl.appendChild(li);
+      return;
+    }
+    totalEl.textContent = formatUsd(res.summary.totalUsd, 'long');
+    if (res.summary.byModel.length === 0) {
+      const li = document.createElement('li');
+      li.className = 'usage-summary-empty';
+      li.textContent = 'No API calls recorded yet this month.';
+      listEl.appendChild(li);
+      return;
+    }
+    for (const row of res.summary.byModel) {
+      const li = document.createElement('li');
+      const label = document.createElement('span');
+      label.className = 'usage-summary-model';
+      label.textContent = `${row.modelId} · ${row.kind} (${row.count})`;
+      const amount = document.createElement('span');
+      amount.className = 'usage-summary-amount';
+      amount.textContent = formatUsd(row.usd, 'long');
+      li.append(label, amount);
+      listEl.appendChild(li);
+    }
+    if (res.summary.modelUnknownCount > 0) {
+      const note = document.createElement('li');
+      note.className = 'usage-summary-empty';
+      note.textContent = `${res.summary.modelUnknownCount} call(s) used a model not in the price table (counted as $0).`;
+      listEl.appendChild(note);
+    }
+  } catch (e) {
+    totalEl.textContent = '$0.00';
+    const li = document.createElement('li');
+    li.className = 'usage-summary-error';
+    li.textContent = `Couldn't load usage: ${e instanceof Error ? e.message : String(e)}`;
+    listEl.appendChild(li);
+  }
 }
 
 function renderKnownWordsChips(): void {

--- a/renderer/ui/recordings-list.ts
+++ b/renderer/ui/recordings-list.ts
@@ -7,6 +7,7 @@
 // overwrite a fresher snapshot.
 
 import { getDom } from '../state';
+import { formatUsd } from '../../src/usageFormat';
 import { showToast } from './notifications';
 import {
   _setCurrentTranscription,
@@ -24,11 +25,18 @@ type Recording = {
   size: number;
 };
 
+type CostSnapshotShape = { usd: number; modelUnknown?: boolean };
+
 type GetRecordingsResult = { success: boolean; recordings: Recording[] };
 type GetMetadataResult = {
   success: boolean;
-  data?: Record<string, unknown> & { transcript?: unknown };
+  data?: Record<string, unknown> & { transcript?: unknown; cost?: CostSnapshotShape };
 };
+
+function formatCostBadge(cost: CostSnapshotShape | undefined): string {
+  if (!cost || typeof cost.usd !== 'number' || cost.usd <= 0) return '';
+  return formatUsd(cost.usd, 'omit');
+}
 type ExportM4AResult = { success?: boolean; canceled?: boolean; code?: string; error?: string };
 type MergeRecordingsResult = {
   success?: boolean;
@@ -110,6 +118,18 @@ export async function createRecordingItem(recording: Recording): Promise<HTMLEle
   const meta = document.createElement('p');
   meta.className = 'recording-meta';
   meta.textContent = metaStr;
+  const costBadge = formatCostBadge(metadataResult?.data?.cost as CostSnapshotShape | undefined);
+  if (costBadge) {
+    const sep = document.createTextNode(' · ');
+    const costSpan = document.createElement('span');
+    costSpan.className = 'recording-cost';
+    costSpan.textContent = costBadge;
+    costSpan.title = 'Estimated API cost (best-effort; actual invoice may differ)';
+    // title alone doesn't surface to keyboard / touch / screen-reader users.
+    // aria-label gives all of them the same context without changing layout.
+    costSpan.setAttribute('aria-label', `Estimated API cost ${costBadge}`);
+    meta.append(sep, costSpan);
+  }
   info.append(title, meta);
   item.appendChild(info);
 

--- a/src/agentService.ts
+++ b/src/agentService.ts
@@ -388,7 +388,12 @@ export class AgentService {
 
     for (let step = 0; step < maxSteps; step++) {
       const apiKey = await this.resolveApiKey();
-      const response = await complete(model, context, { apiKey, temperature: 0.3 });
+      const response = await complete(
+        model,
+        context,
+        { apiKey, temperature: 0.3 },
+        { kind: 'agent' },
+      );
       context.messages.push(response);
 
       const toolCalls = extractToolCalls(response);

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -154,6 +154,42 @@ describe('listener CLI basics', () => {
     assert.equal(code, 1);
     assert.match(stderr, /Unknown key/);
   });
+
+  it('usage prints empty summary when no usage.jsonl exists', async () => {
+    const { stdout, code } = await runCli(['usage', '--month', '2026-05']);
+    assert.equal(code, 0);
+    assert.match(stdout, /Usage for 2026-05/);
+    assert.match(stdout, /No API calls recorded/);
+  });
+
+  it('usage --json emits a parseable JSON document', async () => {
+    const { stdout, code } = await runCli(['usage', '--month', '2026-05', '--json']);
+    assert.equal(code, 0);
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.month, '2026-05');
+    assert.equal(parsed.totalUsd, 0);
+    assert.ok(Array.isArray(parsed.byModel));
+  });
+
+  it('usage rolls up entries from usage.jsonl', async () => {
+    const jsonl = path.join(basicsDataPath, 'usage.jsonl');
+    fs.writeFileSync(
+      jsonl,
+      `${JSON.stringify({ timestamp: '2026-05-10T10:00:00.000Z', modelId: 'gemini-2.5-pro', kind: 'summary', usage: { input: 1_000_000 }, usd: 1.25 })}\n${JSON.stringify({ timestamp: '2026-05-15T10:00:00.000Z', modelId: 'gpt-4o-transcribe', kind: 'transcription', usage: { audioSeconds: 60 }, usd: 0.006 })}\n`,
+      'utf-8',
+    );
+    const { stdout, code } = await runCli(['usage', '--month', '2026-05']);
+    assert.equal(code, 0);
+    assert.match(stdout, /Total: \$1\.26/);
+    assert.match(stdout, /gemini-2\.5-pro/);
+    assert.match(stdout, /gpt-4o-transcribe/);
+  });
+
+  it('usage rejects malformed --month', async () => {
+    const { code, stderr } = await runCli(['usage', '--month', 'not-a-month']);
+    assert.equal(code, 1);
+    assert.match(stderr, /Invalid month/);
+  });
 });
 
 describe('listener transcript (CLI integration)', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ import {
 import { ALL_FIELDS, type SearchField, resolveFields, searchTranscriptions } from './searchService';
 import { concatAudioFiles } from './services/audioConcatService';
 import { FFmpegManager } from './services/ffmpegManager';
+import { currentMonthString, formatUsd, monthRange, summarizeUsage } from './services/usageTracker';
 
 const SUPPORTED_EXTENSIONS = new Set([
   '.mp3',
@@ -72,6 +73,8 @@ const USAGE_TEXT =
   '       listener google sync                Sync all meetings to Google Drive (upload changes only)\n' +
   '       listener config list|get|set|unset|path\n' +
   '                                           Manage configuration\n' +
+  '       listener usage [--month YYYY-MM] [--json]\n' +
+  '                                           Show estimated API spend (best-effort, default: current month)\n' +
   '\n' +
   '<ref> is a number from `listener list` or a folder name.\n' +
   '\n' +
@@ -1028,6 +1031,62 @@ async function handleAsk(args: string[]): Promise<void> {
   }
 }
 
+async function handleUsage(args: string[]): Promise<void> {
+  let month: string | undefined;
+  let asJson = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--month' && i + 1 < args.length) {
+      month = args[++i];
+      continue;
+    }
+    if (a === '--json') {
+      asJson = true;
+      continue;
+    }
+    process.stderr.write(`Error: Unknown option: ${a}\n`);
+    process.exit(1);
+  }
+
+  const resolvedMonth = month?.trim() || currentMonthString();
+  let range: { since: string; until: string };
+  try {
+    range = monthRange(resolvedMonth);
+  } catch (err) {
+    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+
+  const summary = summarizeUsage(range);
+
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify({ month: resolvedMonth, ...summary }, null, 2)}\n`);
+    return;
+  }
+
+  process.stdout.write(`Usage for ${resolvedMonth}\n`);
+  process.stdout.write(`Total: ${formatUsd(summary.totalUsd)}  (${summary.count} call(s))\n`);
+  if (summary.byModel.length === 0) {
+    process.stdout.write('No API calls recorded.\n');
+    return;
+  }
+  process.stdout.write('\n');
+  for (const row of summary.byModel) {
+    process.stdout.write(
+      `  ${row.modelId.padEnd(28)} ${row.kind.padEnd(14)} ${String(row.count).padStart(4)}  ${formatUsd(row.usd)}\n`,
+    );
+  }
+  if (summary.modelUnknownCount > 0) {
+    process.stdout.write(
+      `\nNote: ${summary.modelUnknownCount} call(s) used a model not in the price table (counted as $0).\n`,
+    );
+  }
+  process.stdout.write(
+    '\nBest-effort estimate. Your Google Cloud / OpenAI invoice is the source of truth.\n',
+  );
+}
+
 async function handleTranscript(args: string[]): Promise<void> {
   let filePath: string | undefined;
   let outputArg: string | undefined;
@@ -1195,6 +1254,11 @@ async function main(): Promise<void> {
 
   if (args[0] === 'transcript') {
     await handleTranscript(args.slice(1));
+    return;
+  }
+
+  if (args[0] === 'usage') {
+    await handleUsage(args.slice(1));
     return;
   }
 

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -21,6 +21,7 @@ import {
 import { formatOffsetTimestamp, type LiveNote } from './outputService';
 import { type Context, completeSimple, extractFinalText, getModel } from './piAiClient';
 import { FFmpegManager } from './services/ffmpegManager';
+import { type CostSession, type CostSnapshot, createCostSession } from './services/usageTracker';
 
 const execFileAsync = promisify(execFile);
 
@@ -124,6 +125,10 @@ export interface TranscriptionResult {
   // Pure flag-only notes (empty text) round-trip as `userText: ""` with no
   // subtitle/bullets -- they remain bare timestamp markers.
   highlights?: HighlightEntry[];
+  // Best-effort USD estimate for the API calls that produced this transcription.
+  // Aggregated from per-step usage telemetry via usageTracker. Absent when
+  // every sub-call returned no usage (e.g. test stubs).
+  cost?: CostSnapshot;
 }
 
 export interface HighlightEntry {
@@ -158,6 +163,52 @@ function transcriptOnlyResult(transcript: string): TranscriptionResult {
     actionItems: [],
     emoji: '',
   };
+}
+
+// Attach the session's aggregate cost snapshot to a TranscriptionResult, but
+// drop empty snapshots (no recorded calls -- e.g. test stubs) so we don't
+// pollute the frontmatter with `cost: { usd: 0, breakdown: [] }`.
+function attachCost(result: TranscriptionResult, session: CostSession): TranscriptionResult {
+  const cost = session.snapshot();
+  if (cost.breakdown.length === 0) return result;
+  return { ...result, cost };
+}
+
+// OpenAI's /v1/audio/transcriptions doesn't return token counts, so we record
+// by audio duration alone (per-minute billing on the codex side).
+function recordCodexSttUsage(
+  session: CostSession | undefined,
+  modelId: string,
+  audioSeconds: number,
+): void {
+  session?.record({ modelId, kind: 'transcription', usage: { audioSeconds } });
+}
+
+// Map Gemini's usageMetadata into our UsageTokens. promptTokenCount includes
+// cached tokens, so subtract cachedContentTokenCount before recording so the
+// cached portion isn't billed twice. thoughts billed as output on 2.5 Flash.
+function recordGeminiUsage(
+  session: CostSession | undefined,
+  modelId: string,
+  metadata: unknown,
+): void {
+  if (!session) return;
+  const meta = (metadata ?? {}) as {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    thoughtsTokenCount?: number;
+    cachedContentTokenCount?: number;
+  };
+  const cached = meta.cachedContentTokenCount ?? 0;
+  session.record({
+    modelId,
+    kind: 'transcription',
+    usage: {
+      input: Math.max(0, (meta.promptTokenCount ?? 0) - cached) || undefined,
+      output: (meta.candidatesTokenCount ?? 0) + (meta.thoughtsTokenCount ?? 0) || undefined,
+      cacheRead: cached || undefined,
+    },
+  });
 }
 
 export interface TranscriptionErrorPayload {
@@ -399,6 +450,7 @@ export class GeminiService {
     promptText: string,
     transcript: string,
     signal?: AbortSignal,
+    session?: CostSession,
   ): Promise<string> {
     const modelId = this.provider === 'codex' ? this.codexModel : this.proModel;
     const apiKey =
@@ -427,13 +479,18 @@ export class GeminiService {
     // unifies both: pi-ai translates `reasoning` to reasoningEffort (codex) or
     // thinkingConfig.thinkingLevel (gemini).
     const reasoning = this.provider === 'codex' ? 'xhigh' : this.thinkingLevel;
-    const response = await completeSimple(model, context, {
-      apiKey,
-      temperature: 0.2,
-      maxTokens: 32768,
-      reasoning,
-      signal,
-    });
+    const response = await completeSimple(
+      model,
+      context,
+      {
+        apiKey,
+        temperature: 0.2,
+        maxTokens: 32768,
+        reasoning,
+        signal,
+      },
+      { kind: 'summary', session },
+    );
     return extractFinalText(response);
   }
 
@@ -768,6 +825,7 @@ export class GeminiService {
     options: TranscriptionOptions = {},
   ): Promise<TranscriptionResult> {
     const signal = options.signal;
+    const costSession = createCostSession();
     try {
       let fullTranscript = '';
       const stats = fs.statSync(audioFilePath);
@@ -796,15 +854,18 @@ export class GeminiService {
           options.transcriptionPrompt,
           segmentDuration,
           signal,
+          costSession,
         );
       } else {
         // Get transcript for short audio
         console.error('Transcribing short audio...');
         fullTranscript = await this.getShortAudioTranscript(
           audioFilePath,
+          duration,
           progressCallback,
           options.transcriptionPrompt,
           signal,
+          costSession,
         );
       }
 
@@ -814,7 +875,7 @@ export class GeminiService {
         if (progressCallback) {
           progressCallback(100, 'Transcript ready');
         }
-        return transcriptOnlyResult(fullTranscript);
+        return attachCost(transcriptOnlyResult(fullTranscript), costSession);
       }
 
       // Step 2: Generate summary, key points, action items from transcript
@@ -845,7 +906,12 @@ Return as JSON:
       const highlightsBlock = buildHighlightsPromptBlock(enrichableNotes);
       const summaryPrompt = highlightsBlock ? `${basePrompt}\n\n${highlightsBlock}` : basePrompt;
 
-      const summaryText = await this.generateSummary(summaryPrompt, fullTranscript, signal);
+      const summaryText = await this.generateSummary(
+        summaryPrompt,
+        fullTranscript,
+        signal,
+        costSession,
+      );
 
       let summaryData = {
         suggestedTitle: '',
@@ -901,16 +967,19 @@ Return as JSON:
         progressCallback(95, 'Finalizing results...');
       }
 
-      return {
-        transcript: fullTranscript,
-        summary: summaryData.summary,
-        keyPoints: summaryData.keyPoints,
-        actionItems: summaryData.actionItems,
-        emoji: summaryData.emoji,
-        suggestedTitle: summaryData.suggestedTitle,
-        customFields: Object.keys(customFields).length > 0 ? customFields : undefined,
-        highlights,
-      };
+      return attachCost(
+        {
+          transcript: fullTranscript,
+          summary: summaryData.summary,
+          keyPoints: summaryData.keyPoints,
+          actionItems: summaryData.actionItems,
+          emoji: summaryData.emoji,
+          suggestedTitle: summaryData.suggestedTitle,
+          customFields: Object.keys(customFields).length > 0 ? customFields : undefined,
+          highlights,
+        },
+        costSession,
+      );
     } catch (error) {
       console.error('Error in two-step transcription:', error);
       throw error;
@@ -920,9 +989,11 @@ Return as JSON:
   // Get transcript for short audio files
   private async getShortAudioTranscript(
     audioFilePath: string,
+    audioSeconds: number,
     progressCallback?: (percent: number, message: string) => void,
     customPrompt?: string,
     signal?: AbortSignal,
+    session?: CostSession,
   ): Promise<string> {
     try {
       const stats = fs.statSync(audioFilePath);
@@ -934,7 +1005,7 @@ Return as JSON:
 
       const transcriptPrompt = `${this.buildGlossaryBlock()}${customPrompt ?? DEFAULT_TRANSCRIPT_PROMPT}`;
       if (this.provider === 'codex') {
-        return await transcribeCodexAudio({
+        const text = await transcribeCodexAudio({
           getToken: () => this.getCodexToken(),
           audioFilePath,
           model: this.codexTranscriptionModel,
@@ -948,6 +1019,8 @@ Return as JSON:
           // acronyms/quotes) better than forcing a single language.
           signal,
         });
+        recordCodexSttUsage(session, this.codexTranscriptionModel, audioSeconds);
+        return text;
       }
 
       const ai = this.gemini();
@@ -1052,6 +1125,7 @@ Return as JSON:
         });
       }
 
+      recordGeminiUsage(session, this.flashModel, result.usageMetadata);
       return result.text || '';
     } catch (error) {
       console.error('Error transcribing short audio:', error);
@@ -1096,11 +1170,13 @@ Return as JSON:
     segmentEndTime: number,
     customPrompt?: string,
     signal?: AbortSignal,
+    session?: CostSession,
   ): Promise<{ index: number; content: string }> {
     const maxRetries = 3;
     let lastError: any = null;
     let attemptsMade = 0;
     const segmentPrompt = this.createSegmentPrompt(segmentIndex, totalSegments, customPrompt);
+    const segmentSeconds = Math.max(0, segmentEndTime - segmentStartTime);
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       attemptsMade = attempt;
@@ -1118,6 +1194,7 @@ Return as JSON:
             prompt: segmentPrompt,
             signal,
           });
+          recordCodexSttUsage(session, this.codexTranscriptionModel, segmentSeconds);
           console.error(`Completed transcription for segment ${segmentIndex + 1}/${totalSegments}`);
           return {
             index: segmentIndex,
@@ -1153,6 +1230,7 @@ Return as JSON:
           },
         });
 
+        recordGeminiUsage(session, this.flashModel, result.usageMetadata);
         const transcript = result.text || '';
 
         console.error(`Completed transcription for segment ${segmentIndex + 1}/${totalSegments}`);
@@ -1226,6 +1304,7 @@ Return as JSON:
     customPrompt?: string,
     segmentDuration = 300,
     signal?: AbortSignal,
+    session?: CostSession,
   ): Promise<string> {
     // Track segments outside the try so the finally can clean them up on
     // abort / mid-pipeline failure too. Without this, cancelled transcribes
@@ -1269,6 +1348,7 @@ Return as JSON:
           segmentEndTime,
           customPrompt,
           combinedSignal,
+          session,
         ).catch((err) => {
           aborter.abort();
           throw err;

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,6 +59,12 @@ import { FileHandlerService } from './services/fileHandlerService';
 import { metadataService } from './services/metadataService';
 import { notificationService } from './services/notificationService';
 import { fetchAllReleases, fetchReleaseNotes } from './services/releaseNotesService';
+import {
+  currentMonthString,
+  monthRange,
+  summarizeUsage,
+  type UsageSummaryResult,
+} from './services/usageTracker';
 import { SYSTEM_AUDIO_FORMAT, SystemAudioService } from './services/systemAudioService';
 import { SimpleAudioRecorder } from './simpleAudioRecorder';
 import { SLACK_WEBHOOK_PREFIX, SlackService, isLikelySlackWebhookUrl } from './slackService';
@@ -2109,6 +2115,7 @@ ipcMain.handle('get-metadata', async (_, filePath: string) => {
             notionPageUrl: transcription.notionPageUrl,
             slackSentAt: transcription.slackSentAt,
             slackError: transcription.slackError,
+            cost: transcription.cost,
           },
         };
       }
@@ -2117,6 +2124,17 @@ ipcMain.handle('get-metadata', async (_, filePath: string) => {
 
     // Old format or missing folder fallback: inline data in metadata
     return { success: true, data: metadata };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+});
+
+ipcMain.handle('get-usage-summary', async (_, opts?: { month?: string }) => {
+  try {
+    const month = opts?.month?.trim() || currentMonthString();
+    const range = monthRange(month);
+    const summary: UsageSummaryResult = summarizeUsage(range);
+    return { success: true, month, summary };
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : String(error) };
   }

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { HighlightEntry, TranscriptionResult } from './geminiService';
+import type { CostSnapshot } from './services/usageTracker';
 
 /** One timestamped note captured while recording. Empty `text` = bare flag. */
 export interface LiveNote {
@@ -167,6 +168,7 @@ interface SummaryFrontmatter {
   notionPageUrl?: string;
   slackSentAt?: string;
   slackError?: string;
+  cost?: CostSnapshot;
 }
 
 function buildFrontmatter(meta: SummaryFrontmatter): string {
@@ -213,6 +215,9 @@ function buildFrontmatter(meta: SummaryFrontmatter): string {
   }
   if (meta.slackError) {
     lines.push(`slackError: ${yamlQuote(meta.slackError)}`);
+  }
+  if (meta.cost && meta.cost.breakdown.length > 0) {
+    lines.push(`cost: ${yamlQuote(JSON.stringify(meta.cost))}`);
   }
   lines.push('---');
   return lines.join('\n');
@@ -387,6 +392,7 @@ export function saveTranscription(opts: SaveTranscriptionOptions): string {
     mergedFrom: opts.mergedFrom,
     liveNotes: opts.liveNotes,
     highlights,
+    cost: opts.result.cost,
   });
   const summaryBody = formatSummary(
     opts.result,
@@ -505,6 +511,7 @@ export interface ReadTranscriptionResult {
   notionPageUrl?: string;
   slackSentAt?: string;
   slackError?: string;
+  cost?: CostSnapshot;
 }
 
 /**
@@ -535,6 +542,7 @@ export async function readTranscription(
 
     const liveNotes = parseLiveNotesField(meta.liveNotes);
     const highlights = parseHighlightsField(meta.highlights);
+    const cost = parseCostField(meta.cost);
 
     return {
       title: (meta.title as string) || path.basename(folderPath),
@@ -553,9 +561,29 @@ export async function readTranscription(
       notionPageUrl: meta.notionPageUrl as string | undefined,
       slackSentAt: meta.slackSentAt as string | undefined,
       slackError: meta.slackError as string | undefined,
+      cost,
     };
   } catch {
     return null;
+  }
+}
+
+function parseCostField(raw: unknown): CostSnapshot | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    if (!parsed || typeof parsed !== 'object') return undefined;
+    const usd = Number((parsed as { usd?: unknown }).usd);
+    if (!Number.isFinite(usd)) return undefined;
+    const breakdownRaw = (parsed as { breakdown?: unknown }).breakdown;
+    const breakdown = Array.isArray(breakdownRaw)
+      ? (breakdownRaw as CostSnapshot['breakdown'])
+      : [];
+    const modelUnknown = Boolean((parsed as { modelUnknown?: unknown }).modelUnknown);
+    return modelUnknown ? { usd, breakdown, modelUnknown } : { usd, breakdown };
+  } catch (e) {
+    console.warn('Failed to parse cost from frontmatter:', e);
+    return undefined;
   }
 }
 
@@ -592,6 +620,7 @@ export async function updateTranscriptionStatus(
 
   const liveNotes = parseLiveNotesField(meta.liveNotes);
   const highlights = parseHighlightsField(meta.highlights);
+  const cost = parseCostField(meta.cost);
 
   // Spread first so any unknown frontmatter keys (added by future writers, or
   // by hand-edits) survive the round-trip; named fields override with proper
@@ -605,6 +634,7 @@ export async function updateTranscriptionStatus(
     customFields,
     liveNotes,
     highlights,
+    cost,
   };
 
   applyStatusUpdate(merged, 'notionPageUrl', updates.notionPageUrl);

--- a/src/piAiClient.ts
+++ b/src/piAiClient.ts
@@ -44,6 +44,18 @@ function loadPiAi(): Promise<PiAiModule> {
 }
 
 import { type AiProvider, toPiAiProvider } from './aiProvider';
+import { type CostSession, type UsageKind, recordUsage } from './services/usageTracker';
+
+/**
+ * Cost-tracking context passed alongside `complete()`. `kind` is required so
+ * a future caller can't be silently misclassified as 'agent'; pass `session`
+ * to also capture the cost in a transcribeWithTwoSteps aggregate.
+ */
+export interface UsageContext {
+  kind: UsageKind;
+  session?: CostSession;
+  transcriptionRef?: string;
+}
 
 // Explicit overrides for model ids pi-ai's bundled registry doesn't carry yet.
 // Mirrors pi-ai's upstream main-branch entry shape so the next published
@@ -134,6 +146,7 @@ async function runPiAiCall(
   signal: AbortSignal | undefined,
   context: Context,
   call: () => Promise<AssistantMessage>,
+  usageContext?: UsageContext,
 ): Promise<AssistantMessage> {
   const tag = `[pi-ai ${model.provider}/${model.id}]`;
   const startedAt = Date.now();
@@ -145,6 +158,30 @@ async function runPiAiCall(
   console.log(
     `${tag} <- ${elapsed}ms stop=${stop} textChars=${textChars} usage=in:${response.usage?.input ?? '?'}/out:${response.usage?.output ?? '?'}${response.errorMessage ? ` errorMessage=${response.errorMessage.slice(0, 300)}` : ''}`,
   );
+  // Record cost only on successful turns -- error/aborted paths throw below.
+  // pi-ai already priced this call against its bundled model table
+  // (see node_modules/@earendil-works/pi-ai/dist/models.generated.js); pass
+  // its `cost.total` through verbatim rather than re-implementing.
+  if (usageContext && response.stopReason !== 'error' && response.stopReason !== 'aborted') {
+    const usage = response.usage;
+    const recordInput = {
+      modelId: model.id,
+      kind: usageContext.kind,
+      usage: {
+        input: typeof usage?.input === 'number' ? usage.input : undefined,
+        output: typeof usage?.output === 'number' ? usage.output : undefined,
+        cacheRead: typeof usage?.cacheRead === 'number' ? usage.cacheRead : undefined,
+        cacheWrite: typeof usage?.cacheWrite === 'number' ? usage.cacheWrite : undefined,
+      },
+      precomputedUsd: typeof usage?.cost?.total === 'number' ? usage.cost.total : undefined,
+      transcriptionRef: usageContext.transcriptionRef,
+    };
+    if (usageContext.session) {
+      usageContext.session.record(recordInput);
+    } else {
+      recordUsage(recordInput);
+    }
+  }
   if (response.stopReason === 'error') {
     throw new Error(
       `Pi-ai ${model.provider}/${model.id} failed: ${response.errorMessage ?? 'no errorMessage'}`,
@@ -161,11 +198,16 @@ export async function complete(
   model: PiAiModel,
   context: Context,
   options?: ProviderStreamOptions,
+  usageContext?: UsageContext,
 ): Promise<AssistantMessage> {
   const m = await loadPiAi();
   const adjustedOptions = adjustOptionsForModel(model, options);
-  return runPiAiCall(model, options?.signal, context, () =>
-    m.complete(model, context, adjustedOptions),
+  return runPiAiCall(
+    model,
+    options?.signal,
+    context,
+    () => m.complete(model, context, adjustedOptions),
+    usageContext,
   );
 }
 
@@ -176,14 +218,19 @@ export async function completeSimple(
   model: PiAiModel,
   context: Context,
   options?: SimpleStreamOptions,
+  usageContext?: UsageContext,
 ): Promise<AssistantMessage> {
   const m = await loadPiAi();
   const adjustedOptions = adjustOptionsForModel(
     model,
     options as ProviderStreamOptions | undefined,
   ) as SimpleStreamOptions | undefined;
-  return runPiAiCall(model, options?.signal, context, () =>
-    m.completeSimple(model, context, adjustedOptions),
+  return runPiAiCall(
+    model,
+    options?.signal,
+    context,
+    () => m.completeSimple(model, context, adjustedOptions),
+    usageContext,
   );
 }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -197,6 +197,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   saveMetadata: (filePath: string, metadata: any) =>
     ipcRenderer.invoke('save-metadata', filePath, metadata),
 
+  // Usage / cost tracking
+  getUsageSummary: (opts?: { month?: string }) => ipcRenderer.invoke('get-usage-summary', opts),
+
   // Auto-update events
   onUpdateStatus: (callback: (updateInfo: { event: string; data?: any }) => void) => {
     ipcRenderer.on('update-status', (_, updateInfo) => callback(updateInfo));

--- a/src/services/usageTracker.test.ts
+++ b/src/services/usageTracker.test.ts
@@ -1,0 +1,343 @@
+import assert from 'node:assert/strict';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  _setDataPathForTesting,
+  computeCost,
+  createCostSession,
+  currentMonthString,
+  formatUsd,
+  MODEL_PRICING,
+  monthRange,
+  recordUsage,
+  summarizeUsage,
+} from './usageTracker';
+import { makeTempDir, rmDir } from '../test-helpers';
+
+// Helper: drop the per-key floating-point noise so deepEqual against expected
+// integers works without epsilon plumbing in every assertion.
+function roundCents(n: number, digits = 6): number {
+  const m = 10 ** digits;
+  return Math.round(n * m) / m;
+}
+
+describe('computeCost', () => {
+  it('returns modelUnknown for an unrecognized model id', () => {
+    const result = computeCost('not-a-real-model', 'summary', { input: 1000, output: 500 });
+    assert.equal(result.modelUnknown, true);
+    assert.equal(result.usd, 0);
+  });
+
+  it('uses gemini-2.5-flash audioInput rate when kind is transcription', () => {
+    const pricing = MODEL_PRICING['gemini-2.5-flash'];
+    const trans = computeCost('gemini-2.5-flash', 'transcription', {
+      input: 1_000_000,
+      output: 1_000_000,
+    });
+    assert.equal(roundCents(trans.usd), pricing.audioInput! + pricing.output!);
+
+    const summary = computeCost('gemini-2.5-flash', 'summary', {
+      input: 1_000_000,
+      output: 0,
+    });
+    assert.equal(roundCents(summary.usd), pricing.input!);
+  });
+
+  it('prices gpt-4o-transcribe per audio minute, ignoring tokens', () => {
+    const pricing = MODEL_PRICING['gpt-4o-transcribe'];
+    // 600s = 10min; spurious `input` field must not double-bill.
+    const result = computeCost('gpt-4o-transcribe', 'transcription', {
+      audioSeconds: 600,
+      input: 1_000_000,
+    });
+    assert.equal(roundCents(result.usd), 10 * pricing.audioPerMinute!);
+  });
+
+  it('treats thoughts tokens as output (folded by caller)', () => {
+    // geminiService wraps candidates+thoughts into a single `output` count.
+    const pricing = MODEL_PRICING['gemini-2.5-flash'];
+    const total = 800_000;
+    const result = computeCost('gemini-2.5-flash', 'transcription', { output: total });
+    assert.equal(roundCents(result.usd), roundCents((total / 1_000_000) * pricing.output!));
+  });
+
+  it('falls back to input rate when cacheRead rate is missing', () => {
+    // gemini-2.5-flash has no cacheRead rate. Cached tokens fall back to the
+    // audio rate (transcription) or text rate (summary) so they aren't $0.
+    const pricing = MODEL_PRICING['gemini-2.5-flash'];
+    assert.equal(pricing.cacheRead, undefined);
+
+    const trans = computeCost('gemini-2.5-flash', 'transcription', { cacheRead: 1_000_000 });
+    assert.equal(roundCents(trans.usd), pricing.audioInput!);
+
+    const summary = computeCost('gemini-2.5-flash', 'summary', { cacheRead: 1_000_000 });
+    assert.equal(roundCents(summary.usd), pricing.input!);
+  });
+});
+
+describe('recordUsage + summarizeUsage', () => {
+  let tmp: string;
+
+  before(() => {
+    tmp = makeTempDir('usage-tracker');
+    _setDataPathForTesting(tmp);
+  });
+
+  after(() => {
+    _setDataPathForTesting(undefined);
+    rmDir(tmp);
+  });
+
+  beforeEach(() => {
+    const file = path.join(tmp, 'usage.jsonl');
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+  });
+
+  it('writes one jsonl line per call and round-trips through summarize', () => {
+    recordUsage({
+      modelId: 'gemini-2.5-flash',
+      kind: 'summary',
+      usage: { input: 1_000_000, output: 0 },
+      timestamp: '2026-05-10T10:00:00.000Z',
+    });
+    recordUsage({
+      modelId: 'gpt-4o-transcribe',
+      kind: 'transcription',
+      usage: { audioSeconds: 60 },
+      timestamp: '2026-05-15T10:00:00.000Z',
+    });
+
+    const range = monthRange('2026-05');
+    const summary = summarizeUsage(range);
+    assert.equal(summary.count, 2);
+    assert.equal(summary.byModel.length, 2);
+    // gemini-2.5-flash summary input $0.30/M + gpt-4o-transcribe $0.006
+    assert.equal(roundCents(summary.totalUsd), roundCents(0.3 + 0.006));
+  });
+
+  it('filters entries outside the [since, until) range', () => {
+    // Build fixtures from the actual range so the test is timezone-agnostic.
+    // Mid-month is deep inside the window from any local zone; March/July
+    // are deep outside.
+    const may = monthRange('2026-05');
+    const mid = new Date(new Date(may.since).getTime() + 14 * 24 * 3600 * 1000).toISOString();
+    recordUsage({
+      modelId: 'gemini-2.5-flash',
+      kind: 'summary',
+      usage: { input: 1_000_000 },
+      timestamp: '2026-03-15T12:00:00.000Z',
+    });
+    recordUsage({
+      modelId: 'gemini-2.5-flash',
+      kind: 'summary',
+      usage: { input: 1_000_000 },
+      timestamp: mid,
+    });
+    recordUsage({
+      modelId: 'gemini-2.5-flash',
+      kind: 'summary',
+      usage: { input: 1_000_000 },
+      timestamp: '2026-07-15T12:00:00.000Z',
+    });
+
+    const summary = summarizeUsage(may);
+    assert.equal(summary.count, 1);
+    assert.equal(summary.byModel[0].count, 1);
+  });
+
+  it('excludes the until boundary (half-open range)', () => {
+    const may = monthRange('2026-05');
+    recordUsage({
+      modelId: 'gemini-2.5-flash',
+      kind: 'summary',
+      usage: { input: 1_000_000 },
+      timestamp: may.until, // exactly the upper bound
+    });
+    const summary = summarizeUsage(may);
+    assert.equal(summary.count, 0);
+  });
+
+  it('groups by (modelId, kind) when summarizing', () => {
+    recordUsage({
+      modelId: 'gemini-2.5-flash',
+      kind: 'summary',
+      usage: { input: 500_000 },
+      timestamp: '2026-05-10T10:00:00.000Z',
+    });
+    recordUsage({
+      modelId: 'gemini-2.5-flash',
+      kind: 'agent',
+      usage: { input: 500_000 },
+      timestamp: '2026-05-11T10:00:00.000Z',
+    });
+    recordUsage({
+      modelId: 'gemini-2.5-flash',
+      kind: 'summary',
+      usage: { input: 500_000 },
+      timestamp: '2026-05-12T10:00:00.000Z',
+    });
+
+    const summary = summarizeUsage(monthRange('2026-05'));
+    assert.equal(summary.byModel.length, 2);
+    const summaryRow = summary.byModel.find((r) => r.kind === 'summary');
+    const agentRow = summary.byModel.find((r) => r.kind === 'agent');
+    assert.ok(summaryRow && agentRow);
+    assert.equal(summaryRow!.count, 2);
+    assert.equal(agentRow!.count, 1);
+  });
+
+  it('skips malformed jsonl lines without throwing', () => {
+    const file = path.join(tmp, 'usage.jsonl');
+    fs.writeFileSync(
+      file,
+      '{not valid json}\n' +
+        `${JSON.stringify({ timestamp: '2026-05-10T10:00:00.000Z', modelId: 'gemini-2.5-pro', kind: 'summary', usage: {}, usd: 1.0 })}\n`,
+      'utf-8',
+    );
+    const summary = summarizeUsage(monthRange('2026-05'));
+    assert.equal(summary.count, 1);
+    assert.equal(roundCents(summary.totalUsd), 1.0);
+  });
+});
+
+describe('createCostSession', () => {
+  let tmp: string;
+  before(() => {
+    tmp = makeTempDir('usage-session');
+    _setDataPathForTesting(tmp);
+  });
+  after(() => {
+    _setDataPathForTesting(undefined);
+    rmDir(tmp);
+  });
+  beforeEach(() => {
+    const file = path.join(tmp, 'usage.jsonl');
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+  });
+
+  it('aggregates per-call costs into a snapshot', () => {
+    const session = createCostSession();
+    // Transcription: audioInput rate $1.00/M
+    session.record({
+      modelId: 'gemini-2.5-flash',
+      kind: 'transcription',
+      usage: { input: 1_000_000, output: 0 },
+    });
+    // STT: $0.006/min for 1 minute
+    session.record({
+      modelId: 'gpt-4o-transcribe',
+      kind: 'transcription',
+      usage: { audioSeconds: 60 },
+    });
+    const snap = session.snapshot();
+    assert.equal(snap.breakdown.length, 2);
+    assert.equal(roundCents(snap.usd), roundCents(1.0 + 0.006));
+  });
+
+  it('passes pi-ai precomputedUsd through without re-pricing', () => {
+    const session = createCostSession();
+    // Mimic a piAiClient.complete() call: model isn't in our table (pi-ai
+    // owns chat-model pricing), but precomputedUsd is supplied.
+    session.record({
+      modelId: 'gpt-5.5',
+      kind: 'summary',
+      usage: { input: 1000, output: 500 },
+      precomputedUsd: 0.0234,
+    });
+    const snap = session.snapshot();
+    assert.equal(snap.breakdown.length, 1);
+    assert.equal(roundCents(snap.usd), 0.0234);
+    // modelUnknown must NOT be set -- pi-ai authoritative-priced this call.
+    assert.equal(snap.modelUnknown, undefined);
+  });
+
+  it('marks modelUnknown on the snapshot when any sub-call had an unknown model', () => {
+    const session = createCostSession();
+    session.record({
+      modelId: 'gemini-2.5-flash',
+      kind: 'summary',
+      usage: { input: 1_000_000 },
+    });
+    session.record({
+      modelId: 'made-up-model',
+      kind: 'agent',
+      usage: { input: 1_000_000 },
+    });
+    const snap = session.snapshot();
+    assert.equal(snap.modelUnknown, true);
+  });
+
+  it('persists every recorded call to jsonl', () => {
+    const session = createCostSession();
+    session.record({
+      modelId: 'gemini-2.5-flash',
+      kind: 'summary',
+      usage: { input: 100_000 },
+      timestamp: '2026-05-10T10:00:00.000Z',
+    });
+    session.record({
+      modelId: 'gpt-4o-transcribe',
+      kind: 'transcription',
+      usage: { audioSeconds: 30 },
+      timestamp: '2026-05-10T10:00:01.000Z',
+    });
+    const summary = summarizeUsage(monthRange('2026-05'));
+    assert.equal(summary.count, 2);
+  });
+});
+
+describe('monthRange', () => {
+  it('produces a local-time half-open range for a calendar month', () => {
+    const r = monthRange('2026-05');
+    // Local midnight on May 1 in whatever zone the test runs in; we assert on
+    // the local-time projection of the result, not exact UTC strings.
+    const since = new Date(r.since);
+    const until = new Date(r.until);
+    assert.equal(since.getFullYear(), 2026);
+    assert.equal(since.getMonth(), 4); // May (0-indexed)
+    assert.equal(since.getDate(), 1);
+    assert.equal(since.getHours(), 0);
+    assert.equal(since.getMinutes(), 0);
+    assert.equal(until.getFullYear(), 2026);
+    assert.equal(until.getMonth(), 5); // June (0-indexed)
+    assert.equal(until.getDate(), 1);
+    assert.equal(until.getHours(), 0);
+  });
+
+  it('handles December rollover correctly', () => {
+    const r = monthRange('2026-12');
+    const until = new Date(r.until);
+    assert.equal(until.getFullYear(), 2027);
+    assert.equal(until.getMonth(), 0); // January (0-indexed)
+    assert.equal(until.getDate(), 1);
+  });
+
+  it('throws on invalid input', () => {
+    assert.throws(() => monthRange('not-a-month'));
+    assert.throws(() => monthRange('2026-13'));
+    assert.throws(() => monthRange('2026-00'));
+  });
+});
+
+describe('currentMonthString', () => {
+  it('returns the current month in YYYY-MM (local time)', () => {
+    // Build a Date that is the 15th in local time, then verify the YYYY-MM
+    // we emit matches the local-time month/year of that date. Avoids UTC vs
+    // local timezone drift on the assertion side.
+    const local = new Date(2026, 4, 15, 10, 0, 0);
+    assert.equal(currentMonthString(local), '2026-05');
+  });
+});
+
+describe('formatUsd', () => {
+  it('renders zero as $0', () => {
+    assert.equal(formatUsd(0), '$0');
+  });
+  it('renders tiny amounts at 4-decimal precision', () => {
+    assert.equal(formatUsd(0.001234), '$0.0012');
+  });
+  it('renders normal amounts at 2-decimal precision', () => {
+    assert.equal(formatUsd(1.234), '$1.23');
+  });
+});

--- a/src/services/usageTracker.ts
+++ b/src/services/usageTracker.ts
@@ -1,0 +1,379 @@
+// Best-effort cost accounting for AI API calls. Appends every call to
+// `${dataPath}/usage.jsonl` so the Settings card and `listener usage` CLI can
+// roll up monthly totals.
+//
+// Two cost sources:
+// 1. pi-ai's `response.usage.cost.total` -- already computed by pi-ai using its
+//    bundled model price table (see node_modules/@earendil-works/pi-ai/dist/
+//    models.generated.js). Used for summary/agent calls. Passed verbatim via
+//    `recordUsage({ precomputedUsd, ... })`.
+// 2. Our own MODEL_PRICING table -- for the two paths that bypass pi-ai:
+//    Gemini transcription (`@google/genai` SDK direct, not pi-ai chat) and
+//    OpenAI STT (`/v1/audio/transcriptions` raw fetch). pi-ai is chat-only;
+//    there's no audio surface to delegate to.
+//
+// Caveat: estimate. The user's invoice is the source of truth. Unknown models
+// record as `{ usd: 0, modelUnknown: true }` rather than throwing -- billing
+// tracking must never break the transcription pipeline.
+//
+// jsonl writes use `fs.appendFileSync` (single syscall with O_APPEND on
+// POSIX, where the kernel guarantees an atomic offset+write for local
+// filesystems). Best-effort on Windows and networked filesystems: rare
+// interleaved lines are possible. summarizeUsage skips malformed lines so
+// a single corrupted entry doesn't poison the monthly roll-up.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { getDataPath } from '../dataPath';
+
+/**
+ * Per-model rates. Text/image/audio token rates are $ per 1M tokens.
+ * `audioPerMinute` is $ per minute of audio input (STT models bill this way).
+ * `audioInput` overrides `input` when the call kind is 'transcription' and the
+ * provider charges a different rate for audio tokens (gemini-2.5-flash:
+ * $1.00/M for audio vs $0.30/M for text).
+ */
+export interface ModelPricing {
+  input?: number;
+  output?: number;
+  /** $ per 1M cached-input tokens (pi-ai calls this `cacheRead`). */
+  cacheRead?: number;
+  audioInput?: number;
+  audioPerMinute?: number;
+}
+
+// Source: docs/model-pricing.md (verified 2026-05-13). Keep in sync.
+//
+// This table covers ONLY the two non-pi-ai paths. Anything reachable through
+// pi-ai's `complete()` (gemini-2.5-pro, gpt-5.x, etc.) is priced by pi-ai
+// itself -- adding it here would just create drift with the upstream table.
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  // Gemini transcription: @google/genai SDK direct call. Audio-token rate
+  // ($1/M) overrides the text rate when kind is 'transcription'.
+  'gemini-2.5-flash': { input: 0.3, audioInput: 1.0, output: 2.5 },
+  // OpenAI STT (raw fetch to /v1/audio/transcriptions). Billed per audio
+  // minute, prorated to the second.
+  'gpt-4o-transcribe': { audioPerMinute: 0.006 },
+  'gpt-4o-transcribe-diarize': { audioPerMinute: 0.006 },
+  'gpt-4o-mini-transcribe': { audioPerMinute: 0.003 },
+  'whisper-1': { audioPerMinute: 0.006 },
+};
+
+export type UsageKind = 'summary' | 'transcription' | 'agent';
+
+export interface UsageTokens {
+  /** Input tokens (text/image, or audio when kind=transcription). */
+  input?: number;
+  /** Output tokens. Includes reasoning/thought tokens unless the model splits them. */
+  output?: number;
+  /** Cached input tokens (billed at the model's cacheRead rate). */
+  cacheRead?: number;
+  /** Cache-write tokens from pi-ai. Not priced by us (pi-ai owns chat cost). */
+  cacheWrite?: number;
+  /** Seconds of audio sent to a per-minute STT model. */
+  audioSeconds?: number;
+}
+
+export interface CostResult {
+  usd: number;
+  /** True when the modelId wasn't in MODEL_PRICING. usd is then 0. */
+  modelUnknown?: boolean;
+}
+
+export interface RecordInput {
+  modelId: string;
+  kind: UsageKind;
+  usage: UsageTokens;
+  /**
+   * Pre-computed USD cost. Used by callers that have a more authoritative
+   * number than our MODEL_PRICING table -- specifically pi-ai, whose
+   * `response.usage.cost.total` is already computed by the upstream bundled
+   * price table. When set, computeCost is skipped.
+   */
+  precomputedUsd?: number;
+  /** Optional ref so the entry can be tied back to a transcription folder. */
+  transcriptionRef?: string;
+  /** Override the timestamp (defaults to now). Used by tests. */
+  timestamp?: string;
+}
+
+export interface UsageEntry {
+  timestamp: string;
+  modelId: string;
+  kind: UsageKind;
+  usage: UsageTokens;
+  usd: number;
+  modelUnknown?: boolean;
+  transcriptionRef?: string;
+}
+
+const PER_MILLION = 1_000_000;
+const PER_MINUTE_SECONDS = 60;
+
+/**
+ * Compute the USD cost of a single call. Fails soft when the model isn't in
+ * MODEL_PRICING: returns `{ usd: 0, modelUnknown: true }` so the caller can
+ * continue. Used only for paths that bypass pi-ai (Gemini transcription via
+ * @google/genai, OpenAI STT via raw fetch).
+ */
+export function computeCost(modelId: string, kind: UsageKind, usage: UsageTokens): CostResult {
+  const pricing = MODEL_PRICING[modelId];
+  if (!pricing) return { usd: 0, modelUnknown: true };
+
+  // Per-minute STT models bill audio only; token fields are ignored.
+  if (typeof pricing.audioPerMinute === 'number') {
+    const seconds = usage.audioSeconds ?? 0;
+    return { usd: (seconds / PER_MINUTE_SECONDS) * pricing.audioPerMinute };
+  }
+
+  // Token-priced model (gemini-2.5-flash today). Transcription kind uses the
+  // audio-input rate; summary/agent use the text rate. cacheRead falls back
+  // to the same input rate when no cache discount is defined (avoids silent
+  // $0 billing for cached tokens).
+  const inputRate =
+    kind === 'transcription' && typeof pricing.audioInput === 'number'
+      ? pricing.audioInput
+      : (pricing.input ?? 0);
+  const cacheRate = pricing.cacheRead ?? inputRate;
+  const outputRate = pricing.output ?? 0;
+
+  const usd =
+    ((usage.input ?? 0) * inputRate +
+      (usage.cacheRead ?? 0) * cacheRate +
+      (usage.output ?? 0) * outputRate) /
+    PER_MILLION;
+  return { usd };
+}
+
+/** Override the data path -- used by tests to redirect to a temp dir. */
+let overrideDataPath: string | undefined;
+export function _setDataPathForTesting(p: string | undefined): void {
+  overrideDataPath = p;
+}
+
+/**
+ * Resolve where usage.jsonl lives. Returns null in test mode without an
+ * explicit override -- otherwise unit tests that exercise `complete()` (e.g.
+ * agentService.piai.test.ts) would silently write into the user's real
+ * Application Support dir.
+ *
+ * If you are writing a test that depends on persisted usage entries and they
+ * appear to vanish: call `_setDataPathForTesting(tempDir)` in a `before` hook,
+ * or set `LISTENER_DATA_PATH` in the spawned subprocess's env (CLI integration
+ * tests do this). The null return is intentional and only kicks in when both
+ * are missing.
+ */
+function usageFilePath(): string | null {
+  if (overrideDataPath) return path.join(overrideDataPath, 'usage.jsonl');
+  if (process.env.NODE_ENV === 'test' && !process.env.LISTENER_DATA_PATH) return null;
+  return path.join(getDataPath(), 'usage.jsonl');
+}
+
+/**
+ * Append one usage entry to usage.jsonl and return the computed cost. Never
+ * throws -- swallows fs errors with a warning so accounting failures don't
+ * break transcription. Returns `{ usd: 0, modelUnknown: true }` for unknown
+ * models so the caller can still aggregate.
+ */
+export function recordUsage(input: RecordInput): CostResult {
+  const cost: CostResult =
+    typeof input.precomputedUsd === 'number'
+      ? { usd: input.precomputedUsd }
+      : computeCost(input.modelId, input.kind, input.usage);
+  const entry: UsageEntry = {
+    timestamp: input.timestamp ?? new Date().toISOString(),
+    modelId: input.modelId,
+    kind: input.kind,
+    usage: input.usage,
+    usd: cost.usd,
+    modelUnknown: cost.modelUnknown,
+    transcriptionRef: input.transcriptionRef,
+  };
+  const file = usageFilePath();
+  if (file) {
+    try {
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.appendFileSync(file, `${JSON.stringify(entry)}\n`, 'utf-8');
+    } catch (err) {
+      console.warn('[usageTracker] failed to write usage.jsonl:', err);
+    }
+  }
+  return cost;
+}
+
+export interface CostBreakdownItem {
+  modelId: string;
+  kind: UsageKind;
+  usd: number;
+  usage: UsageTokens;
+  modelUnknown?: boolean;
+}
+
+export interface CostSnapshot {
+  usd: number;
+  breakdown: CostBreakdownItem[];
+  /** True when at least one sub-call hit a model not in MODEL_PRICING. */
+  modelUnknown?: boolean;
+}
+
+/**
+ * Per-call cost session for multi-step pipelines (transcribeWithTwoSteps).
+ * `record()` writes through to usage.jsonl and also accumulates into a local
+ * breakdown the caller can read at the end. The breakdown is what gets
+ * persisted in summary.md frontmatter.
+ */
+export interface CostSession {
+  record(input: RecordInput): CostResult;
+  snapshot(): CostSnapshot;
+}
+
+export function createCostSession(): CostSession {
+  const items: CostBreakdownItem[] = [];
+  return {
+    record(input) {
+      const cost = recordUsage(input);
+      items.push({
+        modelId: input.modelId,
+        kind: input.kind,
+        usd: cost.usd,
+        usage: input.usage,
+        modelUnknown: cost.modelUnknown,
+      });
+      return cost;
+    },
+    snapshot() {
+      const usd = items.reduce((sum, it) => sum + it.usd, 0);
+      const modelUnknown = items.some((it) => it.modelUnknown);
+      return modelUnknown ? { usd, breakdown: items, modelUnknown } : { usd, breakdown: items };
+    },
+  };
+}
+
+export interface SummaryFilter {
+  /** ISO timestamp; entries with `timestamp >= since` are included. */
+  since?: string;
+  /** ISO timestamp; entries with `timestamp < until` are included. */
+  until?: string;
+}
+
+export interface SummaryGroup {
+  modelId: string;
+  kind: UsageKind;
+  usd: number;
+  count: number;
+  tokens: UsageTokens;
+}
+
+export interface UsageSummaryResult {
+  totalUsd: number;
+  count: number;
+  modelUnknownCount: number;
+  byModel: SummaryGroup[];
+}
+
+function readAllEntries(): UsageEntry[] {
+  const file = usageFilePath();
+  // Test mode without an override path: nothing to read. summarizeUsage returns
+  // an empty roll-up, matching the "no usage recorded yet" first-run state.
+  if (!file) return [];
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+  const entries: UsageEntry[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as UsageEntry;
+      if (parsed && typeof parsed.timestamp === 'string' && typeof parsed.modelId === 'string') {
+        entries.push(parsed);
+      }
+    } catch {
+      // Skip malformed lines silently -- jsonl is best-effort, a bad line
+      // from a half-written entry shouldn't poison the whole summary.
+    }
+  }
+  return entries;
+}
+
+/**
+ * Roll up jsonl entries inside [since, until). Both bounds optional. Groups by
+ * (modelId, kind) so the Settings card can show per-model totals.
+ */
+export function summarizeUsage(filter: SummaryFilter = {}): UsageSummaryResult {
+  const all = readAllEntries();
+  const filtered = all.filter((e) => {
+    if (filter.since && e.timestamp < filter.since) return false;
+    if (filter.until && e.timestamp >= filter.until) return false;
+    return true;
+  });
+
+  const groups = new Map<string, SummaryGroup>();
+  let totalUsd = 0;
+  let modelUnknownCount = 0;
+
+  for (const e of filtered) {
+    totalUsd += e.usd;
+    if (e.modelUnknown) modelUnknownCount += 1;
+    const key = `${e.modelId} ${e.kind}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.usd += e.usd;
+      existing.count += 1;
+      existing.tokens = sumTokens(existing.tokens, e.usage);
+    } else {
+      groups.set(key, {
+        modelId: e.modelId,
+        kind: e.kind,
+        usd: e.usd,
+        count: 1,
+        tokens: { ...e.usage },
+      });
+    }
+  }
+
+  const byModel = Array.from(groups.values()).sort((a, b) => b.usd - a.usd);
+  return { totalUsd, count: filtered.length, modelUnknownCount, byModel };
+}
+
+function sumTokens(a: UsageTokens, b: UsageTokens): UsageTokens {
+  return {
+    input: (a.input ?? 0) + (b.input ?? 0) || undefined,
+    output: (a.output ?? 0) + (b.output ?? 0) || undefined,
+    cacheRead: (a.cacheRead ?? 0) + (b.cacheRead ?? 0) || undefined,
+    cacheWrite: (a.cacheWrite ?? 0) + (b.cacheWrite ?? 0) || undefined,
+    audioSeconds: (a.audioSeconds ?? 0) + (b.audioSeconds ?? 0) || undefined,
+  };
+}
+
+/**
+ * Convert "YYYY-MM" to an ISO range [start, end) covering that calendar month
+ * in the user's local timezone. Used by `listener usage --month` and the
+ * Settings card default. Local-zone semantics matter: a user in Asia/Seoul
+ * thinks "May 2026" as KST May 1 00:00 to KST June 1 00:00, not the UTC
+ * window. With UTC bounds, an 09:00 KST call on May 1 would leak into April.
+ */
+export function monthRange(month: string): { since: string; until: string } {
+  const match = month.match(/^(\d{4})-(\d{2})$/);
+  if (!match) throw new Error(`Invalid month: ${month} (expected YYYY-MM)`);
+  const year = Number.parseInt(match[1], 10);
+  const m = Number.parseInt(match[2], 10);
+  if (m < 1 || m > 12) throw new Error(`Invalid month: ${month}`);
+  // `new Date(y, m, d)` is local time; ISO output is the corresponding UTC
+  // instant. JS handles m=12 by rolling year forward automatically.
+  const since = new Date(year, m - 1, 1).toISOString();
+  const until = new Date(year, m, 1).toISOString();
+  return { since, until };
+}
+
+export function currentMonthString(now: Date = new Date()): string {
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+export { formatUsd } from '../usageFormat';

--- a/src/usageFormat.ts
+++ b/src/usageFormat.ts
@@ -1,0 +1,18 @@
+// Renderer-safe USD formatter. Lives in src/ (not src/services/) because
+// src/services/usageTracker.ts pulls in fs + getDataPath() and isn't importable
+// from the renderer. Keep this file dependency-free.
+
+export type ZeroStyle = 'short' | 'long' | 'omit';
+
+/**
+ * Format a USD amount for display.
+ *   - >=$0.01 → `$1.23` (2 decimals)
+ *   - <$0.01  → `$0.0012` (4 decimals, so tiny per-call costs aren't all `$0.00`)
+ *   - 0       → `$0` (short) / `$0.00` (long) / `''` (omit)
+ */
+export function formatUsd(usd: number, zero: ZeroStyle = 'short'): string {
+  if (usd === 0) {
+    return zero === 'omit' ? '' : zero === 'long' ? '$0.00' : '$0';
+  }
+  return usd < 0.01 ? `$${usd.toFixed(4)}` : `$${usd.toFixed(2)}`;
+}


### PR DESCRIPTION
## Summary

Closes #139. Best-effort USD cost tracking for every AI API call.

- Append usage telemetry to `${dataPath}/usage.jsonl` (durable ledger)
- Attach per-recording `cost` snapshot to `summary.md` frontmatter
- "Usage this month" card in Settings → Advanced
- `listener usage [--month YYYY-MM] [--json]` CLI subcommand
- Small `$` next to each recordings-list row when cost is known

### Cost sources

| Path | Priced by |
|---|---|
| `piAiClient.complete()` / `completeSimple()` — summary, agent | **pi-ai's** `response.usage.cost.total` (passed through verbatim) |
| Gemini transcription via `@google/genai` SDK direct | Our `MODEL_PRICING` (gemini-2.5-flash audio rate) |
| OpenAI STT via raw `/v1/audio/transcriptions` fetch | Our `MODEL_PRICING` (per-minute) |

pi-ai's bundled model table is authoritative for anything reachable through `complete()`. Adding chat-model entries to our local table would only drift on the next pi-ai upgrade.

### New files

- `src/services/usageTracker.ts` — `computeCost`, `recordUsage`, `createCostSession`, `summarizeUsage`, `monthRange`
- `src/services/usageTracker.test.ts` — 17 unit tests
- `src/usageFormat.ts` — renderer-safe USD formatter (no `fs` deps), shared by renderer and CLI

### Notable design choices

- **`kind` is required at the type level** on `UsageContext` so a future `complete()` caller can't be silently misclassified as `'agent'`.
- **`CostSession`** lets `transcribeWithTwoSteps` aggregate per-step costs into a single `TranscriptionResult.cost` while also writing each entry to the durable ledger.
- **Test isolation**: `usageTracker.usageFilePath()` returns `null` when `NODE_ENV=test && !LISTENER_DATA_PATH`. Without this, unit tests that exercise `complete()` (e.g. `agentService.piai.test.ts`) would silently leak entries into the user's real `~/Library/Application Support/listener-ai/usage.jsonl`.
- **Local-time month boundaries**: a KST user thinks "May 2026" as KST May 1 → June 1, not UTC. `monthRange()` uses `new Date(y, m-1, 1)` on purpose.

## Test plan

- [x] `pnpm test` — 253 tests pass (17 new in usageTracker.test.ts + 4 new in cli.test.ts + everything inherited from upstream)
- [x] `pnpm lint` — clean
- [x] `pnpm format --check` — clean
- [x] `pnpm run build` — clean
- [ ] Manual: record a meeting → confirm `$0.0xx` appears on the row after transcription completes
- [ ] Manual: open Settings → Advanced → "Usage this month" shows total + per-model breakdown
- [ ] Manual: `listener usage` from CLI shows the same totals
- [ ] Manual: `listener usage --month 2026-04 --json` filters and emits JSON

## Review trail

This PR went through three review rounds before landing:

1. **First /review** (Claude `git-diff-reviewer` + Codex `codex-rescue`) caught the **cached-token double-billing bug** in the original Gemini metadata mapping, the **UTC-vs-local timezone leak** in `monthRange`, accessibility gaps on the usage card, and made `usageContext.kind` required at the type level.
2. **Codex review** found that **pi-ai already provides `calculateCost`** via its bundled model table — refactored to slim `MODEL_PRICING` to non-pi-ai paths only (-32 lines) and pass `response.usage.cost.total` through verbatim.
3. **/simplify pass** unified `formatUsd` into `src/usageFormat.ts`, deduped two near-identical Codex STT record blocks into a `recordCodexSttUsage` helper, made `parseCostField` local to `outputService.ts`, trimmed narration comments.
4. **Final /review** caught a **ship-blocking package.json `files` whitelist gap** — `dist/usageFormat.js` and `dist/services/usageTracker.js` would have broken `npm install -g listener-ai` with `Cannot find module`. Fixed before commit.

## Out of scope (deliberately)

- Real-time meter during recording (post-hoc only)
- Multi-currency (USD only)
- Per-user / per-org aggregation (single-user app)