### PR TITLE
Download Drive meetings atomically via partial directory

### DIFF
--- a/src/services/syncEngine.test.ts
+++ b/src/services/syncEngine.test.ts
@@ -38,6 +38,11 @@ class MockDriveClient {
   private folderIds = new Map<string, string>();
   private fileIds = new Map<string, string>();
   failNextUpload?: (call: UploadCall) => Error | undefined;
+  // Hook that runs at the top of every downloadFile call. Returning an Error
+  // (or throwing) makes the call fail without consuming the content. Used by
+  // download-path crash-recovery tests; one-shot semantics like
+  // failNextUpload would be too coarse for "fail the 2nd of 3 downloads".
+  shouldFailDownload?: (fileId: string, callIndex: number) => Error | undefined;
 
   asDriveClient(): GoogleDriveClient {
     return this as unknown as GoogleDriveClient;
@@ -128,7 +133,12 @@ class MockDriveClient {
   }
 
   async downloadFile(fileId: string): Promise<Buffer> {
+    const callIndex = this.downloadCalls.length;
     this.downloadCalls.push(fileId);
+    if (this.shouldFailDownload) {
+      const err = this.shouldFailDownload(fileId, callIndex);
+      if (err) throw err;
+    }
     const content = this.fileContents.get(fileId);
     if (!content) throw new Error(`MockDriveClient: no content for ${fileId}`);
     return content;
@@ -1179,5 +1189,175 @@ describe('SyncEngine: knownWords config sync (issue #152)', () => {
       .slice(uploadsBefore)
       .filter((u) => u.name === 'known-words.json');
     assert.equal(newKnownWordsUploads.length, 0);
+  });
+});
+
+describe('SyncEngine: download atomicity (meta.json sentinel safety)', () => {
+  // Regression coverage for the bug where syncMeetingDownloadOnly wrote files
+  // straight into <transcriptionsDir>/<meeting>/. If meta.json arrived before
+  // the rest and the sync crashed, the leftover folder satisfied
+  // outputService.isV2Folder() -- the user saw a meeting with no summary,
+  // and subsequent syncs treated the stub as already-downloaded so no
+  // recovery ever happened. The fix stages downloads in
+  // .listener-partial/<meeting>/ and atomically renames on full success.
+
+  it('writes nothing into the final meeting folder until all downloads complete', async () => {
+    const appFolder = await mockClient.ensureFolder('Listener.AI');
+    mockClient.seedRemoteMeeting('m1', appFolder.id, [
+      { name: 'meta.json', content: '{"schemaVersion":2,"title":"M1"}' },
+      { name: 'summary.md', content: 'summary content' },
+      { name: 'transcript.md', content: 'transcript content' },
+    ]);
+
+    // Fail the second download to simulate a mid-sync crash. The exact file
+    // that fails doesn't matter -- we want to prove the partial state never
+    // leaks into <transcriptionsDir>/m1/, regardless of order.
+    mockClient.shouldFailDownload = (_id, callIndex) => {
+      if (callIndex === 1) return new Error('simulated network failure');
+      return undefined;
+    };
+
+    const result = await makeEngine().syncOnce();
+
+    // At least one file errored.
+    assert.ok(
+      result.errors.some((e) => e.meeting === 'm1'),
+      'expected at least one download error for m1',
+    );
+    // Critical invariant: the final meeting folder must NOT exist on disk.
+    // If it did, a v2 reader would see meta.json (the sentinel) and treat
+    // the half-populated folder as a complete meeting.
+    assert.equal(
+      fs.existsSync(path.join(transcriptionsDir, 'm1')),
+      false,
+      'final meeting folder must not exist after a partial download',
+    );
+    // No file from the partial download should have been claimed as
+    // "downloaded" in the result.
+    assert.deepEqual(
+      result.downloaded.filter((d) => d.startsWith('m1/')),
+      [],
+    );
+    // And no per-file state should have been recorded for the meeting's
+    // text files -- promotion to meetingState only happens after rename.
+    const state = JSON.parse(fs.readFileSync(syncStatePath, 'utf-8')) as SyncState;
+    const m1Files = state.meetings['m1']?.files ?? {};
+    for (const name of ['meta.json', 'summary.md', 'transcript.md']) {
+      assert.equal(m1Files[name], undefined, `no staged state expected for ${name}`);
+    }
+  });
+
+  it('recovers cleanly on the next sync after a mid-download failure', async () => {
+    const appFolder = await mockClient.ensureFolder('Listener.AI');
+    mockClient.seedRemoteMeeting('m1', appFolder.id, [
+      { name: 'meta.json', content: '{"schemaVersion":2,"title":"M1"}' },
+      { name: 'summary.md', content: 'summary content' },
+      { name: 'transcript.md', content: 'transcript content' },
+    ]);
+
+    // First sync: fail mid-download.
+    let failOnce = true;
+    mockClient.shouldFailDownload = (_id, callIndex) => {
+      if (failOnce && callIndex === 1) {
+        failOnce = false;
+        return new Error('simulated network failure');
+      }
+      return undefined;
+    };
+    const first = await makeEngine().syncOnce();
+    assert.ok(first.errors.length >= 1, 'first sync should record the download error');
+    assert.equal(fs.existsSync(path.join(transcriptionsDir, 'm1')), false);
+
+    // Second sync: no failures injected. The engine should wipe the stale
+    // partial and complete the download.
+    mockClient.shouldFailDownload = undefined;
+    const second = await makeEngine().syncOnce();
+
+    assert.deepEqual(
+      second.errors.filter((e) => e.meeting === 'm1'),
+      [],
+      'second sync should complete without errors',
+    );
+    assert.deepEqual(second.downloaded.sort(), [
+      'm1/meta.json',
+      'm1/summary.md',
+      'm1/transcript.md',
+    ]);
+    const finalDir = path.join(transcriptionsDir, 'm1');
+    assert.equal(fs.existsSync(path.join(finalDir, 'meta.json')), true);
+    assert.equal(fs.existsSync(path.join(finalDir, 'summary.md')), true);
+    assert.equal(fs.existsSync(path.join(finalDir, 'transcript.md')), true);
+    assert.equal(fs.readFileSync(path.join(finalDir, 'summary.md'), 'utf-8'), 'summary content');
+  });
+
+  it('cleans up the staging directory after a successful download', async () => {
+    const appFolder = await mockClient.ensureFolder('Listener.AI');
+    mockClient.seedRemoteMeeting('m1', appFolder.id, [
+      { name: 'meta.json', content: '{"schemaVersion":2,"title":"M1"}' },
+      { name: 'summary.md', content: 's' },
+    ]);
+
+    await makeEngine().syncOnce();
+
+    // The staging dir (.listener-partial/m1) is consumed by the atomic
+    // rename; only the parent .listener-partial/ may remain (empty).
+    const partialMeetingDir = path.join(transcriptionsDir, '.listener-partial', 'm1');
+    assert.equal(
+      fs.existsSync(partialMeetingDir),
+      false,
+      'staging dir for the meeting should be gone after rename',
+    );
+  });
+
+  it('does not register the staging directory as a syncable meeting', async () => {
+    // Bookend: a leftover staging dir from a crashed prior sync must not be
+    // confused with a real meeting and start replicating itself to Drive.
+    const appFolder = await mockClient.ensureFolder('Listener.AI');
+    mockClient.seedRemoteMeeting('m1', appFolder.id, [
+      { name: 'meta.json', content: '{"schemaVersion":2,"title":"M1"}' },
+      { name: 'summary.md', content: 'summary content' },
+    ]);
+    // Pre-seed a stale partial dir as if a prior sync had crashed.
+    const stalePartial = path.join(transcriptionsDir, '.listener-partial', 'm1');
+    fs.mkdirSync(stalePartial, { recursive: true });
+    fs.writeFileSync(path.join(stalePartial, 'meta.json'), '{"old": true}');
+
+    const result = await makeEngine().syncOnce();
+
+    // The .listener-partial dir is hidden (starts with `.`) so it never
+    // appears as a local meeting in result.uploaded. Only the real download
+    // result for m1 should be visible.
+    assert.ok(
+      !result.uploaded.some((u) => u.startsWith('.listener-partial/')),
+      'staging dir must not be uploaded as a meeting',
+    );
+    assert.deepEqual(result.downloaded.sort(), ['m1/meta.json', 'm1/summary.md']);
+    // The stale partial is replaced and consumed by the new download.
+    assert.equal(fs.existsSync(stalePartial), false);
+  });
+
+  it('still tracks cloudOnly audio when the text download fully succeeds', async () => {
+    // The atomic-rename refactor must not regress the cloudOnly audio
+    // behavior: audio entries live in state, not on disk, and must survive
+    // the move from staging to final state.
+    const appFolder = await mockClient.ensureFolder('Listener.AI');
+    mockClient.seedRemoteMeeting('m1', appFolder.id, [
+      { name: 'meta.json', content: '{"schemaVersion":2,"title":"M1"}' },
+      { name: 'summary.md', content: 's' },
+      { name: 'recording.webm', content: Buffer.from([0x1a]) },
+    ]);
+
+    const result = await makeEngine().syncOnce();
+
+    assert.deepEqual(result.downloaded.sort(), ['m1/meta.json', 'm1/summary.md']);
+    assert.equal(
+      fs.existsSync(path.join(transcriptionsDir, 'm1', 'recording.webm')),
+      false,
+      'audio must not be downloaded',
+    );
+    const state = JSON.parse(fs.readFileSync(syncStatePath, 'utf-8')) as SyncState;
+    const audioEntry = state.meetings['m1'].files['recording.webm'];
+    assert.ok(audioEntry, 'cloudOnly audio entry should be recorded in state');
+    assert.equal(audioEntry.cloudOnly, true);
   });
 });

--- a/src/services/syncEngine.ts
+++ b/src/services/syncEngine.ts
@@ -129,6 +129,16 @@ const TOMBSTONES_FOLDER_NAME = '.listener-tombstones';
 const TOMBSTONE_RETENTION_DAYS = 30;
 const CONFIG_SYNC_FOLDER_NAME = '.listener-config-sync';
 const KNOWN_WORDS_FILENAME = 'known-words.json';
+// Staging area for new-meeting downloads. The download path writes every file
+// into `<transcriptionsDir>/.listener-partial/<meeting>/` and only renames into
+// place after all text files succeed. This preserves the v2 invariant that
+// `meta.json` is the last sentinel a reader sees: a crash mid-download leaves
+// a hidden partial folder that the next sync wipes and restarts from scratch,
+// never a real meeting folder containing only `meta.json` (which would fool
+// `isV2Folder` into treating an empty stub as a complete v2 meeting and the
+// missing summary/transcript as user-visible data loss).
+const PARTIAL_DOWNLOAD_DIRNAME = '.listener-partial';
+const META_JSON_FILENAME = 'meta.json';
 // Bump only on a breaking shape change (e.g. add per-word tombstones). Until
 // then, unknown versions are treated as "ignore the remote and re-upload from
 // local" so a future writer's format never destroys today's words on a
@@ -146,6 +156,18 @@ function safeBasename(name: string): string | null {
   const base = path.basename(name);
   if (!base || base === '.' || base === '..' || base.includes('\0')) return null;
   return base;
+}
+
+// Sort comparator that forces `meta.json` to the end of the iteration order
+// while leaving every other name in lexicographic position. Used by the
+// bidirectional download path to preserve the v2 sentinel invariant -- if
+// `meta.json` were written before its sibling content files and the sync
+// crashed mid-loop, `isV2Folder` would treat the half-populated folder as a
+// complete v2 meeting on the next startup.
+function metaJsonLastCompare(a: string, b: string): number {
+  if (a === META_JSON_FILENAME && b !== META_JSON_FILENAME) return 1;
+  if (b === META_JSON_FILENAME && a !== META_JSON_FILENAME) return -1;
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 // Set-equality (order-insensitive). Used by knownWords sync: order is a
@@ -703,62 +725,131 @@ export class SyncEngine {
   // Path B: remote-only meeting (downloaded from another device for the first
   // time). Creates the local folder, downloads text files, leaves audio as
   // cloudOnly entries (no auto-hydrate per A1' decision).
+  //
+  // Atomicity: all files land in `<transcriptionsDir>/.listener-partial/<meeting>/`
+  // first, then the whole directory is `fs.renameSync`d into place. This
+  // preserves the v2 sentinel invariant -- a crash mid-download never leaves
+  // a final `<meeting>/` directory containing only `meta.json` (which
+  // `isV2Folder` would treat as a complete v2 meeting and silently hide the
+  // missing summary/transcript). The staging dir name starts with `.` so it
+  // is excluded from `scanLocalMeetingNames` -- the next sync's
+  // `localExists=false` branch routes back here, wipes the stale partial, and
+  // retries cleanly from scratch.
   private async syncMeetingDownloadOnly(
     meetingName: string,
     remoteFolder: DriveFile,
     state: SyncState,
     result: SyncResult,
   ): Promise<void> {
-    let meetingState = state.meetings[meetingName];
-    if (!meetingState) {
-      meetingState = {
-        driveFolderId: remoteFolder.id,
-        files: {},
-        lastSyncedAt: new Date().toISOString(),
-      };
-      state.meetings[meetingName] = meetingState;
-    }
-    meetingState.driveFolderId = remoteFolder.id;
+    const finalPath = path.join(this.transcriptionsDir, meetingName);
+    const partialPath = path.join(this.transcriptionsDir, PARTIAL_DOWNLOAD_DIRNAME, meetingName);
 
-    const folderPath = path.join(this.transcriptionsDir, meetingName);
-    fs.mkdirSync(folderPath, { recursive: true });
+    // Wipe any leftover staging dir from a prior crashed download before
+    // starting fresh. `fs.rmSync` with force ignores ENOENT, so calling it
+    // unconditionally is safe and saves the existsSync round-trip.
+    fs.rmSync(partialPath, { recursive: true, force: true });
+    fs.mkdirSync(partialPath, { recursive: true });
 
     const remoteFiles = this.filterSafeRemoteEntries(
       await this.driveClient.listFolder(remoteFolder.id),
       `syncMeetingDownloadOnly("${meetingName}")`,
     );
+
+    // Stage everything in scratch state; only merge into state.meetings AFTER
+    // the rename succeeds. The pre-rename window is intentionally a no-op for
+    // the durable state file -- if we crash before the rename, the next sync
+    // sees no local folder, no entry in state.meetings, and routes back into
+    // this method to retry from scratch. Writing state.meetings eagerly here
+    // would trick the deletion-detection pass into reading "tracked meeting,
+    // not on disk, on Drive" as "user deleted locally" and tombstone the
+    // remote on the next cycle.
+    const stagedFiles: Record<string, FileSyncState> = {};
+    const stagedDownloads: string[] = [];
+    const stagedCloudOnly: Array<{ name: string; remote: DriveFile }> = [];
+    let downloadFailed = false;
+
     for (const remote of remoteFiles) {
       if (this.shouldExcludeName(remote.name)) continue;
       if (this.isAudioFile(remote.name)) {
         // Track but don't download. Phase 3D will surface a "Download for
         // playback" affordance per file.
-        this.trackCloudOnly(meetingState, remote.name, remote);
+        stagedCloudOnly.push({ name: remote.name, remote });
         this.logger(`Cloud-only audio tracked: ${meetingName}/${remote.name}`);
         continue;
       }
       try {
         const content = await this.driveClient.downloadFile(remote.id);
-        const target = path.join(folderPath, remote.name);
+        const target = path.join(partialPath, remote.name);
         fs.writeFileSync(target, content);
         const stat = fs.statSync(target);
-        meetingState.files[remote.name] = {
+        stagedFiles[remote.name] = {
           driveFileId: remote.id,
           localMtimeMs: stat.mtimeMs,
           driveModifiedTime: remote.modifiedTime,
           mimeType: remote.mimeType,
           lastUploadedAt: new Date().toISOString(),
         };
-        result.downloaded.push(`${meetingName}/${remote.name}`);
-        this.logger(`Downloaded ${meetingName}/${remote.name} from ${remote.id}`);
+        stagedDownloads.push(`${meetingName}/${remote.name}`);
+        this.logger(`Downloaded ${meetingName}/${remote.name} from ${remote.id} (staged)`);
       } catch (err) {
+        downloadFailed = true;
         result.errors.push({
           meeting: meetingName,
           file: remote.name,
           error: (err as Error).message,
         });
+        // Continue draining the loop: the result should still record every
+        // file-level error so the UI can surface them, even though the rename
+        // will be skipped at the end.
       }
     }
+
+    if (downloadFailed) {
+      // Leave the partial dir for inspection / retry visibility. The next
+      // sync will rmSync it before re-staging, so no leak. Don't touch
+      // state.meetings at all -- on retry the meeting still routes as
+      // remote-only and we re-stage from scratch.
+      this.logger(
+        `syncMeetingDownloadOnly("${meetingName}"): aborted before rename; staging dir kept at ${partialPath}.`,
+      );
+      return;
+    }
+
+    // Atomic flip: move the staging dir into place. Same filesystem (both
+    // under transcriptionsDir) so renameSync is a single inode swap. Note
+    // that finalPath cannot already exist in this code path -- the caller
+    // only invokes us when `localExists=false`. If a race did create it
+    // between the check and here, prefer to surface a clear error rather
+    // than silently overwriting a sibling meeting.
+    if (fs.existsSync(finalPath)) {
+      result.errors.push({
+        meeting: meetingName,
+        error: `download race: ${meetingName} appeared locally during download; staging kept at ${partialPath}`,
+      });
+      return;
+    }
+    fs.renameSync(partialPath, finalPath);
+
+    // Commit: now register state.meetings, attach staged files, surface the
+    // downloads in the caller's result. From this point a crash leaves a
+    // consistent on-disk + state pair that the next sync treats as steady.
+    const meetingState: MeetingSyncState = state.meetings[meetingName] ?? {
+      driveFolderId: remoteFolder.id,
+      files: {},
+      lastSyncedAt: new Date().toISOString(),
+    };
+    meetingState.driveFolderId = remoteFolder.id;
+    for (const [name, fileState] of Object.entries(stagedFiles)) {
+      meetingState.files[name] = fileState;
+    }
+    for (const { name, remote } of stagedCloudOnly) {
+      this.trackCloudOnly(meetingState, name, remote);
+    }
     meetingState.lastSyncedAt = new Date().toISOString();
+    state.meetings[meetingName] = meetingState;
+    for (const label of stagedDownloads) {
+      result.downloaded.push(label);
+    }
   }
 
   // Path C: meeting exists on both sides. Diff each file and resolve.
@@ -794,7 +885,14 @@ export class SyncEngine {
     const remoteByName = new Map(remoteFiles.map((f) => [f.name, f]));
     const allFilenames = new Set<string>([...localByName.keys(), ...remoteByName.keys()]);
 
-    for (const filename of [...allFilenames].sort()) {
+    // Defensive ordering: process `meta.json` LAST so a crash mid-loop never
+    // promotes a half-populated folder to v2 (the writer side in
+    // `outputService.writeV2Files` makes the same guarantee). Practically
+    // matters only when a local meeting folder predates the v2 sentinel
+    // (legacy v1, manual restore, or a still-staged partial download) -- the
+    // rest of the time `meta.json` is already on disk and reordering is a
+    // no-op. Cheap insurance; no semantic change for the common case.
+    for (const filename of [...allFilenames].sort(metaJsonLastCompare)) {
       if (this.shouldExcludeName(filename)) continue;
       const localEntry = localByName.get(filename);
       const remoteEntry = remoteByName.get(filename);

--- a/src/services/syncEngine.ts
+++ b/src/services/syncEngine.ts
@@ -830,26 +830,22 @@ export class SyncEngine {
     }
     fs.renameSync(partialPath, finalPath);
 
-    // Commit: now register state.meetings, attach staged files, surface the
-    // downloads in the caller's result. From this point a crash leaves a
-    // consistent on-disk + state pair that the next sync treats as steady.
-    const meetingState: MeetingSyncState = state.meetings[meetingName] ?? {
+    // Commit: register state.meetings as a fresh entry, then attach
+    // cloudOnly audio. syncOnce's deletion-detect pass guarantees
+    // state.meetings[meetingName] is undefined at this point (any pre-
+    // existing entry without a local folder was tombstoned or orphan-cleaned
+    // in step 2 before we got here), so building a fresh object is correct
+    // and avoids retaining stale fields from a hypothetical leftover entry.
+    const meetingState: MeetingSyncState = {
       driveFolderId: remoteFolder.id,
-      files: {},
+      files: stagedFiles,
       lastSyncedAt: new Date().toISOString(),
     };
-    meetingState.driveFolderId = remoteFolder.id;
-    for (const [name, fileState] of Object.entries(stagedFiles)) {
-      meetingState.files[name] = fileState;
-    }
     for (const { name, remote } of stagedCloudOnly) {
       this.trackCloudOnly(meetingState, name, remote);
     }
-    meetingState.lastSyncedAt = new Date().toISOString();
     state.meetings[meetingName] = meetingState;
-    for (const label of stagedDownloads) {
-      result.downloaded.push(label);
-    }
+    result.downloaded.push(...stagedDownloads);
   }
 
   // Path C: meeting exists on both sides. Diff each file and resolve.


### PR DESCRIPTION
## Summary

- Stage `syncMeetingDownloadOnly` writes in `<transcriptionsDir>/.listener-partial/<meeting>/` and atomically `renameSync` into place only when the entire download loop succeeds. A mid-flight crash now leaves a hidden partial dir (auto-cleaned on the next sync) instead of a real meeting folder with only `meta.json` present.
- Defer `state.meetings[meetingName]` and `result.downloaded` mutations until after the rename commits, so a failed download never tricks the next cycle's deletion-detection pass into tombstoning the remote meeting.
- Sort `syncMeetingBidirectional`'s iteration so `meta.json` is always processed last. Cheap defensive cover for the narrow case where the local folder lacks a sentinel before sync starts (legacy/manual restore).

The bug: `outputService.writeV2Files` writes `meta.json` last on purpose -- it is the v2 sentinel read by `isV2Folder`. The download side wrote files in remote-listing order, so if `meta.json` arrived first and the sync aborted, the partial folder was indistinguishable from a complete v2 meeting (no summary, no transcript visible to the user) and subsequent syncs never re-fetched the missing pieces.

## Test plan

- [x] `pnpm run build` passes (tsc + vite)
- [x] `pnpm run lint` passes (0 warnings, 0 errors)
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (325/325, including 5 new tests in `SyncEngine: download atomicity (meta.json sentinel safety)`)
- New regression tests in `src/services/syncEngine.test.ts`:
  - Verifies a mid-download failure leaves no `<transcriptionsDir>/<meeting>/` (the bug's core symptom)
  - Verifies the next sync recovers cleanly and produces a complete meeting
  - Verifies the staging dir is consumed by the rename on success
  - Verifies a stale partial dir from a prior crash never gets uploaded as a "meeting"
  - Verifies cloudOnly audio tracking still works through the new atomic flow

Mock extended with `shouldFailDownload(fileId, callIndex)` so tests can fail the Nth download specifically. Reusing `failNextUpload`'s one-shot shape would have been too coarse for "fail the 2nd of 3 downloads".

🤖 Generated with [Claude Code](https://claude.com/claude-code)