### PR TITLE
fix(google-drive): paginate listFolder to read >100 entries

### DIFF
--- a/src/services/googleDriveService.test.ts
+++ b/src/services/googleDriveService.test.ts
@@ -113,6 +113,114 @@ describe('GoogleDriveClient.findFile', () => {
   });
 });
 
+describe('GoogleDriveClient.listFolder', () => {
+  it('concatenates results across pages following nextPageToken', async () => {
+    fetchStub
+      .enqueue(200, {
+        nextPageToken: 'page-2',
+        files: [
+          { id: 'a', name: 'a.md', mimeType: 'text/markdown' },
+          { id: 'b', name: 'b.md', mimeType: 'text/markdown' },
+        ],
+      })
+      .enqueue(200, {
+        nextPageToken: 'page-3',
+        files: [{ id: 'c', name: 'c.md', mimeType: 'text/markdown' }],
+      })
+      .enqueue(200, {
+        files: [{ id: 'd', name: 'd.md', mimeType: 'text/markdown' }],
+      });
+
+    const result = await client.listFolder('folder-id');
+
+    assert.equal(
+      fetchStub.calls.length,
+      3,
+      'should issue one request per page until token exhausted',
+    );
+    assert.deepEqual(
+      result.map((f) => f.id),
+      ['a', 'b', 'c', 'd'],
+    );
+    assert.equal(new URL(fetchStub.calls[0].url).searchParams.get('pageToken'), null);
+    assert.equal(new URL(fetchStub.calls[1].url).searchParams.get('pageToken'), 'page-2');
+    assert.equal(new URL(fetchStub.calls[2].url).searchParams.get('pageToken'), 'page-3');
+  });
+
+  it('requests nextPageToken in the fields parameter (otherwise Drive omits it)', async () => {
+    fetchStub.enqueue(200, { files: [] });
+
+    await client.listFolder('folder-id');
+
+    const fields = new URL(fetchStub.calls[0].url).searchParams.get('fields');
+    assert.ok(
+      fields?.includes('nextPageToken'),
+      `expected fields to include nextPageToken, got: ${fields}`,
+    );
+  });
+
+  it('returns a single page result without issuing a second request', async () => {
+    fetchStub.enqueue(200, {
+      files: [
+        { id: 'x', name: 'x.md', mimeType: 'text/markdown' },
+        { id: 'y', name: 'y.md', mimeType: 'text/markdown' },
+      ],
+    });
+
+    const result = await client.listFolder('folder-id');
+
+    assert.equal(fetchStub.calls.length, 1);
+    assert.equal(result.length, 2);
+  });
+
+  it('returns an empty array for an empty folder', async () => {
+    fetchStub.enqueue(200, { files: [] });
+
+    const result = await client.listFolder('empty-folder');
+
+    assert.equal(fetchStub.calls.length, 1);
+    assert.deepEqual(result, []);
+  });
+
+  it('treats empty-string nextPageToken as terminated (does not loop on it)', async () => {
+    fetchStub.enqueue(200, {
+      nextPageToken: '',
+      files: [{ id: 'only', name: 'only.md', mimeType: 'text/markdown' }],
+    });
+
+    const result = await client.listFolder('folder-id');
+
+    assert.equal(
+      fetchStub.calls.length,
+      1,
+      'empty-string token must not trigger another page request',
+    );
+    assert.deepEqual(
+      result.map((f) => f.id),
+      ['only'],
+    );
+  });
+
+  it('propagates an error from a non-first page and does not return partial results', async () => {
+    fetchStub
+      .enqueue(200, {
+        nextPageToken: 'page-2',
+        files: [{ id: 'a', name: 'a.md', mimeType: 'text/markdown' }],
+      })
+      .enqueue(500, { error: { message: 'internal' } });
+
+    await assert.rejects(
+      () => client.listFolder('folder-id'),
+      (err: unknown) => {
+        assert.ok(err instanceof GoogleDriveError);
+        assert.equal((err as GoogleDriveError).status, 500);
+        return true;
+      },
+    );
+    assert.equal(fetchStub.calls.length, 2);
+  });
+});
+
 describe('GoogleDriveClient.ensureFolder', () => {
   it('returns the existing folder when found', async () => {
     fetchStub.enqueue(200, {

--- a/src/services/googleDriveService.ts
+++ b/src/services/googleDriveService.ts
@@ -101,19 +101,19 @@ export class GoogleDriveClient {
     // only requests `files(...)`, Drive omits the token and the loop exits
     // after one page even when more pages exist.
     const q = `'${this.escapeQueryString(folderId)}' in parents and trashed = false`;
+    const url = new URL(`${DRIVE_API_BASE}/files`);
+    url.searchParams.set('q', q);
+    url.searchParams.set(
+      'fields',
+      'nextPageToken,files(id,name,mimeType,modifiedTime,size,parents)',
+    );
+    url.searchParams.set('pageSize', '100');
+    url.searchParams.set('spaces', 'drive');
+
     const all: DriveFile[] = [];
     let pageToken: string | undefined;
     do {
-      const url = new URL(`${DRIVE_API_BASE}/files`);
-      url.searchParams.set('q', q);
-      url.searchParams.set(
-        'fields',
-        'nextPageToken,files(id,name,mimeType,modifiedTime,size,parents)',
-      );
-      url.searchParams.set('pageSize', '100');
-      url.searchParams.set('spaces', 'drive');
       if (pageToken) url.searchParams.set('pageToken', pageToken);
-
       const res = await this.authedFetch(url.toString());
       await this.ensureOk(res, `Drive listFolder ${folderId}`);
       const json = (await res.json()) as { files?: DriveFile[]; nextPageToken?: string };

--- a/src/services/googleDriveService.ts
+++ b/src/services/googleDriveService.ts
@@ -95,20 +95,32 @@ export class GoogleDriveClient {
   }
 
   async listFolder(folderId: string): Promise<DriveFile[]> {
+    // Drive v3 caps pageSize at 100 (higher values are silently coerced down),
+    // so the only way to read a folder with >100 entries is to follow
+    // nextPageToken. `fields` must explicitly name `nextPageToken` -- if it
+    // only requests `files(...)`, Drive omits the token and the loop exits
+    // after one page even when more pages exist.
     const q = `'${this.escapeQueryString(folderId)}' in parents and trashed = false`;
-    const url = new URL(`${DRIVE_API_BASE}/files`);
-    url.searchParams.set('q', q);
-    url.searchParams.set('fields', 'files(id,name,mimeType,modifiedTime,size,parents)');
-    // TODO(#137): paginate via nextPageToken. A meeting folder with >100 files
-    // silently drops the rest -- audio + summary + transcript per meeting fits
-    // easily, but conflict backups or future attachments could push it over.
-    url.searchParams.set('pageSize', '100');
-    url.searchParams.set('spaces', 'drive');
+    const all: DriveFile[] = [];
+    let pageToken: string | undefined;
+    do {
+      const url = new URL(`${DRIVE_API_BASE}/files`);
+      url.searchParams.set('q', q);
+      url.searchParams.set(
+        'fields',
+        'nextPageToken,files(id,name,mimeType,modifiedTime,size,parents)',
+      );
+      url.searchParams.set('pageSize', '100');
+      url.searchParams.set('spaces', 'drive');
+      if (pageToken) url.searchParams.set('pageToken', pageToken);
 
-    const res = await this.authedFetch(url.toString());
-    await this.ensureOk(res, `Drive listFolder ${folderId}`);
-    const json = (await res.json()) as { files?: DriveFile[] };
-    return json.files ?? [];
+      const res = await this.authedFetch(url.toString());
+      await this.ensureOk(res, `Drive listFolder ${folderId}`);
+      const json = (await res.json()) as { files?: DriveFile[]; nextPageToken?: string };
+      if (json.files) all.push(...json.files);
+      pageToken = json.nextPageToken || undefined;
+    } while (pageToken);
+    return all;
   }
 
   async ensureFolder(name: string, parentId?: string): Promise<DriveFile> {


### PR DESCRIPTION
Closes #153.

## Summary
- `GoogleDriveClient.listFolder` now follows `nextPageToken` until exhausted, so folders with >100 entries are read in full.
- `fields` now explicitly names `nextPageToken` -- without it, Drive omits the token from the response and the loop would exit after one page even when more pages exist.
- Invariant URL params (`q`, `fields`, `pageSize`, `spaces`) are built once outside the loop; only `pageToken` mutates per iteration.

## Why this matters
Drive v3 caps `pageSize` at 100 (higher values are silently coerced down). For users with >100 meetings (or >100 deletions in the tombstones folder), the prior code silently truncated:
- `scanRemoteMeetingFolders` misclassified meetings as upload-only -> spurious re-uploads / wrong conflict baselines.
- Tombstone listing missed deletions -> stale local folders not removed.
- First-time download on a fresh device dropped meetings past the 100th.

## Test plan
- [x] Six new unit tests in `googleDriveService.test.ts`: multi-page concatenation, fields-includes-nextPageToken, single-page (no extra request), empty folder, empty-string token termination, mid-loop error propagation (no partial results returned).
- [x] Full suite: 259 tests pass.
- [x] `oxlint`: 0 warnings.
- [ ] Manual: list a Drive folder with 250+ files via a debug session and confirm all are returned (deferred to merger -- not easy to reproduce without a heavy account).