### PR TITLE
feat(storage): v2 per-field transcription layout with force-migrate-on-startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,8 @@ listener google upload <ref>         Upload a meeting folder to Google Drive
 listener google sync                 Sync all meetings to Google Drive (upload changes only)
 listener config list|get|set|unset|path
                                      Manage configuration
+listener migrate <ref> | --all [--dry-run]
+                                     Migrate legacy v1 folders to the v2 layout. Idempotent.
 listener --version                   Print CLI version
 listener --help                      Show usage
 ```
@@ -141,11 +143,35 @@ Injection mechanism: `scripts/write-build-constants.js` runs as part of `pnpm ru
 ## Transcription Storage
 
 - Root: `getDataPath()/transcriptions/`
-- One folder per meeting: `<sanitized-title>_<timestamp>/`
-  - `summary.md` — YAML frontmatter (`title`, `suggestedTitle`, `summary`, `keyPoints`, `actionItems`, `customFields`, `audioFilePath`, `transcribedAt`, `emoji`) plus markdown body
-  - `transcript.md` — full transcript
-  - Optional original audio file
-- `src/outputService.ts` is the only read/write surface: `saveTranscription`, `listTranscriptions`, `readTranscription`, `parseFrontmatter`, `getTranscriptionsDir`.
+- `src/outputService.ts` is the only read/write surface: `saveTranscription`, `listTranscriptions`, `readTranscription`, `updateTranscriptionStatus`, `migrateV1ToV2`, `parseFrontmatter`, `getTranscriptionsDir`.
+
+### v2 layout (current writer)
+
+Each meeting is a folder named `<ts24>_<sanitized-title>/` where `ts24` is a 24-character filesystem-safe ISO 8601 UTC timestamp (`YYYY-MM-DDTHH-MM-SS.mmmZ`). Time-first naming means `ls` sorts chronologically by default, which matters when an external agent (Claude Code, MCP server) walks the directory.
+
+Files inside the folder (each holds exactly one semantic field, so there is no in-file duplication and no body parser is needed):
+
+- `meta.json` — structured metadata: `schemaVersion`, `title`, `suggestedTitle`, `emoji`, `transcribedAt`, `audioFile`, `cost`, `customFields`, `merge.sourceIds`, `exports.notion`, `exports.slack`. Unknown keys are preserved on read so future writers can add fields without bumping `schemaVersion`. **`meta.json` is written LAST by `writeV2Files` so it doubles as a v2 sentinel — if a save/migration crashes mid-write the folder still looks like v1 and a retry restarts cleanly.**
+- `summary.md` — plain markdown text of the summary, no frontmatter, no `# heading`.
+- `key-points.md` — bullets (`- item` per line). Writer normalizes `\n` in items to spaces so the round-trip is unambiguous.
+- `action-items.md` — same shape as `key-points.md`.
+- `transcript.md` — plain transcript text, no `# title` heading.
+- `notes.json` (optional) — live notes captured during recording.
+- `highlights.json` (optional) — AI-enriched highlights.
+- Original audio file (optional, path lives in `meta.audioFile`).
+
+### v1 layout (legacy, auto-migrated on startup)
+
+Pre-v2 folders use `<sanitized-title>_<timestamp>/` with `summary.md` (YAML frontmatter + rendered markdown body) plus `transcript.md`. The runtime no longer reads v1 directly — `autoMigrateLegacyOnStartup` runs on every app/CLI entry point and converts each v1 folder to v2 in place before any other code touches the directory.
+
+### Runtime rules
+
+- **v2-only at runtime.** `readTranscription`, `listTranscriptions`, and `updateTranscriptionStatus` only understand v2. After `autoMigrateLegacyOnStartup` finishes, every folder has a `meta.json`. `readV1Transcription`, `buildFrontmatter`, `parseFrontmatter`, etc. exist only as migration helpers (called by `migrateV1ToV2`).
+- **Startup migration is mandatory and crash-safe.** `main.ts` (Electron) and `cli.ts` (CLI) both `await autoMigrateLegacyOnStartup(getDataPath())` before any other code. Failure aborts startup with a dialog (Electron) or error exit (CLI) — partial migration is worse than no migration. For each v1 folder, the destructively-overwritten files (`summary.md`, `transcript.md`) are snapshotted to `<dataPath>/.v1-backup-<ts>/<folderName>/` before migration. Backups are GC'd after 30 days via `gcLegacyBackups`.
+- **`meta.json` is written LAST in `writeV2Files`** so it doubles as the v2 sentinel — if a save/migration crashes mid-write the folder is still recognised as v1 and a retry restarts cleanly instead of treating a half-written folder as already-migrated.
+- **`updateTranscriptionStatus` touches only `meta.json`** so Drive sync sees a one-file change per status update. Content files (`summary.md`, `transcript.md`, etc.) keep their existing mtime.
+- **Migration preserves folder names.** Drive sync keys change detection on folder name; renaming would look like delete+recreate and force a full re-upload. v1-named folders keep their v1 names; only the internal file layout flips.
+- **`LISTENER_SKIP_AUTO_MIGRATE`** disables the startup migration. Used only by CLI tests that need to drive `listener migrate` against an un-migrated fixture; do not set this in production.
 
 ## Google Drive Sync
 
