### PR TITLE
perf(transcription): convert hot-path fs operations to fs.promises

### DIFF
--- a/src/codexTranscription.ts
+++ b/src/codexTranscription.ts
@@ -105,7 +105,7 @@ export function isDiarizeModel(model: string): boolean {
 }
 
 export async function transcribeCodexAudio(params: TranscribeCodexAudioParams): Promise<string> {
-  const audioData = fs.readFileSync(params.audioFilePath);
+  const audioData = await fs.promises.readFile(params.audioFilePath);
   const ext = path.extname(params.audioFilePath);
   const model = params.model.trim();
   const diarize = isDiarizeModel(model);

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -582,7 +582,7 @@ export class GeminiService {
     try {
       signal?.throwIfAborted();
       // Check file size
-      const stats = fs.statSync(prepared.audioFilePath);
+      const stats = await fs.promises.stat(prepared.audioFilePath);
       const fileSizeInMB = stats.size / (1024 * 1024);
       console.error(`Audio file size: ${fileSizeInMB.toFixed(2)} MB`);
 
@@ -828,7 +828,7 @@ export class GeminiService {
     const costSession = createCostSession();
     try {
       let fullTranscript = '';
-      const stats = fs.statSync(audioFilePath);
+      const stats = await fs.promises.stat(audioFilePath);
       const fileSizeInMB = stats.size / (1024 * 1024);
       // Segment intentionally for parallelism: even when the API would
       // accept the whole file (Gemini long-context, gpt-4o-transcribe-diarize
@@ -996,7 +996,7 @@ Return as JSON:
     session?: CostSession,
   ): Promise<string> {
     try {
-      const stats = fs.statSync(audioFilePath);
+      const stats = await fs.promises.stat(audioFilePath);
       const fileSizeInMB = stats.size / (1024 * 1024);
 
       if (progressCallback) {
@@ -1036,7 +1036,7 @@ Return as JSON:
 
         const mimeType = mimeTypeForExtension(path.extname(audioFilePath));
 
-        const fileData = fs.readFileSync(audioFilePath);
+        const fileData = await fs.promises.readFile(audioFilePath);
         const uploadResult = await ai.files.upload({
           file: new Blob([fileData], { type: mimeType }),
           config: { abortSignal: signal },
@@ -1097,7 +1097,7 @@ Return as JSON:
           },
         });
       } else {
-        const audioData = fs.readFileSync(audioFilePath);
+        const audioData = await fs.promises.readFile(audioFilePath);
         const base64Audio = audioData.toString('base64');
         const mimeType = mimeTypeForExtension(path.extname(audioFilePath));
 
@@ -1203,7 +1203,7 @@ Return as JSON:
           };
         }
 
-        const audioData = fs.readFileSync(segmentFile);
+        const audioData = await fs.promises.readFile(segmentFile);
         const base64Audio = audioData.toString('base64');
         const mimeType = mimeTypeForExtension(path.extname(segmentFile));
 


### PR DESCRIPTION
Closes #120.

## Summary

- Convert 7 synchronous fs calls in the audio transcription hot path to `fs.promises` so 50 MB stat/read operations no longer block the Node event loop
- 3 `statSync` → `await fs.promises.stat` in `geminiService.ts` (`transcribeAudio`, `transcribeWithTwoSteps`, `getShortAudioTranscript`)
- 3 `readFileSync` → `await fs.promises.readFile` in `geminiService.ts` (`getShortAudioTranscript` >20MB upload path, `getShortAudioTranscript` inline base64 path, `transcribeSingleSegment` segment-loop body)
- 1 `readFileSync` → `await fs.promises.readFile` in `codexTranscription.ts` (OpenAI multipart upload)

## Scope notes

Issue #120 enumerated only the 3 oldest sites (filed 2026-05-14). The other 4 are the same `statSync`/`readFileSync` audio-hot-path pattern in the same two files, added between then and now (Codex transcription split, diarize codepath). Folding them into the same commit since the rationale is identical.

Cancellation semantics unchanged — no `{ signal }` threading was added even though `fs.promises.readFile` would accept it in modern Node. That's a real follow-up but explicitly out of scope per the issue's "mechanical swap" framing.

## Test plan

- [x] \`pnpm test\` — 253 tests pass
- [x] \`pnpm run build\` — clean (pre-existing TS diagnostic on geminiService.ts:1340 about an arrow function in \`.map()\` that could be \`async\`; unrelated to this diff)
- [ ] Manual smoke: record a >20 MB meeting and confirm transcription completes through both the Files-API upload path (Gemini) and the inline base64 path (small file)