### PR TITLE
Reset notion service when credentials are cleared

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1344,6 +1344,12 @@ function applyConfigSideEffects(changed: Partial<AppConfig>): void {
     const databaseId = configService.getNotionDatabaseId();
     if (apiKey && databaseId) {
       notionService = new NotionService({ apiKey, databaseId });
+    } else {
+      // Credentials cleared (one or both blank) — drop the cached client so
+      // the next upload doesn't reuse stale credentials targeting a different
+      // workspace. The upload-to-notion handler re-checks config on a null
+      // service and returns "Notion configuration not found".
+      notionService = null;
     }
   }
   if (changed.slackWebhookUrl !== undefined) {


### PR DESCRIPTION
## Summary

- When a user blanks Notion API key or database ID in Settings, `applyConfigSideEffects` previously only handled the both-set case and left the cached `NotionService` instance in place. The next upload reused the prior credentials, which after a workspace switch silently posted meeting notes into the wrong workspace -- a privacy regression.
- Mirror the existing `slackService` reset pattern: when the new credential pair is incomplete, null the cached client. The `upload-to-notion` IPC handler already re-checks config on a null service and returns `Notion configuration not found`, so the user gets a clear error instead of a misrouted upload.

## Test plan

- [x] `pnpm run build`
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm test` (320 pass, 0 fail)
- [ ] Manual: open Settings, clear Notion API key (or database ID), save, attempt upload -- expect `Notion configuration not found` error, not a successful upload to the prior workspace.

`applyConfigSideEffects` is not exported and depends on multiple top-level singletons, so a unit test would require either invasive mocking or a refactor that conflicts with the parallel `main.ts` modularization PR. Scope intentionally limited to the one-line behavioral fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)