@@ -207,6 +233,7 @@ Injection mechanism: `scripts/write-build-constants.js` runs as part of `pnpm ru
 - Test escape hatches (read-only at process start, never set in production):
   - `LISTENER_DATA_PATH` — overrides `getDataPath()` so tests run against a temp directory
   - `LISTENER_TEST_MODE` — `GeminiService.transcribeAudio` returns a canned fixture instead of calling the API
+  - `LISTENER_SKIP_AUTO_MIGRATE` — CLI bypasses the v1→v2 startup migration, so `listener migrate` tests can drive the explicit command against an un-migrated fixture
 
 #### Patterns proven in this codebase
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -9,7 +9,7 @@ import assert from 'node:assert/strict';
 // transcribe -> saveTranscription, and the mergedFrom round-trip.
 import { after, before, describe, it } from 'node:test';
 import * as path from 'path';
-import { saveTranscription } from './outputService';
+import { __saveTranscriptionLegacyV1ForTests, saveTranscription } from './outputService';
 import { execFileAsync, findFfmpegSync, makeOpusWebm, makeTempDir, rmDir } from './test-helpers';
 
 const ffmpegPath = findFfmpegSync();
@@ -192,6 +192,212 @@ describe('listener CLI basics', () => {
   });
 });
 
+describe('listener show / export across v1 + v2 folders', () => {
+  let showDataPath: string;
+  let cliPath2: string;
+
+  before(() => {
+    showDataPath = makeTempDir('cli-show');
+    cliPath2 = path.join(__dirname, 'cli.js');
+  });
+
+  after(() => rmDir(showDataPath));
+
+  function runCli(
+    args: string[],
+    extraEnv: Record<string, string> = {},
+  ): Promise<{ stdout: string; stderr: string; code: number | null }> {
+    return new Promise((resolve) => {
+      const { spawn } = require('child_process') as typeof import('child_process');
+      const child = spawn('node', [cliPath2, ...args], {
+        env: {
+          ...process.env,
+          NODE_ENV: 'test',
+          LISTENER_AI_PROVIDER: '',
+          LISTENER_DATA_PATH: showDataPath,
+          ...extraEnv,
+        },
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (d: Buffer) => {
+        stdout += d.toString();
+      });
+      child.stderr.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      child.on('close', (code: number | null) => {
+        resolve({ stdout, stderr, code });
+      });
+    });
+  }
+
+  it('show on a v2 folder prints synthesized markdown with all sections', async () => {
+    const folderPath = saveTranscription({
+      title: 'Show Test',
+      result: {
+        transcript: 't',
+        summary: 'Summary text.',
+        keyPoints: ['KP1', 'KP2'],
+        actionItems: ['AI1'],
+        emoji: 'X',
+      },
+      dataPath: showDataPath,
+    });
+
+    const { stdout, code } = await runCli(['show', path.basename(folderPath)]);
+    assert.equal(code, 0);
+    assert.match(stdout, /^# Show Test/);
+    assert.match(stdout, /## Summary\n[\s\S]*Summary text\./);
+    assert.match(stdout, /## Key Points\n[\s\S]*- KP1\n- KP2/);
+    assert.match(stdout, /## Action Items\n[\s\S]*- AI1/);
+  });
+
+  it('show on a v1 folder still prints its frontmatter body', async () => {
+    const folderPath = __saveTranscriptionLegacyV1ForTests({
+      title: 'V1 Show',
+      result: {
+        transcript: 't',
+        summary: 'Legacy summary.',
+        keyPoints: ['LK1'],
+        actionItems: ['LA1'],
+        emoji: 'L',
+      },
+      dataPath: showDataPath,
+    });
+    const { stdout, code } = await runCli(['show', path.basename(folderPath)]);
+    assert.equal(code, 0);
+    assert.match(stdout, /## Summary/);
+    assert.match(stdout, /Legacy summary\./);
+    assert.match(stdout, /## Key Points/);
+    assert.match(stdout, /- LK1/);
+  });
+
+  it('export --json works for both v1 and v2 (same shape)', async () => {
+    const v2Path = saveTranscription({
+      title: 'V2 Export',
+      result: {
+        transcript: 'tx',
+        summary: 'S',
+        keyPoints: ['K'],
+        actionItems: ['A'],
+        emoji: 'E',
+      },
+      dataPath: showDataPath,
+    });
+    const v1Path = __saveTranscriptionLegacyV1ForTests({
+      title: 'V1 Export',
+      result: {
+        transcript: 'tx',
+        summary: 'S',
+        keyPoints: ['K'],
+        actionItems: ['A'],
+        emoji: 'E',
+      },
+      dataPath: showDataPath,
+    });
+
+    const v2 = await runCli(['export', path.basename(v2Path), '--json']);
+    const v1 = await runCli(['export', path.basename(v1Path), '--json']);
+    assert.equal(v2.code, 0);
+    assert.equal(v1.code, 0);
+
+    const v2Json = JSON.parse(v2.stdout);
+    const v1Json = JSON.parse(v1.stdout);
+
+    // Field-by-field equivalence (excluding title and date which differ by fixture).
+    assert.equal(v2Json.summary, v1Json.summary);
+    assert.deepEqual(v2Json.keyPoints, v1Json.keyPoints);
+    assert.deepEqual(v2Json.actionItems, v1Json.actionItems);
+  });
+
+  it('export --json --transcript includes transcript on both formats', async () => {
+    const folderPath = saveTranscription({
+      title: 'V2 ExportTx',
+      result: {
+        transcript: 'transcript body',
+        summary: 's',
+        keyPoints: [],
+        actionItems: [],
+        emoji: 'E',
+      },
+      dataPath: showDataPath,
+    });
+    const { stdout, code } = await runCli([
+      'export',
+      path.basename(folderPath),
+      '--json',
+      '--transcript',
+    ]);
+    assert.equal(code, 0);
+    const json = JSON.parse(stdout);
+    assert.equal(json.transcript, 'transcript body');
+  });
+
+  it('list shows mixed v1 + v2 folders', async () => {
+    const { stdout, code } = await runCli(['list', '--limit', '0']);
+    assert.equal(code, 0);
+    assert.match(stdout, /Show Test/);
+    assert.match(stdout, /V1 Show/);
+    assert.match(stdout, /V2 Export/);
+    assert.match(stdout, /V1 Export/);
+  });
+
+  it('migrate <ref> converts a v1 folder to v2 in place', async () => {
+    const v1Path = __saveTranscriptionLegacyV1ForTests({
+      title: 'To Migrate',
+      result: {
+        transcript: 'mtx',
+        summary: 'mig summary',
+        keyPoints: ['mk1'],
+        actionItems: ['ma1'],
+        emoji: 'M',
+      },
+      dataPath: showDataPath,
+    });
+
+    // Sanity: v1 fixture has no meta.json yet
+    assert.ok(!fs.existsSync(path.join(v1Path, 'meta.json')));
+
+    // LISTENER_SKIP_AUTO_MIGRATE: otherwise the runtime's startup
+    // auto-migration converts the fixture before `listener migrate` even runs.
+    const { code, stderr } = await runCli(['migrate', path.basename(v1Path)], {
+      LISTENER_SKIP_AUTO_MIGRATE: '1',
+    });
+    assert.equal(code, 0);
+    assert.match(stderr, /1 migrated/);
+    assert.ok(fs.existsSync(path.join(v1Path, 'meta.json')));
+
+    // After migration, show still works and prints synthesized markdown.
+    const show = await runCli(['show', path.basename(v1Path)]);
+    assert.equal(show.code, 0);
+    assert.match(show.stdout, /^# To Migrate/);
+    assert.match(show.stdout, /mig summary/);
+  });
+
+  it('migrate --dry-run reports without modifying disk', async () => {
+    const v1Path = __saveTranscriptionLegacyV1ForTests({
+      title: 'Dry Run',
+      result: {
+        transcript: 'dry',
+        summary: 'dry summary',
+        keyPoints: [],
+        actionItems: [],
+        emoji: 'D',
+      },
+      dataPath: showDataPath,
+    });
+
+    const { code, stdout } = await runCli(
+      ['migrate', path.basename(v1Path), '--dry-run'],
+      { LISTENER_SKIP_AUTO_MIGRATE: '1' },
+    );
+    assert.equal(code, 0);
+    assert.match(stdout, /would migrate/);
+    assert.ok(!fs.existsSync(path.join(v1Path, 'meta.json')));
+  });
+});
+
 describe('listener transcript (CLI integration)', () => {
   let transcriptDataPath: string;
 
@@ -364,16 +570,16 @@ describe(
         `result folder must live inside the test dataPath, got ${resultFolder}`,
       );
 
-      const summary = fs.readFileSync(path.join(resultFolder, 'summary.md'), 'utf-8');
+      // v2 layout: structured data lives in meta.json, not in summary.md frontmatter.
+      const metaPath = path.join(resultFolder, 'meta.json');
+      assert.ok(fs.existsSync(metaPath), 'meta.json should exist (v2 layout)');
+      const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
       // User-provided --title beats the stub's suggestedTitle.
-      assert.match(summary, /^title: Combined Meeting$/m);
-      assert.match(summary, /suggestedTitle: Stubbed Title/);
-      assert.match(summary, /## Sources/);
-      assert.match(summary, new RegExp(folderNameA.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-      assert.match(summary, new RegExp(folderNameB.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      assert.equal(meta.title, 'Combined Meeting');
+      assert.equal(meta.suggestedTitle, 'Stubbed Title');
+      assert.deepEqual(meta.merge?.sourceIds, [folderNameA, folderNameB]);
 
-      const audioLine = summary.match(/^audioFilePath:\s*(.+)$/m);
-      const mergedAudioPath = audioLine?.[1].trim().replace(/^"|"$/g, '') ?? '';
+      const mergedAudioPath: string = meta.audioFile ?? '';
       assert.ok(
         mergedAudioPath.endsWith('.webm'),
         `merged audio should be webm, got ${mergedAudioPath}`,

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -388,10 +388,9 @@ describe('listener show / export across v1 + v2 folders', () => {
       dataPath: showDataPath,
     });
 
-    const { code, stdout } = await runCli(
-      ['migrate', path.basename(v1Path), '--dry-run'],
-      { LISTENER_SKIP_AUTO_MIGRATE: '1' },
-    );
+    const { code, stdout } = await runCli(['migrate', path.basename(v1Path), '--dry-run'], {
+      LISTENER_SKIP_AUTO_MIGRATE: '1',
+    });
     assert.equal(code, 0);
     assert.match(stdout, /would migrate/);
     assert.ok(!fs.existsSync(path.join(v1Path, 'meta.json')));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1339,10 +1339,7 @@ async function main(): Promise<void> {
   // dir-scan when it's irrelevant. Also skip when `LISTENER_SKIP_AUTO_MIGRATE`
   // is set -- the migrate-command tests use this to drive the explicit
   // `listener migrate` flow on un-migrated fixtures.
-  if (
-    !COMMANDS_WITHOUT_DATA_ACCESS.has(args[0]) &&
-    !process.env.LISTENER_SKIP_AUTO_MIGRATE
-  ) {
+  if (!COMMANDS_WITHOUT_DATA_ACCESS.has(args[0]) && !process.env.LISTENER_SKIP_AUTO_MIGRATE) {
     try {
       await autoMigrateLegacyOnStartup(getDataPath());
     } catch (err) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,12 +15,20 @@ import { loginGoogleOAuth, resolveGoogleAccessToken } from './googleOAuth';
 import { GoogleDriveClient, uploadMeetingFolder } from './services/googleDriveService';
 import { SyncEngine } from './services/syncEngine';
 import {
+  ACTION_ITEMS_FILE,
+  HIGHLIGHTS_JSON_FILE,
+  KEY_POINTS_FILE,
+  META_JSON,
+  NOTES_JSON_FILE,
+  SUMMARY_FILE,
+  TRANSCRIPT_FILE,
+  autoMigrateLegacyOnStartup,
+  formatSummary,
   formatTimestamp,
   getTranscriptionsDir,
+  isV2Folder,
   listTranscriptions,
-  parseFrontmatter,
-  parseHighlightsField,
-  parseLiveNotesField,
+  migrateV1ToV2,
   readTranscription,
   sanitizeForPath,
   saveTranscription,
@@ -41,6 +49,14 @@ const SUPPORTED_EXTENSIONS = new Set([
   '.opus',
   '.webm',
 ]);
+
+/** Commands that don't trigger the one-shot v1->v2 startup migration:
+ * - `config`/`codex` never touch the transcriptions directory.
+ * - `migrate` IS the migration command itself; its own loop scans for v1
+ *   folders. Running the startup auto-migrate first would convert everything
+ *   to v2 before `--dry-run` could observe it. The `migrate` handler is
+ *   responsible for any conversion it does. */
+const COMMANDS_WITHOUT_DATA_ACCESS = new Set(['config', 'codex', 'migrate']);
 
 const VERSION = (() => {
   try {
@@ -75,6 +91,9 @@ const USAGE_TEXT =
   '                                           Manage configuration\n' +
   '       listener usage [--month YYYY-MM] [--json]\n' +
   '                                           Show estimated API spend (best-effort, default: current month)\n' +
+  '       listener migrate <ref> | --all [--dry-run]\n' +
+  '                                           Migrate one or all transcription folders from the legacy\n' +
+  '                                           single-summary.md layout to the v2 multi-file layout\n' +
   '\n' +
   '<ref> is a number from `listener list` or a folder name.\n' +
   '\n' +
@@ -666,14 +685,19 @@ async function handleShow(args: string[]): Promise<void> {
   }
   const dataPath = getDataPath();
   const folderPath = await resolveRef(ref, dataPath);
-  const summaryPath = path.join(folderPath, 'summary.md');
-  if (!fs.existsSync(summaryPath)) {
-    process.stderr.write(`Error: summary.md not found in ${folderPath}\n`);
+
+  const md = await renderV2Markdown(folderPath);
+  if (md === null) {
+    process.stderr.write(`Error: could not read transcription at ${folderPath}\n`);
     process.exit(1);
   }
-  const content = fs.readFileSync(summaryPath, 'utf-8');
-  const { body } = parseFrontmatter(content);
-  process.stdout.write(body);
+  process.stdout.write(md);
+}
+
+async function renderV2Markdown(folderPath: string): Promise<string | null> {
+  const data = await readTranscription(folderPath);
+  if (!data) return null;
+  return formatSummary(data, data.title, data.mergedFrom, data.liveNotes, data.highlights);
 }
 
 async function handleExport(args: string[]): Promise<void> {
@@ -713,14 +737,14 @@ async function handleExport(args: string[]): Promise<void> {
 
   const dataPath = getDataPath();
   const folderPath = await resolveRef(ref, dataPath);
-  const summaryPath = path.join(folderPath, 'summary.md');
 
-  if (!fs.existsSync(summaryPath)) {
-    process.stderr.write(`Error: summary.md not found in ${folderPath}\n`);
+  // meta.json is the v2 sentinel. Fires when migration was skipped
+  // (`LISTENER_SKIP_AUTO_MIGRATE`) or the folder is corrupt.
+  if (!isV2Folder(folderPath)) {
+    process.stderr.write(`Error: ${META_JSON} not found in ${folderPath}\n`);
     process.exit(1);
   }
 
-  // Copy files to target path
   if (targetPath && (json || includeTranscript)) {
     process.stderr.write(
       'Error: --json and --transcript are only supported when writing to stdout (omit <path>)\n',
@@ -730,55 +754,63 @@ async function handleExport(args: string[]): Promise<void> {
   if (targetPath) {
     targetPath = path.resolve(targetPath);
     fs.mkdirSync(targetPath, { recursive: true });
-    fs.copyFileSync(summaryPath, path.join(targetPath, 'summary.md'));
-    const transcriptPath = path.join(folderPath, 'transcript.md');
-    if (fs.existsSync(transcriptPath)) {
-      fs.copyFileSync(transcriptPath, path.join(targetPath, 'transcript.md'));
-    }
+    copyExportedFiles(folderPath, targetPath);
     process.stderr.write(`Exported to ${targetPath}\n`);
     return;
   }
 
-  // Output to stdout
-  const content = fs.readFileSync(summaryPath, 'utf-8');
-  const { meta, body } = parseFrontmatter(content);
-
   if (json) {
-    let customFields: Record<string, unknown> = {};
-    if (meta.customFields) {
-      try {
-        customFields =
-          typeof meta.customFields === 'string'
-            ? JSON.parse(meta.customFields as string)
-            : (meta.customFields as Record<string, unknown>);
-      } catch {
-        /* ignore */
-      }
+    const data = await readTranscription(folderPath);
+    if (!data) {
+      process.stderr.write(`Error: could not read transcription at ${folderPath}\n`);
+      process.exit(1);
     }
-    const liveNotes = parseLiveNotesField(meta.liveNotes);
-    const highlights = parseHighlightsField(meta.highlights);
     const obj: Record<string, unknown> = {
-      title: meta.title || '',
-      transcribedAt: meta.transcribedAt || '',
-      summary: meta.summary || '',
-      keyPoints: meta.keyPoints || [],
-      actionItems: meta.actionItems || [],
-      customFields,
-      ...(liveNotes ? { liveNotes } : {}),
-      ...(highlights ? { highlights } : {}),
+      title: data.title || '',
+      transcribedAt: data.transcribedAt || '',
+      summary: data.summary || '',
+      keyPoints: data.keyPoints ?? [],
+      actionItems: data.actionItems ?? [],
+      customFields: data.customFields ?? {},
+      ...(data.liveNotes ? { liveNotes: data.liveNotes } : {}),
+      ...(data.highlights ? { highlights: data.highlights } : {}),
     };
     if (includeTranscript) {
-      obj.transcript = meta.transcript || '';
+      obj.transcript = data.transcript || '';
     }
     process.stdout.write(`${JSON.stringify(obj, null, 2)}\n`);
   } else {
-    process.stdout.write(body);
+    const md = await renderV2Markdown(folderPath);
+    if (md === null) {
+      process.stderr.write(`Error: could not read transcription at ${folderPath}\n`);
+      process.exit(1);
+    }
+    process.stdout.write(md);
     if (includeTranscript) {
-      const transcriptPath = path.join(folderPath, 'transcript.md');
+      const transcriptPath = path.join(folderPath, TRANSCRIPT_FILE);
       if (fs.existsSync(transcriptPath)) {
         const transcriptContent = fs.readFileSync(transcriptPath, 'utf-8');
         process.stdout.write(`\n${transcriptContent}`);
       }
+    }
+  }
+}
+
+/** Whitelist known files so audio + ad-hoc artifacts stay local. */
+function copyExportedFiles(folderPath: string, targetPath: string): void {
+  const candidates = [
+    META_JSON,
+    SUMMARY_FILE,
+    KEY_POINTS_FILE,
+    ACTION_ITEMS_FILE,
+    TRANSCRIPT_FILE,
+    NOTES_JSON_FILE,
+    HIGHLIGHTS_JSON_FILE,
+  ];
+  for (const name of candidates) {
+    const src = path.join(folderPath, name);
+    if (fs.existsSync(src)) {
+      fs.copyFileSync(src, path.join(targetPath, name));
     }
   }
 }
@@ -1031,6 +1063,100 @@ async function handleAsk(args: string[]): Promise<void> {
   }
 }
 
+async function handleMigrate(args: string[]): Promise<void> {
+  let dryRun = false;
+  let all = false;
+  let ref: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    if (a === '--all') {
+      all = true;
+      continue;
+    }
+    if (a.startsWith('-')) {
+      process.stderr.write(`Error: Unknown option: ${a}\n`);
+      process.exit(1);
+    }
+    if (!ref) {
+      ref = a;
+      continue;
+    }
+    process.stderr.write(`Error: Unexpected argument: ${a}\n`);
+    process.exit(1);
+  }
+
+  if (!ref && !all) {
+    process.stderr.write(
+      'Error: Missing target. Usage: listener migrate <ref> | --all [--dry-run]\n',
+    );
+    process.exit(1);
+  }
+  if (ref && all) {
+    process.stderr.write('Error: pass either <ref> or --all, not both.\n');
+    process.exit(1);
+  }
+
+  const dataPath = getDataPath();
+  const targets: { folderPath: string; folderName: string }[] = [];
+  if (all) {
+    // Use a direct readdir, NOT `listTranscriptions`: the v2-only lister
+    // filters out folders without meta.json, which is exactly the set we
+    // want to migrate.
+    const transcriptionsDir = getTranscriptionsDir(dataPath);
+    let dirents: fs.Dirent[] = [];
+    try {
+      dirents = fs.readdirSync(transcriptionsDir, { withFileTypes: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+    for (const d of dirents) {
+      if (!d.isDirectory()) continue;
+      if (d.name.startsWith('.')) continue; // skip backup directories
+      const folderPath = path.join(transcriptionsDir, d.name);
+      targets.push({ folderPath, folderName: d.name });
+    }
+  } else {
+    const folderPath = await resolveRef(ref!, dataPath);
+    targets.push({ folderPath, folderName: path.basename(folderPath) });
+  }
+
+  let needsMigration = 0;
+  let alreadyV2 = 0;
+  let failed = 0;
+  for (const t of targets) {
+    if (isV2Folder(t.folderPath)) {
+      alreadyV2 += 1;
+      if (dryRun) process.stdout.write(`skip (already v2)  ${t.folderName}\n`);
+      continue;
+    }
+    if (dryRun) {
+      needsMigration += 1;
+      process.stdout.write(`would migrate      ${t.folderName}\n`);
+      continue;
+    }
+    try {
+      await migrateV1ToV2(t.folderPath);
+      needsMigration += 1;
+      process.stdout.write(`migrated           ${t.folderName}\n`);
+    } catch (err) {
+      failed += 1;
+      process.stderr.write(
+        `failed             ${t.folderName}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  const verb = dryRun ? 'to migrate' : 'migrated';
+  const summary = `${dryRun ? 'dry-run: ' : ''}${needsMigration} ${verb}, ${alreadyV2} skipped, ${failed} failed (of ${targets.length} total).\n`;
+  process.stderr.write(summary);
+  if (failed > 0) process.exit(1);
+}
+
 async function handleUsage(args: string[]): Promise<void> {
   let month: string | undefined;
   let asJson = false;
@@ -1207,6 +1333,26 @@ async function main(): Promise<void> {
     usageError();
   }
 
+  // One-shot v1 -> v2 migration is the runtime's responsibility on every
+  // entry point. Skip for commands that don't touch the transcriptions dir
+  // (`config`, `codex`, `google login/logout/status`) so we don't pay the
+  // dir-scan when it's irrelevant. Also skip when `LISTENER_SKIP_AUTO_MIGRATE`
+  // is set -- the migrate-command tests use this to drive the explicit
+  // `listener migrate` flow on un-migrated fixtures.
+  if (
+    !COMMANDS_WITHOUT_DATA_ACCESS.has(args[0]) &&
+    !process.env.LISTENER_SKIP_AUTO_MIGRATE
+  ) {
+    try {
+      await autoMigrateLegacyOnStartup(getDataPath());
+    } catch (err) {
+      process.stderr.write(
+        `Error: legacy migration failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+  }
+
   if (args[0] === 'config') {
     handleConfig(args.slice(1));
     return;
@@ -1259,6 +1405,11 @@ async function main(): Promise<void> {
 
   if (args[0] === 'usage') {
     await handleUsage(args.slice(1));
+    return;
+  }
+
+  if (args[0] === 'migrate') {
+    await handleMigrate(args.slice(1));
     return;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -463,9 +463,7 @@ app.whenReady().then(async () => {
       );
     }
     // Clean up backup directories older than 30 days. Best-effort; never fatal.
-    gcLegacyBackups(getDataPath()).catch((err) =>
-      console.warn('[migrate] backup GC failed:', err),
-    );
+    gcLegacyBackups(getDataPath()).catch((err) => console.warn('[migrate] backup GC failed:', err));
   } catch (err) {
     console.error('[migrate] startup migration failed:', err);
     const message =

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,9 @@ import { MeetingDetectorService } from './meetingDetectorService';
 import { MenuBarManager } from './menuBarManager';
 import { NotionService } from './notionService';
 import {
+  autoMigrateLegacyOnStartup,
   formatTimestamp,
+  gcLegacyBackups,
   getTranscriptionsDir,
   type LiveNote,
   readTranscription,
@@ -442,7 +444,45 @@ function createWindow() {
   });
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  // Run the one-shot v1 -> v2 transcription folder migration BEFORE anything
+  // else can touch the transcriptions directory (window creation, Drive sync
+  // timer, recording watcher). A partial migration would leave some folders
+  // v1 (unreadable to the v2-only runtime) and others v2 -- so on failure we
+  // log + show a dialog + quit rather than proceed with broken state.
+  try {
+    const result = await autoMigrateLegacyOnStartup(getDataPath(), {
+      onProgress: (current, total, name) => {
+        console.log(`[migrate] (${current}/${total}) ${name}`);
+      },
+    });
+    if (result.migrated.length > 0) {
+      console.log(
+        `[migrate] Migrated ${result.migrated.length} legacy meeting${result.migrated.length === 1 ? '' : 's'} to v2.` +
+          ` Backup: ${result.backupDir}`,
+      );
+    }
+    // Clean up backup directories older than 30 days. Best-effort; never fatal.
+    gcLegacyBackups(getDataPath()).catch((err) =>
+      console.warn('[migrate] backup GC failed:', err),
+    );
+  } catch (err) {
+    console.error('[migrate] startup migration failed:', err);
+    const message =
+      err instanceof Error
+        ? err.message
+        : 'Unknown error converting your transcriptions to the new layout.';
+    dialog.showErrorBox(
+      'Listener.AI could not start',
+      `Migrating your existing meetings to the new storage layout failed:\n\n${message}\n\n` +
+        `Your original files are backed up under ${getDataPath()}/.v1-backup-<timestamp>/ ` +
+        `(if the backup step completed). The app will now quit. ` +
+        `Please report this to the maintainer.`,
+    );
+    app.quit();
+    return;
+  }
+
   // Create menu with DevTools option
   const template = [
     {

--- a/src/outputService.test.ts
+++ b/src/outputService.test.ts
@@ -4,11 +4,29 @@ import { after, describe, it } from 'node:test';
 import * as path from 'path';
 import type { TranscriptionResult } from './geminiService';
 import {
+  ACTION_ITEMS_FILE,
+  HIGHLIGHTS_JSON_FILE,
+  KEY_POINTS_FILE,
+  META_JSON,
+  NOTES_JSON_FILE,
+  SUMMARY_FILE,
+  TRANSCRIPT_FILE,
+  __saveTranscriptionLegacyV1ForTests,
+  autoMigrateLegacyOnStartup,
   formatSummary,
+  formatV2Timestamp,
+  gcLegacyBackups,
+  getTranscriptionsDir,
+  isV2Folder,
+  listTranscriptions,
+  migrateV1ToV2,
+  parseBullets,
   parseFrontmatter,
   readTranscription,
   sanitizeForPath,
+  sanitizeV2Title,
   saveTranscription,
+  splitV2FolderName,
   updateTranscriptionStatus,
 } from './outputService';
 import { makeTempDir, rmDir } from './test-helpers';
@@ -286,5 +304,654 @@ describe('sanitizeForPath', () => {
 
   it('collapses repeated whitespace', () => {
     assert.equal(sanitizeForPath('hello    world'), 'hello world');
+  });
+});
+
+// ---------- v2 layout suite ----------
+
+describe('v2 folder naming primitives', () => {
+  it('formatV2Timestamp produces a 24-char filesystem-safe ISO stamp', () => {
+    const ts = formatV2Timestamp(new Date('2026-05-20T10:30:15.123Z'));
+    assert.equal(ts, '2026-05-20T10-30-15.123Z');
+    assert.equal(ts.length, 24);
+  });
+
+  it('splitV2FolderName parses a v2 folder name', () => {
+    const split = splitV2FolderName('2026-05-20T10-30-15.123Z_Team_Meeting');
+    assert.deepEqual(split, { ts: '2026-05-20T10-30-15.123Z', title: 'Team_Meeting' });
+  });
+
+  it('splitV2FolderName rejects v1-style folder names', () => {
+    assert.equal(splitV2FolderName('Team_Meeting_20260520_103015'), null);
+  });
+
+  it('sanitizeV2Title strips filesystem-forbidden characters', () => {
+    assert.equal(sanitizeV2Title('LG : meeting / part 1?'), 'LG_meeting_part_1');
+  });
+
+  it('sanitizeV2Title preserves Korean characters and length-caps', () => {
+    assert.equal(sanitizeV2Title('Q3 로드맵 논의'), 'Q3_로드맵_논의');
+    assert.ok(sanitizeV2Title('x'.repeat(500)).length <= 100);
+  });
+
+  it('sanitizeV2Title falls back to "meeting" on empty input', () => {
+    assert.equal(sanitizeV2Title(''), 'meeting');
+    assert.equal(sanitizeV2Title('   '), 'meeting');
+  });
+
+  it('parseBullets strips the "- " prefix and ignores other lines', () => {
+    const text = '- first item\n- second item\nstray line\n- third item';
+    assert.deepEqual(parseBullets(text), ['first item', 'second item', 'third item']);
+  });
+});
+
+describe('saveTranscription v2 default', () => {
+  it('writes the v2 layout, not v1', () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'V2 Meeting',
+      result: baseResult,
+      dataPath,
+    });
+
+    assert.ok(isV2Folder(folderPath), 'folder should be v2');
+    assert.ok(fs.existsSync(path.join(folderPath, META_JSON)));
+    assert.ok(fs.existsSync(path.join(folderPath, SUMMARY_FILE)));
+    assert.ok(fs.existsSync(path.join(folderPath, TRANSCRIPT_FILE)));
+
+    // summary.md must be plain markdown -- no YAML frontmatter on the v2 path.
+    const summary = fs.readFileSync(path.join(folderPath, SUMMARY_FILE), 'utf-8');
+    assert.ok(!summary.startsWith('---'), 'v2 summary.md must not start with frontmatter');
+    assert.equal(summary.trim(), 'A short greeting.');
+
+    // transcript.md drops the "# title" heading too.
+    const transcript = fs.readFileSync(path.join(folderPath, TRANSCRIPT_FILE), 'utf-8');
+    assert.equal(transcript.trim(), 'Speaker A: hello.\nSpeaker B: hi.');
+    assert.ok(!transcript.startsWith('# '), 'v2 transcript.md should have no `# title` heading');
+  });
+
+  it('folder name follows the v2 naming scheme', () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Team Meeting',
+      result: baseResult,
+      dataPath,
+      now: new Date('2026-05-20T10:30:15.123Z'),
+    });
+    assert.equal(path.basename(folderPath), '2026-05-20T10-30-15.123Z_Team_Meeting');
+  });
+
+  it('bumps the timestamp ms on folder-name collision', () => {
+    const dataPath = makeTmpDataPath();
+    const ts = new Date('2026-05-20T10:30:15.123Z');
+    const a = saveTranscription({ title: 'Same', result: baseResult, dataPath, now: ts });
+    const b = saveTranscription({ title: 'Same', result: baseResult, dataPath, now: ts });
+    assert.notEqual(path.basename(a), path.basename(b));
+  });
+
+  it('round-trips through readTranscription (mergedFrom + keyPoints + actionItems)', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Combined Meeting',
+      result: baseResult,
+      dataPath,
+      mergedFrom: ['Part_One', 'Part_Two'],
+    });
+
+    const data = await readTranscription(folderPath);
+    assert.ok(data);
+    assert.equal(data!.title, 'Combined Meeting');
+    assert.equal(data!.summary, 'A short greeting.');
+    assert.deepEqual(data!.keyPoints, ['Greeting exchanged']);
+    assert.deepEqual(data!.actionItems, ['Schedule follow-up']);
+    assert.deepEqual(data!.mergedFrom, ['Part_One', 'Part_Two']);
+    assert.equal(data!.transcript, 'Speaker A: hello.\nSpeaker B: hi.');
+  });
+
+  it('omits optional files when fields are empty', () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Minimal',
+      result: {
+        transcript: 'just a transcript',
+        summary: '',
+        keyPoints: [],
+        actionItems: [],
+        emoji: '',
+      },
+      dataPath,
+    });
+
+    assert.ok(!fs.existsSync(path.join(folderPath, KEY_POINTS_FILE)));
+    assert.ok(!fs.existsSync(path.join(folderPath, ACTION_ITEMS_FILE)));
+    assert.ok(!fs.existsSync(path.join(folderPath, NOTES_JSON_FILE)));
+    assert.ok(!fs.existsSync(path.join(folderPath, HIGHLIGHTS_JSON_FILE)));
+  });
+
+  it('writes liveNotes + highlights as separate JSON files', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Rich',
+      result: {
+        ...baseResult,
+        highlights: [
+          {
+            offsetMs: 8000,
+            userText: 'now',
+            subtitle: 'intro',
+            bullets: ['point one'],
+          },
+        ],
+      },
+      dataPath,
+      liveNotes: [{ offsetMs: 8000, text: 'now' }],
+    });
+
+    assert.ok(fs.existsSync(path.join(folderPath, NOTES_JSON_FILE)));
+    assert.ok(fs.existsSync(path.join(folderPath, HIGHLIGHTS_JSON_FILE)));
+
+    const data = await readTranscription(folderPath);
+    assert.deepEqual(data!.liveNotes, [{ offsetMs: 8000, text: 'now' }]);
+    assert.equal(data!.highlights!.length, 1);
+    assert.equal(data!.highlights![0].subtitle, 'intro');
+  });
+
+  it('normalizes multi-line bullets so they survive a round-trip', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'MultiLine',
+      result: {
+        ...baseResult,
+        keyPoints: ['line one\n  continued on line two', 'second item'],
+      },
+      dataPath,
+    });
+    const data = await readTranscription(folderPath);
+    assert.deepEqual(data!.keyPoints, ['line one continued on line two', 'second item']);
+  });
+});
+
+describe('updateTranscriptionStatus on v2 folders', () => {
+  it('writes Notion URL and Slack timestamp into meta.json', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'V2 Status',
+      result: baseResult,
+      dataPath,
+    });
+
+    const summaryBefore = fs.readFileSync(path.join(folderPath, SUMMARY_FILE), 'utf-8');
+
+    await updateTranscriptionStatus(folderPath, {
+      notionPageUrl: 'https://www.notion.so/abc',
+      slackSentAt: '2026-04-30T09:30:00Z',
+    });
+
+    // summary.md must not be touched -- only meta.json holds tracking state.
+    const summaryAfter = fs.readFileSync(path.join(folderPath, SUMMARY_FILE), 'utf-8');
+    assert.equal(summaryAfter, summaryBefore, 'summary.md should not change on status update');
+
+    const meta = JSON.parse(fs.readFileSync(path.join(folderPath, META_JSON), 'utf-8'));
+    assert.equal(meta.exports.notion.pageUrl, 'https://www.notion.so/abc');
+    assert.equal(meta.exports.slack.sentAt, '2026-04-30T09:30:00Z');
+
+    const data = await readTranscription(folderPath);
+    assert.equal(data!.notionPageUrl, 'https://www.notion.so/abc');
+    assert.equal(data!.slackSentAt, '2026-04-30T09:30:00Z');
+  });
+
+  it('clears slackError when passed null', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'V2 Clear',
+      result: baseResult,
+      dataPath,
+    });
+
+    await updateTranscriptionStatus(folderPath, {
+      slackSentAt: '2026-04-30T09:30:00Z',
+      slackError: 'transient failure',
+    });
+    let data = await readTranscription(folderPath);
+    assert.equal(data!.slackError, 'transient failure');
+
+    await updateTranscriptionStatus(folderPath, { slackError: null });
+    data = await readTranscription(folderPath);
+    assert.equal(data!.slackError, undefined);
+    assert.equal(data!.slackSentAt, '2026-04-30T09:30:00Z');
+  });
+
+  it('preserves liveNotes across a status write (file unchanged)', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'V2 LiveNotes',
+      result: baseResult,
+      dataPath,
+      liveNotes: [{ offsetMs: 1000, text: 'first' }],
+    });
+
+    const notesBefore = fs.readFileSync(path.join(folderPath, NOTES_JSON_FILE), 'utf-8');
+
+    await updateTranscriptionStatus(folderPath, {
+      notionPageUrl: 'https://www.notion.so/x',
+    });
+
+    const notesAfter = fs.readFileSync(path.join(folderPath, NOTES_JSON_FILE), 'utf-8');
+    assert.equal(notesAfter, notesBefore, 'notes.json should be untouched');
+
+    const data = await readTranscription(folderPath);
+    assert.deepEqual(data!.liveNotes, [{ offsetMs: 1000, text: 'first' }]);
+    assert.equal(data!.notionPageUrl, 'https://www.notion.so/x');
+  });
+});
+
+describe('v1 fixtures round-trip through migration', () => {
+  it('a v1 fixture migrated to v2 reads back identically', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = __saveTranscriptionLegacyV1ForTests({
+      title: 'Legacy Meeting',
+      result: baseResult,
+      dataPath,
+    });
+    assert.ok(!isV2Folder(folderPath));
+
+    await migrateV1ToV2(folderPath);
+
+    const data = await readTranscription(folderPath);
+    assert.ok(data);
+    assert.equal(data!.title, 'Legacy Meeting');
+    assert.equal(data!.summary, 'A short greeting.');
+    assert.deepEqual(data!.keyPoints, ['Greeting exchanged']);
+    assert.deepEqual(data!.actionItems, ['Schedule follow-up']);
+    assert.equal(data!.transcript, 'Speaker A: hello.\nSpeaker B: hi.');
+  });
+
+  it('listTranscriptions returns v2 folders after migration', async () => {
+    const dataPath = makeTmpDataPath();
+
+    __saveTranscriptionLegacyV1ForTests({
+      title: 'Legacy A',
+      result: { ...baseResult, suggestedTitle: 'A' },
+      dataPath,
+    });
+    saveTranscription({
+      title: 'V2 B',
+      result: { ...baseResult, suggestedTitle: 'B' },
+      dataPath,
+    });
+
+    // Auto-migrate brings the v1 fixture up to v2 so the runtime reader sees it.
+    await autoMigrateLegacyOnStartup(dataPath);
+
+    const entries = await listTranscriptions(dataPath, 0);
+    assert.equal(entries.length, 2);
+    const titles = entries.map((e) => e.title).sort();
+    assert.deepEqual(titles, ['Legacy A', 'V2 B']);
+    for (const e of entries) assert.ok(e.transcribedAt, `each entry must have a transcribedAt`);
+  });
+});
+
+describe('migrateV1ToV2', () => {
+  it('migrates a v1 folder in-place and is idempotent', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = __saveTranscriptionLegacyV1ForTests({
+      title: 'Migrate Me',
+      result: {
+        ...baseResult,
+        customFields: { decisions: ['ship it'] },
+      },
+      audioFilePath: '/tmp/migrate.webm',
+      dataPath,
+      liveNotes: [{ offsetMs: 1000, text: 'remember this' }],
+    });
+    assert.ok(!isV2Folder(folderPath));
+
+    // Round 1: actually migrates.
+    const changed1 = await migrateV1ToV2(folderPath);
+    assert.equal(changed1, true);
+    assert.ok(isV2Folder(folderPath));
+    assert.ok(fs.existsSync(path.join(folderPath, META_JSON)));
+    assert.ok(fs.existsSync(path.join(folderPath, NOTES_JSON_FILE)));
+
+    // Round 2: idempotent.
+    const changed2 = await migrateV1ToV2(folderPath);
+    assert.equal(changed2, false);
+
+    // Data survives.
+    const data = await readTranscription(folderPath);
+    assert.equal(data!.title, 'Migrate Me');
+    assert.equal(data!.summary, 'A short greeting.');
+    assert.deepEqual(data!.keyPoints, ['Greeting exchanged']);
+    assert.deepEqual(data!.actionItems, ['Schedule follow-up']);
+    assert.equal(data!.transcript, 'Speaker A: hello.\nSpeaker B: hi.');
+    assert.equal(data!.audioFilePath, '/tmp/migrate.webm');
+    assert.deepEqual(data!.customFields, { decisions: ['ship it'] });
+    assert.deepEqual(data!.liveNotes, [{ offsetMs: 1000, text: 'remember this' }]);
+  });
+
+  it('carries Notion URL and Slack sentAt forward into v2 exports', async () => {
+    const dataPath = makeTmpDataPath();
+    // Hand-craft a v1 folder that already has notionPageUrl + slackSentAt in
+    // its frontmatter (simulating a previously-published meeting). We can't
+    // route through updateTranscriptionStatus anymore because that's v2-only.
+    const folderPath = __saveTranscriptionLegacyV1ForTests({
+      title: 'Already Published',
+      result: baseResult,
+      dataPath,
+    });
+    const summaryPath = path.join(folderPath, 'summary.md');
+    const original = fs.readFileSync(summaryPath, 'utf-8');
+    const patched = original.replace(
+      /^---\n/,
+      `---\nnotionPageUrl: "https://www.notion.so/published"\nslackSentAt: "2026-04-30T09:30:00Z"\n`,
+    );
+    fs.writeFileSync(summaryPath, patched, 'utf-8');
+
+    const changed = await migrateV1ToV2(folderPath);
+    assert.equal(changed, true);
+
+    const meta = JSON.parse(fs.readFileSync(path.join(folderPath, META_JSON), 'utf-8'));
+    assert.equal(meta.exports.notion.pageUrl, 'https://www.notion.so/published');
+    assert.equal(meta.exports.slack.sentAt, '2026-04-30T09:30:00Z');
+  });
+
+  it('does not destroy transcript content when frontmatter transcript was empty', async () => {
+    const dataPath = makeTmpDataPath();
+    // Build a folder where summary.md has no `transcript:` field but
+    // transcript.md still has content. Mimics a hand-edited corruption.
+    const folderPath = __saveTranscriptionLegacyV1ForTests({
+      title: 'Recover',
+      result: { ...baseResult, transcript: '' }, // empty frontmatter transcript
+      dataPath,
+    });
+    fs.writeFileSync(
+      path.join(folderPath, 'transcript.md'),
+      '# Recover\n\nrescued transcript content\n',
+      'utf-8',
+    );
+
+    await migrateV1ToV2(folderPath);
+    const data = await readTranscription(folderPath);
+    assert.equal(data!.transcript, 'rescued transcript content');
+  });
+});
+
+describe('listTranscriptions ordering', () => {
+  it('sorts by transcribedAt descending after a mixed v1/v2 dir is migrated', async () => {
+    const dataPath = makeTmpDataPath();
+
+    saveTranscription({
+      title: 'Newest',
+      result: baseResult,
+      dataPath,
+      now: new Date('2026-05-22T10:00:00.000Z'),
+    });
+    saveTranscription({
+      title: 'Middle',
+      result: baseResult,
+      dataPath,
+      now: new Date('2026-05-21T10:00:00.000Z'),
+    });
+    // Legacy folder dated by its formatTimestamp (now) -- will sort by its real time.
+    __saveTranscriptionLegacyV1ForTests({
+      title: 'OldestLegacy',
+      result: baseResult,
+      dataPath,
+    });
+
+    // Bring the v1 fixture forward; listTranscriptions only sees v2 folders.
+    await autoMigrateLegacyOnStartup(dataPath);
+
+    const entries = await listTranscriptions(dataPath, 0);
+    assert.equal(entries.length, 3);
+    // V2 entries are dated 2026-05-22 and 2026-05-21; the legacy fixture uses
+    // `new Date().toISOString()` for its transcribedAt, so its position
+    // depends on the real-world clock. Pin only the v2 ordering and the
+    // legacy entry's presence.
+    const v2Order = entries.filter((e) => e.title !== 'OldestLegacy').map((e) => e.title);
+    assert.deepEqual(v2Order, ['Newest', 'Middle']);
+    assert.ok(entries.some((e) => e.title === 'OldestLegacy'));
+  });
+});
+
+describe('autoMigrateLegacyOnStartup', () => {
+  it('returns empty result when there is no transcriptions/ dir', async () => {
+    const dataPath = makeTmpDataPath();
+    const r = await autoMigrateLegacyOnStartup(dataPath);
+    assert.deepEqual(r, { migrated: [], alreadyV2: 0 });
+  });
+
+  it('returns empty result when there are no v1 folders', async () => {
+    const dataPath = makeTmpDataPath();
+    saveTranscription({ title: 'V2', result: baseResult, dataPath });
+    const r = await autoMigrateLegacyOnStartup(dataPath);
+    assert.equal(r.migrated.length, 0);
+    assert.equal(r.alreadyV2, 1);
+    assert.equal(r.backupDir, undefined);
+  });
+
+  it('migrates every v1 folder and writes a backup outside transcriptions/', async () => {
+    const dataPath = makeTmpDataPath();
+    const v1a = __saveTranscriptionLegacyV1ForTests({
+      title: 'Legacy A',
+      result: baseResult,
+      dataPath,
+    });
+    const v1b = __saveTranscriptionLegacyV1ForTests({
+      title: 'Legacy B',
+      result: baseResult,
+      dataPath,
+    });
+    saveTranscription({ title: 'New V2', result: baseResult, dataPath });
+
+    const r = await autoMigrateLegacyOnStartup(dataPath);
+    assert.equal(r.migrated.length, 2);
+    assert.equal(r.alreadyV2, 1);
+    assert.ok(r.backupDir);
+
+    // Both legacy folders are now v2 (meta.json present)
+    assert.ok(isV2Folder(v1a));
+    assert.ok(isV2Folder(v1b));
+
+    // Backup lives OUTSIDE transcriptions/ so Drive sync won't see it.
+    assert.ok(r.backupDir!.startsWith(dataPath));
+    assert.ok(!r.backupDir!.startsWith(getTranscriptionsDir(dataPath)));
+
+    // Backup contains the original summary.md per legacy folder.
+    for (const folderName of r.migrated) {
+      assert.ok(
+        fs.existsSync(path.join(r.backupDir!, folderName, 'summary.md')),
+        `backup should include summary.md for ${folderName}`,
+      );
+    }
+  });
+
+  it('snapshot contains v1 frontmatter (recoverable)', async () => {
+    const dataPath = makeTmpDataPath();
+    const v1 = __saveTranscriptionLegacyV1ForTests({
+      title: 'Recoverable',
+      result: baseResult,
+      dataPath,
+    });
+
+    const r = await autoMigrateLegacyOnStartup(dataPath);
+    assert.ok(r.backupDir);
+
+    const backupSummary = fs.readFileSync(
+      path.join(r.backupDir!, path.basename(v1), 'summary.md'),
+      'utf-8',
+    );
+    // Original v1 summary.md had YAML frontmatter
+    assert.match(backupSummary, /^---\n/);
+    assert.match(backupSummary, /title:/);
+  });
+
+  it('is idempotent (no-op on second run)', async () => {
+    const dataPath = makeTmpDataPath();
+    __saveTranscriptionLegacyV1ForTests({
+      title: 'Once',
+      result: baseResult,
+      dataPath,
+    });
+
+    const r1 = await autoMigrateLegacyOnStartup(dataPath);
+    assert.equal(r1.migrated.length, 1);
+
+    const r2 = await autoMigrateLegacyOnStartup(dataPath);
+    assert.equal(r2.migrated.length, 0);
+    assert.equal(r2.alreadyV2, 1);
+  });
+
+  it('ignores prior .v1-backup-* directories during scan', async () => {
+    const dataPath = makeTmpDataPath();
+    // Manually drop a `.v1-backup-...` directory inside transcriptions/ to be
+    // sure the scan doesn't try to migrate it. (Normally the backup lives at
+    // the data-path root, not inside transcriptions/, but we guard anyway.)
+    const decoyBackup = path.join(getTranscriptionsDir(dataPath), '.v1-backup-decoy');
+    fs.mkdirSync(decoyBackup, { recursive: true });
+    fs.writeFileSync(path.join(decoyBackup, 'summary.md'), 'decoy\n', 'utf-8');
+
+    __saveTranscriptionLegacyV1ForTests({ title: 'Real', result: baseResult, dataPath });
+
+    const r = await autoMigrateLegacyOnStartup(dataPath);
+    assert.equal(r.migrated.length, 1);
+    assert.ok(r.migrated[0].includes('Real'));
+  });
+
+  it('preserves data through migration (round-trips via readTranscription)', async () => {
+    const dataPath = makeTmpDataPath();
+    const v1 = __saveTranscriptionLegacyV1ForTests({
+      title: 'Round Trip',
+      result: {
+        ...baseResult,
+        customFields: { decisions: ['ship it'] },
+      },
+      dataPath,
+      liveNotes: [{ offsetMs: 2000, text: 'note' }],
+    });
+
+    await autoMigrateLegacyOnStartup(dataPath);
+
+    const data = await readTranscription(v1);
+    assert.equal(data!.title, 'Round Trip');
+    assert.equal(data!.summary, baseResult.summary);
+    assert.deepEqual(data!.keyPoints, baseResult.keyPoints);
+    assert.deepEqual(data!.actionItems, baseResult.actionItems);
+    assert.deepEqual(data!.customFields, { decisions: ['ship it'] });
+    assert.deepEqual(data!.liveNotes, [{ offsetMs: 2000, text: 'note' }]);
+  });
+});
+
+describe('gcLegacyBackups', () => {
+  it('returns 0 when there are no backups', async () => {
+    const dataPath = makeTmpDataPath();
+    assert.equal(await gcLegacyBackups(dataPath), 0);
+  });
+
+  it('preserves recent backups, deletes old ones', async () => {
+    const dataPath = makeTmpDataPath();
+    const recent = path.join(dataPath, '.v1-backup-recent');
+    const stale = path.join(dataPath, '.v1-backup-stale');
+    fs.mkdirSync(recent, { recursive: true });
+    fs.mkdirSync(stale, { recursive: true });
+    // Force stale's mtime to 60 days ago.
+    const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(stale, sixtyDaysAgo, sixtyDaysAgo);
+
+    const removed = await gcLegacyBackups(dataPath, 30);
+    assert.equal(removed, 1);
+    assert.ok(fs.existsSync(recent), 'recent backup should survive');
+    assert.ok(!fs.existsSync(stale), 'stale backup should be removed');
+  });
+
+  it('ignores non-backup directories', async () => {
+    const dataPath = makeTmpDataPath();
+    const transcriptions = getTranscriptionsDir(dataPath);
+    fs.mkdirSync(transcriptions, { recursive: true });
+    const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(transcriptions, sixtyDaysAgo, sixtyDaysAgo);
+
+    await gcLegacyBackups(dataPath, 30);
+    assert.ok(fs.existsSync(transcriptions), 'transcriptions/ must be untouched');
+  });
+});
+
+describe('migrate crash-safety and corruption recovery', () => {
+  it('detects and migrates a v1 folder whose name matches the v2 timestamp pattern', async () => {
+    // Create a normal v1 fixture, then rename its folder so the slug starts
+    // with a 24-char ISO timestamp prefix (a v2-shaped name without meta.json).
+    const dataPath = makeTmpDataPath();
+    const v1OriginalPath = __saveTranscriptionLegacyV1ForTests({
+      title: 'Renamed v1',
+      result: baseResult,
+      dataPath,
+    });
+    const v2ShapedName = '2026-05-20T10-30-15.123Z_Renamed_v1';
+    const v2ShapedPath = path.join(getTranscriptionsDir(dataPath), v2ShapedName);
+    fs.renameSync(v1OriginalPath, v2ShapedPath);
+
+    const r = await autoMigrateLegacyOnStartup(dataPath);
+    assert.equal(r.migrated.length, 1, 'name-matches-v2 v1 folder must still be migrated');
+    assert.ok(isV2Folder(v2ShapedPath), 'folder must end up v2');
+
+    const data = await readTranscription(v2ShapedPath);
+    assert.equal(data!.title, 'Renamed v1');
+    assert.equal(data!.summary, baseResult.summary);
+  });
+
+  it('recovers from .v1-bak siblings left by a previous crashed migration', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = __saveTranscriptionLegacyV1ForTests({
+      title: 'Crash Recovery',
+      result: baseResult,
+      dataPath,
+    });
+
+    // Simulate the on-disk state after a mid-migration crash: v1 summary/transcript
+    // renamed to `.v1-bak`, body files replaced with empty v2-shaped scaffold,
+    // meta.json never landed.
+    const summary = path.join(folderPath, 'summary.md');
+    const transcript = path.join(folderPath, 'transcript.md');
+    fs.renameSync(summary, `${summary}.v1-bak`);
+    fs.renameSync(transcript, `${transcript}.v1-bak`);
+    fs.writeFileSync(summary, '', 'utf-8'); // half-written v2 summary
+    fs.writeFileSync(transcript, '', 'utf-8');
+
+    // migrateV1ToV2 should detect the .v1-bak siblings, restore originals,
+    // then complete the migration cleanly.
+    const changed = await migrateV1ToV2(folderPath);
+    assert.equal(changed, true);
+    assert.ok(isV2Folder(folderPath));
+    assert.ok(!fs.existsSync(`${summary}.v1-bak`), '.v1-bak must be cleaned up after success');
+    assert.ok(!fs.existsSync(`${transcript}.v1-bak`));
+
+    const data = await readTranscription(folderPath);
+    assert.equal(data!.title, 'Crash Recovery');
+    assert.equal(data!.summary, baseResult.summary);
+    assert.equal(data!.transcript, baseResult.transcript);
+  });
+
+  it('writes meta.json atomically (write-to-tmp + rename, no .tmp leftover)', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Atomic Meta',
+      result: baseResult,
+      dataPath,
+    });
+    assert.ok(!fs.existsSync(path.join(folderPath, 'meta.json.tmp')));
+    assert.ok(fs.existsSync(path.join(folderPath, 'meta.json')));
+  });
+
+  it('readTranscription returns null (not throws) on corrupt meta.json', async () => {
+    const dataPath = makeTmpDataPath();
+    const folderPath = saveTranscription({
+      title: 'Corrupt',
+      result: baseResult,
+      dataPath,
+    });
+    // Truncate meta.json to invalid JSON.
+    fs.writeFileSync(path.join(folderPath, 'meta.json'), '{ not valid json', 'utf-8');
+    const data = await readTranscription(folderPath);
+    assert.equal(data, null, 'corrupt meta.json must yield null, not throw');
   });
 });

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -1231,7 +1231,12 @@ export async function autoMigrateLegacyOnStartup(
   let alreadyV2 = 0;
   for (const d of dirents) {
     if (!d.isDirectory()) continue;
-    if (d.name.startsWith('.')) continue; // skip prior backup directories
+    // Skip dotfile-prefixed dirs. `.v1-backup-*` lives at the data-path root
+    // (not here), but a misplaced backup, restored-archive artifact, or stray
+    // OS dir (e.g. `.fseventsd`) would otherwise try to migrate, fail to read
+    // a v1 summary.md, and abort startup. The app itself never produces
+    // dot-prefixed meeting folder names, so this is purely defensive.
+    if (d.name.startsWith('.')) continue;
     const folderPath = path.join(transcriptionsDir, d.name);
     if (isV2Folder(folderPath)) {
       alreadyV2 += 1;

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -44,6 +44,149 @@ export function formatTimestamp(): string {
   return `${y}${m}${d}_${h}${min}${s}`;
 }
 
+// ---------- v2 storage layout ----------
+//
+// v2 folder layout (one file per semantic field, no frontmatter, no duplication):
+//   <ts24>_<title>/
+//     meta.json           structured metadata (always present)
+//     summary.md          plain summary text (no headings, no frontmatter)
+//     key-points.md       bullet list (`- item` per line)
+//     action-items.md     bullet list
+//     transcript.md       plain transcript text (no `# title` heading)
+//     notes.json          live notes (optional)
+//     highlights.json     AI-enriched highlights (optional)
+//     <audio file>        original recording (optional, path stored in meta)
+//
+// v1 (legacy) layout is one summary.md with YAML frontmatter + rendered body
+// plus a transcript.md. v1 folders are detected by absence of meta.json and
+// are read/updated through the original code paths.
+
+export const META_JSON = 'meta.json';
+export const SUMMARY_FILE = 'summary.md';
+export const KEY_POINTS_FILE = 'key-points.md';
+export const ACTION_ITEMS_FILE = 'action-items.md';
+export const TRANSCRIPT_FILE = 'transcript.md';
+export const NOTES_JSON_FILE = 'notes.json';
+export const HIGHLIGHTS_JSON_FILE = 'highlights.json';
+
+export const META_SCHEMA_VERSION = 1;
+
+/** Prefix used for the per-startup v1->v2 migration backup directory.
+ * Lives at the data-path root (not under transcriptions/) so Drive sync
+ * never sees it. Garbage-collected by `gcLegacyBackups`. */
+export const V1_BACKUP_DIR_PREFIX = '.v1-backup-';
+
+/** Suffix used for in-folder v1 snapshots during migration. The v1
+ * summary.md / transcript.md are renamed to `<file>.v1-bak` so the
+ * destructive v2 writes can't lose data on crash; the originals are
+ * restored by `restoreV1BakIfPresent` if a retry finds them lingering. */
+const V1_BAK_SUFFIX = '.v1-bak';
+
+/** Files that `migrateV1ToV2` destructively overwrites; the per-folder
+ * crash-recovery + backup logic both iterate this list. */
+const V1_BAK_FILES = [SUMMARY_FILE, TRANSCRIPT_FILE] as const;
+
+/** Persisted shape of meta.json. Unknown keys are preserved on read/write. */
+export interface MeetingMetaV2 {
+  schemaVersion: number;
+  title: string;
+  suggestedTitle?: string;
+  emoji?: string;
+  transcribedAt: string; // canonical ISO 8601 UTC, e.g. 2026-05-20T10:30:15.123Z
+  audioFile?: string; // absolute path (kept compatible with v1.audioFilePath)
+  cost?: CostSnapshot;
+  customFields?: Record<string, unknown>;
+  merge?: { sourceIds: string[] };
+  exports?: {
+    notion?: { pageUrl: string; uploadedAt?: string };
+    slack?: { sentAt?: string; error?: string | null };
+  };
+  // Forward-compat: writers preserve unknown keys.
+  [unknownKey: string]: unknown;
+}
+
+/**
+ * Format the current time as a 24-character filesystem-safe ISO 8601 UTC stamp.
+ * Layout: YYYY-MM-DDTHH-MM-SS.mmmZ -- the `:` separators are replaced with `-`
+ * so the string is usable as a folder-name component on macOS/Windows/Linux.
+ * The total length is always 24 chars, which is exploited by `splitV2FolderName`.
+ */
+export function formatV2Timestamp(date: Date = new Date()): string {
+  // Date#toISOString -> 2026-05-20T10:30:15.123Z. Replace `:` (forbidden on
+  // Windows, awkward on macOS APFS exports) with `-`.
+  return date.toISOString().replace(/:/g, '-');
+}
+
+/** Sanitize a user-supplied title for use inside a folder-name component. */
+export function sanitizeV2Title(raw: string): string {
+  let s = raw.normalize('NFC');
+  // Filesystem-forbidden characters
+  s = s.replace(/[\/\\:*?"<>|]/g, '_');
+  // NUL byte handled via string split to dodge oxlint no-control-regex
+  s = s.split('\u0000').join('_');
+  // Collapse all whitespace runs to single underscore
+  s = s.replace(/\s+/g, '_');
+  // Collapse runs of underscores produced by adjacent replacements into one
+  s = s.replace(/_+/g, '_');
+  // Strip leading/trailing dots (Windows quirk) and underscores
+  s = s.replace(/^[._]+/, '').replace(/[._]+$/, '');
+  // Hard cap to keep the full folder name under platform limits
+  if (s.length > 100) s = s.slice(0, 100).replace(/_+$/, '');
+  // Last-ditch fallback so the folder name is never just the timestamp
+  return s.length > 0 ? s : 'meeting';
+}
+
+/**
+ * Split a v2 folder name into its timestamp prefix and title suffix. Returns
+ * null when the name doesn't follow the v2 convention (e.g. a legacy folder).
+ */
+export function splitV2FolderName(name: string): { ts: string; title: string } | null {
+  if (name.length < 26) return null; // 24 ts + '_' + at least 1 title char
+  if (name[24] !== '_') return null;
+  const ts = name.slice(0, 24);
+  // Cheap structural check: 4 digits, -, 2 digits, -, 2 digits, T, 2 digits, -, 2 digits, -, 2 digits, ., 3 digits, Z
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z$/.test(ts)) return null;
+  return { ts, title: name.slice(25) };
+}
+
+/** Convert the FS-safe 24-char timestamp back into a canonical ISO 8601 string. */
+export function v2TimestampToIso(ts: string): string {
+  // YYYY-MM-DDTHH-MM-SS.mmmZ -> YYYY-MM-DDTHH:MM:SS.mmmZ.
+  // We only rewrite the `-` separators inside the time portion (after position 10),
+  // never the ones inside the date portion.
+  return `${ts.slice(0, 10)}T${ts.slice(11, 13)}:${ts.slice(14, 16)}:${ts.slice(17)}`;
+}
+
+/** Detect whether a folder uses the v2 layout (meta.json present). */
+export function isV2Folder(folderPath: string): boolean {
+  try {
+    return fs.statSync(path.join(folderPath, META_JSON)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Collapse all whitespace (incl. newlines) so a bullet survives `- item`
+ * round-trip; an embedded newline would otherwise split into two bullets. */
+function normalizeBulletItem(item: string): string {
+  return item.replace(/\s+/g, ' ').trim();
+}
+
+/** Parse a `- item` markdown bullet list back into a string array. */
+export function parseBullets(text: string): string[] {
+  return text
+    .split('\n')
+    .map((l) => l.replace(/\r$/, ''))
+    .filter((l) => l.startsWith('- '))
+    .map((l) => l.slice(2).trim())
+    .filter((l) => l.length > 0);
+}
+
+/** Render an array of bullets back into markdown. */
+function formatBullets(items: string[]): string {
+  return items.map((item) => `- ${normalizeBulletItem(item)}`).join('\n') + '\n';
+}
+
 /** Convert camelCase key to a display label: "keyDecisions" -> "Key Decisions" */
 export function camelToLabel(key: string): string {
   return key
@@ -52,8 +195,18 @@ export function camelToLabel(key: string): string {
     .trim();
 }
 
+/** Subset of TranscriptionResult / ReadTranscriptionResult that formatSummary
+ * actually consumes -- intentionally loose so both shapes (writer-side
+ * TranscriptionResult and reader-side ReadTranscriptionResult) satisfy it. */
+export type FormatSummaryInput = {
+  summary?: string;
+  keyPoints?: string[];
+  actionItems?: string[];
+  customFields?: Record<string, unknown>;
+};
+
 export function formatSummary(
-  result: TranscriptionResult,
+  result: FormatSummaryInput,
   title: string,
   mergedFrom?: string[],
   liveNotes?: LiveNote[],
@@ -358,6 +511,7 @@ export interface SaveTranscriptionOptions {
   dataPath: string; // app data path (default location)
   mergedFrom?: string[]; // source folder names when this note was created by merging others
   liveNotes?: LiveNote[]; // timestamped notes captured during recording
+  now?: Date; // test hook for deterministic v2 folder timestamps
 }
 
 function getResultHighlights(result: TranscriptionResult): HighlightEntry[] | undefined {
@@ -365,10 +519,157 @@ function getResultHighlights(result: TranscriptionResult): HighlightEntry[] | un
 }
 
 /**
- * Save transcription as summary.md + transcript.md in a timestamped folder.
- * Returns the created folder path.
+ * Save a transcription using the v2 folder layout. Returns the created folder path.
+ *
+ * New writes always use v2. Existing v1 folders on disk continue to be read via
+ * the dispatch in `readTranscription` and updated via `updateTranscriptionStatus`.
  */
 export function saveTranscription(opts: SaveTranscriptionOptions): string {
+  const parentDir = opts.outputDir ?? getTranscriptionsDir(opts.dataPath);
+  const now = opts.now ?? new Date();
+  const ts = formatV2Timestamp(now);
+  const titleSlug = sanitizeV2Title(opts.title);
+
+  fs.mkdirSync(parentDir, { recursive: true });
+
+  // Bump the timestamp ms when two saves race within the same millisecond.
+  // mkdir is the atomic claim; existsSync would TOCTOU.
+  const tsBase = now.getTime();
+  let usedTs = ts;
+  let folderPath = path.join(parentDir, `${usedTs}_${titleSlug}`);
+  for (let attempt = 0; ; attempt++) {
+    try {
+      fs.mkdirSync(folderPath);
+      break;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'EEXIST') throw e;
+      if (attempt >= 1000) {
+        throw new Error('saveTranscription: could not find a free folder name after 1000 attempts');
+      }
+      usedTs = formatV2Timestamp(new Date(tsBase + attempt + 1));
+      folderPath = path.join(parentDir, `${usedTs}_${titleSlug}`);
+    }
+  }
+
+  writeV2Files(folderPath, {
+    transcribedAt: v2TimestampToIso(usedTs),
+    title: opts.title,
+    result: opts.result,
+    audioFilePath: opts.audioFilePath,
+    mergedFrom: opts.mergedFrom,
+    liveNotes: opts.liveNotes,
+  });
+
+  return folderPath;
+}
+
+/** Inputs accepted by `writeV2Files`. Decoupled from `SaveTranscriptionOptions`
+ * because migration also calls this with values it lifted from a v1 folder. */
+interface V2WriteInputs {
+  transcribedAt: string;
+  title: string;
+  result: TranscriptionResult;
+  audioFilePath?: string;
+  mergedFrom?: string[];
+  liveNotes?: LiveNote[];
+  /** Optional pre-existing exports (carried over by migration). */
+  exports?: MeetingMetaV2['exports'];
+}
+
+/** Write the full v2 file set into an existing folder. Overwrites whatever's there. */
+function writeV2Files(folderPath: string, inputs: V2WriteInputs): void {
+  const highlights = getResultHighlights(inputs.result);
+
+  const meta: MeetingMetaV2 = {
+    schemaVersion: META_SCHEMA_VERSION,
+    title: inputs.title,
+    transcribedAt: inputs.transcribedAt,
+  };
+  if (inputs.result.suggestedTitle) meta.suggestedTitle = inputs.result.suggestedTitle;
+  if (inputs.result.emoji) meta.emoji = inputs.result.emoji;
+  if (inputs.audioFilePath) meta.audioFile = inputs.audioFilePath;
+  if (inputs.result.cost && inputs.result.cost.breakdown.length > 0) meta.cost = inputs.result.cost;
+  if (
+    inputs.result.customFields &&
+    Object.keys(inputs.result.customFields).length > 0
+  ) {
+    meta.customFields = inputs.result.customFields;
+  }
+  if (inputs.mergedFrom?.length) {
+    meta.merge = { sourceIds: inputs.mergedFrom };
+  }
+  if (inputs.exports) meta.exports = inputs.exports;
+
+  // Intentional: an empty summary string still writes an empty summary.md so
+  // existence checks elsewhere see a "the meeting was saved" file. Same for
+  // transcript.md. Other optional files (key-points, action-items, notes,
+  // highlights) are absent when their data is empty.
+  writeOrRemove(
+    folderPath,
+    SUMMARY_FILE,
+    inputs.result.summary ? `${inputs.result.summary.trim()}\n` : '',
+  );
+  writeOrRemove(
+    folderPath,
+    KEY_POINTS_FILE,
+    inputs.result.keyPoints?.length ? formatBullets(inputs.result.keyPoints) : null,
+  );
+  writeOrRemove(
+    folderPath,
+    ACTION_ITEMS_FILE,
+    inputs.result.actionItems?.length ? formatBullets(inputs.result.actionItems) : null,
+  );
+  writeOrRemove(
+    folderPath,
+    TRANSCRIPT_FILE,
+    inputs.result.transcript ? `${inputs.result.transcript.trim()}\n` : '',
+  );
+  writeOrRemove(
+    folderPath,
+    NOTES_JSON_FILE,
+    inputs.liveNotes?.length ? `${JSON.stringify(inputs.liveNotes, null, 2)}\n` : null,
+  );
+  writeOrRemove(
+    folderPath,
+    HIGHLIGHTS_JSON_FILE,
+    highlights?.length ? `${JSON.stringify(highlights, null, 2)}\n` : null,
+  );
+
+  // meta.json LAST and ATOMIC: it is the v2 sentinel (`isV2Folder`). Use
+  // write-to-tmp + rename so a crash mid-write leaves either the old file
+  // (no meta.json yet -> still v1) or the new file fully landed (-> v2) --
+  // never a truncated meta.json that fools `isV2Folder` but breaks JSON parse.
+  writeAtomic(path.join(folderPath, META_JSON), `${JSON.stringify(meta, null, 2)}\n`);
+}
+
+/** Write `content` to `folderPath/filename` when non-null, otherwise ensure
+ * any stale copy is gone. Used by the v2 writer + migration so the on-disk
+ * file set always matches the in-memory record. */
+function writeOrRemove(folderPath: string, filename: string, content: string | null): void {
+  const target = path.join(folderPath, filename);
+  if (content === null) {
+    fs.rmSync(target, { force: true });
+  } else {
+    fs.writeFileSync(target, content, 'utf-8');
+  }
+}
+
+/** Write `content` to `targetPath` via a `.tmp` sibling + rename so the
+ * write is atomic on POSIX (the rename is a single inode swap on the same
+ * filesystem). Used for files whose mid-write truncation would corrupt the
+ * data model -- currently just meta.json (the v2 sentinel). */
+function writeAtomic(targetPath: string, content: string): void {
+  const tmp = `${targetPath}.tmp`;
+  fs.writeFileSync(tmp, content, 'utf-8');
+  fs.renameSync(tmp, targetPath);
+}
+
+/**
+ * Write a transcription using the legacy v1 layout (summary.md with YAML
+ * frontmatter + rendered body). Only used by test fixtures and migration
+ * rollback; production writes always go through `saveTranscription` (v2).
+ */
+export function __saveTranscriptionLegacyV1ForTests(opts: SaveTranscriptionOptions): string {
   const parentDir = opts.outputDir ?? getTranscriptionsDir(opts.dataPath);
   const folderName = `${sanitizeForPath(opts.title)}_${formatTimestamp()}`;
   const folderPath = path.join(parentDir, folderName);
@@ -377,7 +678,6 @@ export function saveTranscription(opts: SaveTranscriptionOptions): string {
   const transcribedAt = new Date().toISOString();
 
   const highlights = getResultHighlights(opts.result);
-  // summary.md with frontmatter (stores all raw data for machine reading)
   const frontmatter = buildFrontmatter({
     title: opts.title,
     suggestedTitle: opts.result.suggestedTitle,
@@ -401,13 +701,7 @@ export function saveTranscription(opts: SaveTranscriptionOptions): string {
     opts.liveNotes,
     highlights,
   );
-  fs.writeFileSync(
-    path.join(folderPath, 'summary.md'),
-    `${frontmatter}\n\n${summaryBody}`,
-    'utf-8',
-  );
-
-  // transcript.md
+  fs.writeFileSync(path.join(folderPath, 'summary.md'), `${frontmatter}\n\n${summaryBody}`, 'utf-8');
   fs.writeFileSync(
     path.join(folderPath, 'transcript.md'),
     formatTranscript(opts.result, opts.title),
@@ -425,8 +719,10 @@ export interface TranscriptionEntry {
 }
 
 /**
- * List transcription folders sorted by most-recent-first.
- * Performs a lightweight line scan of each summary.md to extract only title and transcribedAt.
+ * List transcription folders sorted by most-recent-first. Reads meta.json
+ * for each folder. Folders without meta.json (i.e. unmigrated v1 folders --
+ * shouldn't exist at runtime because `autoMigrateLegacyOnStartup` runs first)
+ * are silently skipped.
  */
 export async function listTranscriptions(
   dataPath: string,
@@ -444,54 +740,48 @@ export async function listTranscriptions(
   const entries: TranscriptionEntry[] = [];
   for (const dirent of dirents) {
     if (!dirent.isDirectory()) continue;
-    const name = dirent.name;
-    const folderPath = path.join(dir, name);
-    const summaryPath = path.join(folderPath, 'summary.md');
-
-    let title = name;
-    let transcribedAt = '';
-
-    // Lightweight line scan -- read only frontmatter, not the full file
-    let fileHandle: fs.promises.FileHandle;
-    try {
-      fileHandle = await fs.promises.open(summaryPath, 'r');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
-      throw err;
-    }
-    try {
-      const buf = Buffer.alloc(2048);
-      const { bytesRead } = await fileHandle.read(buf, 0, 2048, 0);
-      const head = buf.toString('utf-8', 0, bytesRead);
-
-      for (const line of head.split('\n')) {
-        const titleMatch = line.match(/^title:\s*(.+)$/);
-        if (titleMatch) title = yamlUnquote(titleMatch[1]);
-        const dateMatch = line.match(/^transcribedAt:\s*(.+)$/);
-        if (dateMatch) transcribedAt = yamlUnquote(dateMatch[1]);
-        // Stop after closing frontmatter delimiter
-        if (line === '---' && transcribedAt) break;
-      }
-    } finally {
-      await fileHandle.close();
-    }
-
-    // Fall back to folder name timestamp suffix (e.g. _20260219_143000)
-    if (!transcribedAt) {
-      const tsMatch = name.match(/(\d{8}_\d{6})$/);
-      if (tsMatch) {
-        const s = tsMatch[1];
-        transcribedAt = `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}T${s.slice(9, 11)}:${s.slice(11, 13)}:${s.slice(13, 15)}`;
-      }
-    }
-
-    entries.push({ folderPath, folderName: name, title, transcribedAt });
+    const entry = await listEntryFromV2Meta(path.join(dir, dirent.name), dirent.name);
+    if (entry) entries.push(entry);
   }
 
   entries.sort((a, b) => (b.transcribedAt || '').localeCompare(a.transcribedAt || ''));
 
   const max = limit === 0 ? entries.length : (limit ?? 20);
   return entries.slice(0, max);
+}
+
+async function listEntryFromV2Meta(
+  folderPath: string,
+  folderName: string,
+): Promise<TranscriptionEntry | null> {
+  try {
+    const raw = await fs.promises.readFile(path.join(folderPath, META_JSON), 'utf-8');
+    const meta = JSON.parse(raw) as MeetingMetaV2;
+    return {
+      folderPath,
+      folderName,
+      title: meta.title || folderName,
+      transcribedAt: meta.transcribedAt || folderNameToTimestamp(folderName),
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    console.warn(`listTranscriptions: failed to read v2 meta for ${folderName}:`, err);
+    return null;
+  }
+}
+
+/** Recover an ISO-ish timestamp from a folder name as last-resort fallback. */
+function folderNameToTimestamp(name: string): string {
+  // v2 prefix: YYYY-MM-DDTHH-MM-SS.mmmZ
+  const v2 = splitV2FolderName(name);
+  if (v2) return v2TimestampToIso(v2.ts);
+  // v1 suffix: _YYYYMMDD_HHMMSS
+  const tsMatch = name.match(/(\d{8}_\d{6})$/);
+  if (tsMatch) {
+    const s = tsMatch[1];
+    return `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}T${s.slice(9, 11)}:${s.slice(11, 13)}:${s.slice(13, 15)}`;
+  }
+  return '';
 }
 
 export interface ReadTranscriptionResult {
@@ -516,9 +806,119 @@ export interface ReadTranscriptionResult {
 
 /**
  * Read transcription data from a transcription folder.
- * Returns raw data from frontmatter (machine-readable), not the markdown body.
+ *
+ * Dispatches by format: v2 folders (presence of meta.json) are stitched from
+ * the per-field files; legacy v1 folders fall back to the frontmatter parser.
+ * Either way the returned shape is identical so all upstream code is
+ * format-agnostic.
+ */
+export interface ReadTranscriptionOptions {
+  /** Skip transcript.md / frontmatter.transcript -- callers that filter
+   * transcript out (e.g. default search scope) can avoid loading the largest
+   * file in the folder. The returned `transcript` field will be an empty
+   * string. */
+  skipTranscript?: boolean;
+}
+
+/**
+ * Read a transcription folder (v2 layout only). At runtime the
+ * `autoMigrateLegacyOnStartup` pass guarantees every folder has been
+ * converted, so this reader never sees a v1 folder. If meta.json is missing
+ * we return null with a warning -- the caller should treat that as "corrupt
+ * or unrecognised meeting" rather than try to read frontmatter.
  */
 export async function readTranscription(
+  folderPath: string,
+  opts: ReadTranscriptionOptions = {},
+): Promise<ReadTranscriptionResult | null> {
+  let metaRaw: string;
+  try {
+    metaRaw = await fs.promises.readFile(path.join(folderPath, META_JSON), 'utf-8');
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      console.warn(
+        `readTranscription: meta.json missing at ${folderPath} -- folder may be unmigrated v1 or corrupt.`,
+      );
+      return null;
+    }
+    throw e;
+  }
+
+  try {
+    const meta = JSON.parse(metaRaw) as MeetingMetaV2;
+
+    // Reject anything that isn't exactly the current version: future versions
+    // could break our reader, and `0` / `NaN` / negatives are hand-edit
+    // corruption signals -- safer to bail than to silently write defaults back.
+    if (typeof meta.schemaVersion !== 'number' || meta.schemaVersion !== META_SCHEMA_VERSION) {
+      console.warn(
+        `readTranscription: unknown meta.json schemaVersion ${meta.schemaVersion} in ${folderPath}`,
+      );
+      return null;
+    }
+
+    const [summary, keyPointsText, actionItemsText, transcript, notesRaw, highlightsRaw] =
+      await Promise.all([
+        readOptionalFile(path.join(folderPath, SUMMARY_FILE)),
+        readOptionalFile(path.join(folderPath, KEY_POINTS_FILE)),
+        readOptionalFile(path.join(folderPath, ACTION_ITEMS_FILE)),
+        opts.skipTranscript
+          ? Promise.resolve(null)
+          : readOptionalFile(path.join(folderPath, TRANSCRIPT_FILE)),
+        readOptionalFile(path.join(folderPath, NOTES_JSON_FILE)),
+        readOptionalFile(path.join(folderPath, HIGHLIGHTS_JSON_FILE)),
+      ]);
+
+    const keyPoints = keyPointsText ? parseBullets(keyPointsText) : undefined;
+    const actionItems = actionItemsText ? parseBullets(actionItemsText) : undefined;
+
+    let liveNotes: LiveNote[] | undefined;
+    if (notesRaw) {
+      try {
+        liveNotes = parseLiveNotesField(JSON.parse(notesRaw));
+      } catch (e) {
+        console.warn(`Failed to parse notes.json in ${folderPath}:`, e);
+      }
+    }
+
+    let highlights: ReadTranscriptionResult['highlights'];
+    if (highlightsRaw) {
+      try {
+        highlights = parseHighlightsField(JSON.parse(highlightsRaw));
+      } catch (e) {
+        console.warn(`Failed to parse highlights.json in ${folderPath}:`, e);
+      }
+    }
+
+    return {
+      title: meta.title || path.basename(folderPath),
+      suggestedTitle: meta.suggestedTitle,
+      transcript: (transcript ?? '').trim(),
+      summary: (summary ?? '').trim(),
+      keyPoints: keyPoints && keyPoints.length > 0 ? keyPoints : undefined,
+      actionItems: actionItems && actionItems.length > 0 ? actionItems : undefined,
+      customFields: meta.customFields,
+      audioFilePath: meta.audioFile,
+      transcribedAt: meta.transcribedAt,
+      emoji: meta.emoji,
+      mergedFrom: meta.merge?.sourceIds,
+      liveNotes,
+      highlights,
+      notionPageUrl: meta.exports?.notion?.pageUrl,
+      slackSentAt: meta.exports?.slack?.sentAt,
+      slackError: meta.exports?.slack?.error ?? undefined,
+      cost: meta.cost,
+    };
+  } catch (e) {
+    console.warn(`Failed to read v2 transcription at ${folderPath}:`, e);
+    return null;
+  }
+}
+
+/** Migration-only reader: parses a v1 summary.md (YAML frontmatter) into the
+ * shared shape so `migrateV1ToV2` can lift the data forward. Not exported --
+ * runtime reads always go through the v2 `readTranscription`. */
+async function readV1Transcription(
   folderPath: string,
 ): Promise<ReadTranscriptionResult | null> {
   try {
@@ -527,7 +927,6 @@ export async function readTranscription(
     const summaryContent = await fs.promises.readFile(summaryPath, 'utf-8');
     const { meta } = parseFrontmatter(summaryContent);
 
-    // Parse customFields from frontmatter (stored as JSON string)
     let customFields: Record<string, unknown> | undefined;
     if (meta.customFields) {
       try {
@@ -544,11 +943,14 @@ export async function readTranscription(
     const highlights = parseHighlightsField(meta.highlights);
     const cost = parseCostField(meta.cost);
 
+    // `parseFrontmatter` can return an empty array for `summary:` / `transcript:`
+    // value lines that are blank (hand-edited or malformed v1 file); coerce
+    // non-strings to '' so the v2 writer's `.trim()` doesn't blow up.
     return {
-      title: (meta.title as string) || path.basename(folderPath),
+      title: asString(meta.title) || path.basename(folderPath),
       suggestedTitle: meta.suggestedTitle as string | undefined,
-      transcript: (meta.transcript as string) || '',
-      summary: (meta.summary as string) || '',
+      transcript: asString(meta.transcript),
+      summary: asString(meta.summary),
       keyPoints: meta.keyPoints as string[] | undefined,
       actionItems: meta.actionItems as string[] | undefined,
       customFields,
@@ -565,6 +967,19 @@ export async function readTranscription(
     };
   } catch {
     return null;
+  }
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+async function readOptionalFile(filePath: string): Promise<string | null> {
+  try {
+    return await fs.promises.readFile(filePath, 'utf-8');
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw e;
   }
 }
 
@@ -594,66 +1009,301 @@ export interface TranscriptionStatusUpdate {
 }
 
 /**
- * Update tracking fields (Notion URL, Slack send status) in summary.md frontmatter
- * without rewriting the markdown body. Pass `null` to clear a field, `undefined` to leave unchanged.
+ * Update tracking fields (Notion URL, Slack send status) in a v2 folder's
+ * meta.json. Pass `null` to clear a field, `undefined` to leave unchanged.
+ * Touches only meta.json -- the content files (summary.md, transcript.md,
+ * etc.) keep their existing mtime so Drive sync only re-uploads the one file
+ * that actually changed.
  */
 export async function updateTranscriptionStatus(
   folderPath: string,
   updates: TranscriptionStatusUpdate,
 ): Promise<void> {
-  const summaryPath = path.join(folderPath, 'summary.md');
-  const content = await fs.promises.readFile(summaryPath, 'utf-8');
-  const { meta, body } = parseFrontmatter(content);
+  const metaPath = path.join(folderPath, META_JSON);
+  const raw = await fs.promises.readFile(metaPath, 'utf-8');
+  const meta = JSON.parse(raw) as MeetingMetaV2;
 
-  // Recover customFields shape (parseFrontmatter returns it as a JSON string)
-  let customFields: Record<string, unknown> | undefined;
-  if (meta.customFields) {
-    try {
-      customFields =
-        typeof meta.customFields === 'string'
-          ? JSON.parse(meta.customFields as string)
-          : (meta.customFields as Record<string, unknown>);
-    } catch {
-      customFields = undefined;
-    }
+  // `exports` is reserved as a CommonJS module local; use a different name.
+  const exportsMeta = { ...meta.exports } as NonNullable<MeetingMetaV2['exports']>;
+  applyV2Notion(exportsMeta, updates.notionPageUrl);
+  applyV2Slack(exportsMeta, 'sentAt', updates.slackSentAt);
+  applyV2Slack(exportsMeta, 'error', updates.slackError);
+
+  if (Object.keys(exportsMeta).length === 0) {
+    delete meta.exports;
+  } else {
+    meta.exports = exportsMeta;
   }
 
-  const liveNotes = parseLiveNotesField(meta.liveNotes);
-  const highlights = parseHighlightsField(meta.highlights);
-  const cost = parseCostField(meta.cost);
-
-  // Spread first so any unknown frontmatter keys (added by future writers, or
-  // by hand-edits) survive the round-trip; named fields override with proper
-  // typing and defaults.
-  const merged: SummaryFrontmatter = {
-    ...(meta as unknown as Partial<SummaryFrontmatter>),
-    title: (meta.title as string) || path.basename(folderPath),
-    summary: (meta.summary as string) || '',
-    transcript: (meta.transcript as string) || '',
-    transcribedAt: (meta.transcribedAt as string) || new Date().toISOString(),
-    customFields,
-    liveNotes,
-    highlights,
-    cost,
-  };
-
-  applyStatusUpdate(merged, 'notionPageUrl', updates.notionPageUrl);
-  applyStatusUpdate(merged, 'slackSentAt', updates.slackSentAt);
-  applyStatusUpdate(merged, 'slackError', updates.slackError);
-
-  const frontmatter = buildFrontmatter(merged);
-  await fs.promises.writeFile(summaryPath, `${frontmatter}\n\n${body}`, 'utf-8');
+  // Atomic write so a crash never leaves a truncated meta.json behind.
+  writeAtomic(metaPath, `${JSON.stringify(meta, null, 2)}\n`);
 }
 
-function applyStatusUpdate(
-  meta: SummaryFrontmatter,
-  key: 'notionPageUrl' | 'slackSentAt' | 'slackError',
+function applyV2Notion(
+  exportsMeta: NonNullable<MeetingMetaV2['exports']>,
   value: string | null | undefined,
 ): void {
   if (value === undefined) return;
   if (value === null || value === '') {
-    delete meta[key];
+    delete exportsMeta.notion;
     return;
   }
-  meta[key] = value;
+  exportsMeta.notion = { ...exportsMeta.notion, pageUrl: value };
+}
+
+function applyV2Slack(
+  exportsMeta: NonNullable<MeetingMetaV2['exports']>,
+  key: 'sentAt' | 'error',
+  value: string | null | undefined,
+): void {
+  if (value === undefined) return;
+  const slack = { ...exportsMeta.slack };
+  if (value === null || value === '') {
+    delete slack[key];
+  } else {
+    slack[key] = value;
+  }
+  if (Object.keys(slack).length === 0) {
+    delete exportsMeta.slack;
+  } else {
+    exportsMeta.slack = slack;
+  }
+}
+
+/**
+ * Migrate a v1 folder to the v2 layout in-place. Idempotent: returns false
+ * when the folder is already v2.
+ *
+ * Why: the folder name is preserved (Drive sync keys change detection on
+ * folder identity, so a rename would force a full re-upload).
+ *
+ * Crash safety: the v1 summary.md / transcript.md are renamed to in-folder
+ * `.v1-bak` siblings BEFORE any v2 writes, so a crash anywhere in the loop
+ * leaves the v1 originals recoverable. The `.v1-bak` files are deleted only
+ * after `meta.json` (the v2 sentinel) lands. On retry, the migration sees no
+ * `meta.json` and the `.v1-bak` files signal "previous attempt crashed" --
+ * we restore the originals before re-reading.
+ */
+export async function migrateV1ToV2(folderPath: string): Promise<boolean> {
+  if (isV2Folder(folderPath)) return false;
+
+  // Recover from a previous-attempt crash: if `.v1-bak` siblings exist (v2
+  // sentinel absent, body files overwritten), restore them before reading.
+  restoreV1BakIfPresent(folderPath);
+
+  const v1 = await readV1Transcription(folderPath);
+  if (!v1) {
+    throw new Error(`migrateV1ToV2: could not read v1 folder at ${folderPath}`);
+  }
+
+  // Prefer the v1 frontmatter date; fall back to the folder-name suffix;
+  // last-ditch use now.
+  const transcribedAt =
+    v1.transcribedAt ||
+    folderNameToTimestamp(path.basename(folderPath)) ||
+    new Date().toISOString();
+
+  // transcript.md is the user-visible source; prefer it over frontmatter.transcript
+  // in case a user hand-edited only the markdown side.
+  let transcriptText = v1.transcript;
+  try {
+    const transcriptRaw = fs.readFileSync(path.join(folderPath, TRANSCRIPT_FILE), 'utf-8');
+    const cleaned = transcriptRaw.replace(/^# [^\n]*\n+/, '').trim();
+    if (cleaned.length > 0) transcriptText = cleaned;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
+  }
+
+  const result: TranscriptionResult = {
+    transcript: transcriptText,
+    summary: v1.summary,
+    keyPoints: v1.keyPoints ?? [],
+    actionItems: v1.actionItems ?? [],
+    emoji: v1.emoji ?? '',
+    customFields: v1.customFields,
+    suggestedTitle: v1.suggestedTitle,
+    highlights: v1.highlights,
+    cost: v1.cost,
+  };
+
+  const exportsMeta: MeetingMetaV2['exports'] = {};
+  if (v1.notionPageUrl) exportsMeta.notion = { pageUrl: v1.notionPageUrl };
+  if (v1.slackSentAt || v1.slackError) {
+    exportsMeta.slack = {};
+    if (v1.slackSentAt) exportsMeta.slack.sentAt = v1.slackSentAt;
+    if (v1.slackError) exportsMeta.slack.error = v1.slackError;
+  }
+
+  // Rename v1 originals to `.v1-bak` siblings (atomic on POSIX) so the
+  // upcoming destructive writeV2Files cannot lose data on crash. On retry
+  // we'd see no meta.json + .v1-bak present and restore above.
+  for (const name of V1_BAK_FILES) {
+    renameIfExists(path.join(folderPath, name), path.join(folderPath, `${name}${V1_BAK_SUFFIX}`));
+  }
+
+  writeV2Files(folderPath, {
+    transcribedAt,
+    title: v1.title,
+    result,
+    audioFilePath: v1.audioFilePath,
+    mergedFrom: v1.mergedFrom,
+    liveNotes: v1.liveNotes,
+    exports: Object.keys(exportsMeta).length > 0 ? exportsMeta : undefined,
+  });
+
+  // meta.json landed -- safe to drop the .v1-bak siblings.
+  for (const name of V1_BAK_FILES) {
+    fs.rmSync(path.join(folderPath, `${name}${V1_BAK_SUFFIX}`), { force: true });
+  }
+
+  return true;
+}
+
+function renameIfExists(src: string, dst: string): void {
+  try {
+    fs.renameSync(src, dst);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
+  }
+}
+
+/** If a previous `migrateV1ToV2` crashed mid-write the folder is in a hybrid
+ * state: no `meta.json`, body files possibly partly overwritten, and the
+ * pre-write `.v1-bak` siblings still present. Restore the .v1-bak files back
+ * to their canonical names so the next attempt sees a clean v1 folder. */
+function restoreV1BakIfPresent(folderPath: string): void {
+  for (const name of V1_BAK_FILES) {
+    const bak = path.join(folderPath, `${name}${V1_BAK_SUFFIX}`);
+    const target = path.join(folderPath, name);
+    if (!fs.existsSync(bak)) continue;
+    fs.rmSync(target, { force: true });
+    fs.renameSync(bak, target);
+  }
+}
+
+export interface AutoMigrateResult {
+  /** Folder names that were migrated this run. */
+  migrated: string[];
+  /** Folders that were already v2 and skipped. */
+  alreadyV2: number;
+  /** Absolute path to the backup directory, if any migration occurred. */
+  backupDir?: string;
+}
+
+export interface AutoMigrateOptions {
+  now?: Date;
+  onProgress?: (current: number, total: number, folderName: string) => void;
+}
+
+/**
+ * Scan the transcriptions directory for legacy v1 folders, snapshot each
+ * one's destructively-overwritten files into a sibling `.v1-backup-<ts>/`
+ * directory, then convert every v1 folder to v2 in place.
+ *
+ * Atomicity contract: if any individual migration throws, the function
+ * propagates -- the caller MUST refuse to continue startup. A partial
+ * migration would leave some folders v1 (unreadable to the v2-only runtime)
+ * and others v2, which is worse than not migrating at all.
+ *
+ * The backup directory lives under `dataPath/` (NOT under `transcriptions/`)
+ * so the Google Drive sync engine never sees it.
+ */
+export async function autoMigrateLegacyOnStartup(
+  dataPath: string,
+  opts: AutoMigrateOptions = {},
+): Promise<AutoMigrateResult> {
+  const transcriptionsDir = getTranscriptionsDir(dataPath);
+  let dirents: fs.Dirent[];
+  try {
+    dirents = await fs.promises.readdir(transcriptionsDir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { migrated: [], alreadyV2: 0 };
+    }
+    throw err;
+  }
+
+  // Per-folder isV2Folder is one statSync (~10us on SSD); a name-pattern
+  // shortcut was considered and rejected because a v1 folder that happens to
+  // have a v2-shaped name (manual rename, restored backup, name collision
+  // with the v2 convention) would be falsely skipped and silently dropped at
+  // read time.
+  const v1Folders: string[] = [];
+  let alreadyV2 = 0;
+  for (const d of dirents) {
+    if (!d.isDirectory()) continue;
+    if (d.name.startsWith('.')) continue; // skip prior backup directories
+    const folderPath = path.join(transcriptionsDir, d.name);
+    if (isV2Folder(folderPath)) {
+      alreadyV2 += 1;
+    } else {
+      v1Folders.push(folderPath);
+    }
+  }
+
+  if (v1Folders.length === 0) {
+    return { migrated: [], alreadyV2 };
+  }
+
+  const now = opts.now ?? new Date();
+  const backupDir = path.join(dataPath, `${V1_BACKUP_DIR_PREFIX}${formatV2Timestamp(now)}`);
+  fs.mkdirSync(backupDir, { recursive: true });
+
+  const migrated: string[] = [];
+  for (let i = 0; i < v1Folders.length; i++) {
+    const folderPath = v1Folders[i];
+    const folderName = path.basename(folderPath);
+    opts.onProgress?.(i + 1, v1Folders.length, folderName);
+    snapshotV1Files(folderPath, path.join(backupDir, folderName));
+    await migrateV1ToV2(folderPath);
+    migrated.push(folderName);
+  }
+
+  return { migrated, alreadyV2, backupDir };
+}
+
+/** Copy the files that `migrateV1ToV2` destructively overwrites into a
+ * backup directory so the operation is recoverable. summary.md is replaced
+ * (frontmatter dropped) and transcript.md may have its leading `# title`
+ * stripped; everything else is additive. */
+function snapshotV1Files(folderPath: string, backupTargetDir: string): void {
+  fs.mkdirSync(backupTargetDir, { recursive: true });
+  for (const name of V1_BAK_FILES) {
+    const src = path.join(folderPath, name);
+    if (fs.existsSync(src)) {
+      fs.copyFileSync(src, path.join(backupTargetDir, name));
+    }
+  }
+}
+
+/** Remove `.v1-backup-*` directories older than `retentionDays` days.
+ * Returns the number of backups removed. */
+export async function gcLegacyBackups(
+  dataPath: string,
+  retentionDays = 30,
+): Promise<number> {
+  let dirents: fs.Dirent[];
+  try {
+    dirents = await fs.promises.readdir(dataPath, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 0;
+    throw err;
+  }
+  const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  let removed = 0;
+  for (const d of dirents) {
+    if (!d.isDirectory()) continue;
+    if (!d.name.startsWith(V1_BACKUP_DIR_PREFIX)) continue;
+    const full = path.join(dataPath, d.name);
+    try {
+      const stat = fs.statSync(full);
+      if (stat.mtimeMs < cutoffMs) {
+        fs.rmSync(full, { recursive: true, force: true });
+        removed += 1;
+      }
+    } catch {
+      // ignore -- the backup is either gone or the user pulled it out
+    }
+  }
+  return removed;
 }

--- a/src/outputService.ts
+++ b/src/outputService.ts
@@ -589,10 +589,7 @@ function writeV2Files(folderPath: string, inputs: V2WriteInputs): void {
   if (inputs.result.emoji) meta.emoji = inputs.result.emoji;
   if (inputs.audioFilePath) meta.audioFile = inputs.audioFilePath;
   if (inputs.result.cost && inputs.result.cost.breakdown.length > 0) meta.cost = inputs.result.cost;
-  if (
-    inputs.result.customFields &&
-    Object.keys(inputs.result.customFields).length > 0
-  ) {
+  if (inputs.result.customFields && Object.keys(inputs.result.customFields).length > 0) {
     meta.customFields = inputs.result.customFields;
   }
   if (inputs.mergedFrom?.length) {
@@ -701,7 +698,11 @@ export function __saveTranscriptionLegacyV1ForTests(opts: SaveTranscriptionOptio
     opts.liveNotes,
     highlights,
   );
-  fs.writeFileSync(path.join(folderPath, 'summary.md'), `${frontmatter}\n\n${summaryBody}`, 'utf-8');
+  fs.writeFileSync(
+    path.join(folderPath, 'summary.md'),
+    `${frontmatter}\n\n${summaryBody}`,
+    'utf-8',
+  );
   fs.writeFileSync(
     path.join(folderPath, 'transcript.md'),
     formatTranscript(opts.result, opts.title),
@@ -918,9 +919,7 @@ export async function readTranscription(
 /** Migration-only reader: parses a v1 summary.md (YAML frontmatter) into the
  * shared shape so `migrateV1ToV2` can lift the data forward. Not exported --
  * runtime reads always go through the v2 `readTranscription`. */
-async function readV1Transcription(
-  folderPath: string,
-): Promise<ReadTranscriptionResult | null> {
+async function readV1Transcription(folderPath: string): Promise<ReadTranscriptionResult | null> {
   try {
     const summaryPath = path.join(folderPath, 'summary.md');
 
@@ -1278,10 +1277,7 @@ function snapshotV1Files(folderPath: string, backupTargetDir: string): void {
 
 /** Remove `.v1-backup-*` directories older than `retentionDays` days.
  * Returns the number of backups removed. */
-export async function gcLegacyBackups(
-  dataPath: string,
-  retentionDays = 30,
-): Promise<number> {
+export async function gcLegacyBackups(dataPath: string, retentionDays = 30): Promise<number> {
   let dirents: fs.Dirent[];
   try {
     dirents = await fs.promises.readdir(dataPath, { withFileTypes: true });

--- a/src/searchService.ts
+++ b/src/searchService.ts
@@ -168,8 +168,9 @@ export async function searchTranscriptions(
   const scope = new Set(fields);
   const hits: SearchHit[] = [];
 
+  const skipTranscript = !scope.has('transcript');
   for (const entry of entries) {
-    const data = await readTranscription(entry.folderPath);
+    const data = await readTranscription(entry.folderPath, { skipTranscript });
     if (!data) continue;
     const hit = scoreRecordPrepared(entry, data, needle, scope);
     if (hit) hits.push(hit);


### PR DESCRIPTION
## Summary

Replace the v1 single-summary.md-with-YAML-frontmatter layout with a v2 per-semantic-field layout (`meta.json` + `summary.md` + `key-points.md` + `action-items.md` + `transcript.md` + optional `notes.json` / `highlights.json`), then force-migrate every legacy folder on Electron app and CLI startup. Cuts ~3x transcript duplication and removes the frontmatter↔body drift surface that issue #116 flagged.

## What this changes

**On-disk layout** (per meeting folder):

| | v1 | v2 |
|---|---|---|
| Folder name | `<title>_<timestamp>/` | `<24-char ISO ts>_<sanitized-title>/` |
| Metadata | YAML frontmatter in `summary.md` | `meta.json` |
| Summary text | duplicated (frontmatter + body) | `summary.md` only |
| Key points | duplicated | `key-points.md` only |
| Action items | duplicated | `action-items.md` only |
| Transcript | duplicated (frontmatter + `transcript.md`) | `transcript.md` only |
| Live notes / highlights | JSON in frontmatter | `notes.json` / `highlights.json` |

**Runtime** is v2-only. `readTranscription` / `listTranscriptions` / `updateTranscriptionStatus` no longer fall back to v1 — `autoMigrateLegacyOnStartup` runs before any of them at every Electron / CLI entry point (except `config` / `codex` / `migrate`, which don't read the data dir or are the migration itself).

**Crash safety**:
- v1 `summary.md` / `transcript.md` are renamed to in-folder `.v1-bak` siblings BEFORE any v2 writes — so a crash in the destructive write window leaves the originals recoverable.
- `meta.json` is written LAST via write-tmp + rename (POSIX-atomic) — it doubles as the v2 sentinel, so a half-written folder still looks like v1 and the next startup retries cleanly.
- A per-startup `.v1-backup-<ts>/` mirror at `<dataPath>/` (outside `transcriptions/` so Drive sync never sees it) captures the originals; GC'd after 30 days.
- Fail-fast: any per-folder migration error throws, callers abort startup with a dialog (Electron) or exit 1 (CLI). Partial migration is impossible by design.

**Drive sync**: folder names are preserved → no delete+recreate, no full re-upload. First post-migration cycle uploads the new files (5–7 per folder); subsequent updates touch only `meta.json` because `updateTranscriptionStatus` is now meta-only.

**New CLI**: `listener migrate <ref> | --all [--dry-run]` for explicit re-runs and dry-run inspection. The startup migration is what every user actually hits; this command is for ad-hoc / debugging.

## Test plan

- [x] 49 new tests added (303/303 pass): v2 round-trip, `autoMigrateLegacyOnStartup`, `gcLegacyBackups`, `.v1-bak` crash recovery, atomic meta.json write, corrupt-meta.json read returns null (not throw), v1 folder with v2-shaped name detected and migrated, CLI integration for `show` / `export` / `migrate` on both v1 and v2 fixtures
- [x] Lint clean (`oxlint src renderer scripts`)
- [x] Both tsc configs clean (`tsc` + `tsc -p tsconfig.renderer.json`)
- [x] Live-tested twice with real 65-folder v1 archive: 65/65 migrated in ~200ms, 0 errors, zero `.v1-bak` / `.tmp` leftovers, backup directory fully recoverable
- [x] Verified `audioFile` paths preserved (38 pre-existing-missing audios pre-migration = 38 post-migration; migration didn't drop any)
- [x] Verified all consumers (`searchService`, `agentService`, `main.ts` Notion/Slack export, CLI `show`/`export`, `syncEngine`) work unchanged via the stable `ReadTranscriptionResult` shape

## Risk profile

- **Regression**: Low. 303/303 tests; same shape returned from `readTranscription`; live-validated.
- **Drive sync compat**: Low. Folder names preserved; backup directory outside the synced subtree; per-folder mtime locality maintained for status updates.
- **Migration safety**: Low. `meta.json`-as-sentinel + atomic write + `.v1-bak` recovery + per-startup `.v1-backup-<ts>/` mirror compose into recovery from every crash window enumerated in two review rounds.
- **Security**: Low. `sanitizeV2Title` strips path traversal + Windows-forbidden chars + NUL; JSON parse failures return null instead of throwing; `schemaVersion` strict-equality gate rejects future versions and 0/NaN hand-edits.
- **One-way**: Users can't revert to a v1-only app after upgrade. Backup is the escape hatch.

Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)