### PR TITLE
Extract meetings-management IPC handlers to src/ipc/

### DIFF
--- a/src/ipc/meetingsManagement.test.ts
+++ b/src/ipc/meetingsManagement.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import Module from 'node:module';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import type { IpcContext } from './types';
+
+// Intercepts CJS `require('electron')` so the meetingsManagement module --
+// which static-imports `ipcMain`, `app`, and `dialog` from electron -- loads
+// outside an Electron runtime. The mocked ipcMain just records each
+// `handle()` call so we can assert that register() wires up the three
+// channels the rest of the codebase expects (renderer preload calls them by
+// these exact string names; a typo here would silently break the GUI).
+//
+// We use a deferred require for meetingsManagement so it picks up the
+// intercepted loader. A normal top-of-file import would resolve before
+// beforeEach runs.
+type ElectronStub = {
+  ipcMain: { handle: (channel: string, fn: (...args: unknown[]) => unknown) => void };
+  app: { getPath: () => string };
+  dialog: Record<string, unknown>;
+};
+
+type ModuleWithLoad = typeof Module & {
+  _load: (request: string, parent: NodeModule | null, isMain: boolean) => unknown;
+};
+
+describe('meetingsManagement.register', () => {
+  let originalLoad: ModuleWithLoad['_load'];
+  let handlers: Map<string, (...args: unknown[]) => unknown>;
+  let registerFn: ((ctx: IpcContext) => void) | null = null;
+
+  beforeEach(() => {
+    handlers = new Map();
+    const fakeElectron: ElectronStub = {
+      ipcMain: { handle: (channel, fn) => handlers.set(channel, fn) },
+      app: { getPath: () => '/tmp/listener-ai-test' },
+      dialog: {},
+    };
+    const moduleAny = Module as ModuleWithLoad;
+    originalLoad = moduleAny._load;
+    moduleAny._load = function (request: string, parent: NodeModule | null, isMain: boolean) {
+      if (request === 'electron') return fakeElectron;
+      return originalLoad.call(this, request, parent, isMain);
+    };
+    // Force a fresh require so the module body re-runs against the
+    // intercepted loader (relevant when other tests in the suite have
+    // already required the real electron stub).
+    const mPath = require.resolve('./meetingsManagement');
+    delete require.cache[mPath];
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('./meetingsManagement') as { register: (ctx: IpcContext) => void };
+    registerFn = mod.register;
+  });
+
+  afterEach(() => {
+    const moduleAny = Module as ModuleWithLoad;
+    moduleAny._load = originalLoad;
+    // Drop the cache entry so production callers (and other test files)
+    // require the module against the real loader.
+    const mPath = require.resolve('./meetingsManagement');
+    delete require.cache[mPath];
+    registerFn = null;
+  });
+
+  it('registers delete-meeting, export-recording-m4a, and merge-recordings channels', () => {
+    assert.ok(registerFn, 'register should be importable');
+    registerFn!({
+      getMainWindow: () => null,
+      configService: {} as IpcContext['configService'],
+      notificationService: {} as IpcContext['notificationService'],
+      ffmpegManager: {} as IpcContext['ffmpegManager'],
+      ensureGeminiService: () => null,
+      maybeAutoSync: () => {},
+      isContainedTranscriptionPath: (p): p is string => typeof p === 'string',
+      formatAiCredentialsError: () => 'no credentials',
+    });
+    assert.deepEqual([...handlers.keys()].sort(), [
+      'delete-meeting',
+      'export-recording-m4a',
+      'merge-recordings',
+    ]);
+  });
+});

--- a/src/ipc/meetingsManagement.test.ts
+++ b/src/ipc/meetingsManagement.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 import Module from 'node:module';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import type { IpcContext } from './types';
@@ -47,7 +46,6 @@ describe('meetingsManagement.register', () => {
     // already required the real electron stub).
     const mPath = require.resolve('./meetingsManagement');
     delete require.cache[mPath];
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const mod = require('./meetingsManagement') as { register: (ctx: IpcContext) => void };
     registerFn = mod.register;
   });

--- a/src/ipc/meetingsManagement.ts
+++ b/src/ipc/meetingsManagement.ts
@@ -1,0 +1,332 @@
+import { execFile } from 'child_process';
+import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+import { app, dialog, ipcMain } from 'electron';
+import { extensionForMimeType } from '../audioFormats';
+import { formatTimestamp, sanitizeForPath, saveTranscription } from '../outputService';
+import { concatAudioFiles } from '../services/audioConcatService';
+import { metadataService } from '../services/metadataService';
+import type { IpcContext } from './types';
+
+const execFileAsync = promisify(execFile);
+
+// Single-flight gate for `merge-recordings`. A second click while a merge is
+// running returns `{ code: 'merge-busy' }` rather than racing against the
+// in-flight one for the shared GeminiService and the merged-output filename
+// slot. Lives at module scope (not on ctx) because this state is local to
+// this handler set and shouldn't leak into the IpcContext surface.
+let mergeInFlight = false;
+
+export function register(ctx: IpcContext): void {
+  // Permanently removes a meeting: audio file, metadata JSON, and the
+  // transcription folder (if one exists). Containment-checks every path
+  // before touching disk so a buggy or compromised renderer can't aim
+  // fs.rmSync at arbitrary locations. Triggers a Drive sync immediately
+  // afterward so the Phase 3C tombstone propagation kicks in -- otherwise
+  // the user wouldn't see the deletion mirrored on their other devices
+  // until the next 60s timer tick.
+  ipcMain.handle('delete-meeting', async (_, audioFilePath: string) => {
+    try {
+      if (!audioFilePath || typeof audioFilePath !== 'string') {
+        return { success: false as const, error: 'Invalid audio file path' };
+      }
+      const recordingsDir = path.join(app.getPath('userData'), 'recordings');
+      const resolved = path.resolve(audioFilePath);
+      if (!resolved.startsWith(recordingsDir + path.sep)) {
+        return { success: false as const, error: 'Path is outside the recordings directory' };
+      }
+
+      // Pull metadata first so we know whether to clean up a transcription
+      // folder. Missing metadata is fine (raw recording never transcribed).
+      const meta = await metadataService.getMetadata(resolved);
+      if (meta?.transcriptionPath && ctx.isContainedTranscriptionPath(meta.transcriptionPath)) {
+        try {
+          fs.rmSync(meta.transcriptionPath, { recursive: true, force: true });
+        } catch (err) {
+          console.error('Failed to remove transcription folder:', err);
+          // Continue -- audio cleanup still useful even if folder rm partially failed.
+        }
+      }
+
+      try {
+        fs.rmSync(resolved, { force: true });
+      } catch (err) {
+        console.error('Failed to remove audio file:', err);
+      }
+
+      await metadataService.deleteMetadata(resolved);
+
+      // Refresh the renderer's list immediately; auto-sync to Drive in the
+      // background so the deletion propagates to other devices via tombstone.
+      const mainWindow = ctx.getMainWindow();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('recordings-changed');
+      }
+      ctx.maybeAutoSync();
+
+      return { success: true as const };
+    } catch (error) {
+      console.error('delete-meeting failed:', error);
+      return {
+        success: false as const,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  });
+
+  ipcMain.handle('export-recording-m4a', async (_, srcPath: string) => {
+    try {
+      if (!srcPath || typeof srcPath !== 'string') {
+        return { success: false, error: 'Invalid source path' };
+      }
+      // Containment: the renderer is trusted today, but bound srcPath to the
+      // recordings directory so a future renderer bug can't transcode arbitrary
+      // local files. realpath resolves symlinks before the prefix check.
+      const recordingsDir = path.join(app.getPath('userData'), 'recordings');
+      let resolvedSrc: string;
+      try {
+        resolvedSrc = await fs.promises.realpath(srcPath);
+      } catch {
+        return { success: false, error: 'Source recording not found' };
+      }
+      const resolvedRoot = await fs.promises.realpath(recordingsDir).catch(() => recordingsDir);
+      if (!resolvedSrc.startsWith(resolvedRoot + path.sep)) {
+        return { success: false, error: 'Source path is outside the recordings directory' };
+      }
+
+      const ffmpegPath = await ctx.ffmpegManager.ensureFFmpeg();
+      if (!ffmpegPath) {
+        return {
+          success: false,
+          code: 'ffmpeg-missing',
+          error: 'FFmpeg is required for M4A export.',
+        };
+      }
+
+      const baseName = path.basename(resolvedSrc, path.extname(resolvedSrc));
+      const dialogOptions = {
+        title: 'Export recording as M4A',
+        defaultPath: `${baseName}.m4a`,
+        filters: [{ name: 'M4A Audio', extensions: ['m4a'] }],
+      };
+      const mainWindow = ctx.getMainWindow();
+      const saveResult = mainWindow
+        ? await dialog.showSaveDialog(mainWindow, dialogOptions)
+        : await dialog.showSaveDialog(dialogOptions);
+      if (saveResult.canceled || !saveResult.filePath) {
+        return { canceled: true };
+      }
+      const destPath = saveResult.filePath;
+      // Write to a sibling temp file and atomically rename on success so a
+      // failed encode never overwrites the user's picked path with a partial.
+      const tmpPath = `${destPath}.partial`;
+
+      try {
+        // Force -f ipod (M4A muxer) because the `.partial` extension defeats
+        // ffmpeg's format-by-extension detection otherwise.
+        await execFileAsync(ffmpegPath, [
+          '-y',
+          '-loglevel',
+          'error',
+          '-i',
+          resolvedSrc,
+          '-vn',
+          '-c:a',
+          'aac',
+          '-b:a',
+          '128k',
+          '-movflags',
+          '+faststart',
+          '-f',
+          'ipod',
+          tmpPath,
+        ]);
+        await fs.promises.rename(tmpPath, destPath);
+      } catch (encodeError) {
+        await fs.promises.unlink(tmpPath).catch(() => {});
+        throw encodeError;
+      }
+
+      return { success: true, path: destPath };
+    } catch (error) {
+      console.error('Error exporting M4A:', error);
+      // execFileAsync rejections carry stderr on the error object — surface it
+      // so renderer-side toasts aren't reduced to "Command failed".
+      const stderr = (error as { stderr?: string } | null)?.stderr;
+      const baseMessage = error instanceof Error ? error.message : String(error);
+      const message = stderr ? `${baseMessage.split('\n')[0]} — ${stderr.trim()}` : baseMessage;
+      return { success: false, error: message };
+    }
+  });
+
+  // Merge multiple recordings: concat audio files, then run the standard
+  // transcription pipeline on the merged file. Originals are left untouched.
+  // Resolves source folder names from per-recording metadata so the merged note's
+  // `mergedFrom` frontmatter (and "Sources" body section) can reference them.
+  //
+  // Single-flight: a second click while a merge is running returns
+  // `{ code: 'merge-busy' }` rather than racing against the in-flight one for
+  // the shared geminiService and the merged-output filename slot.
+  ipcMain.handle('merge-recordings', async (_, opts: { paths: string[]; title?: string }) => {
+    if (mergeInFlight) {
+      return {
+        success: false,
+        code: 'merge-busy',
+        error: 'Another merge is already running. Wait for it to finish.',
+      };
+    }
+    mergeInFlight = true;
+    const sendProgress = (percent: number, message: string) => {
+      const mainWindow = ctx.getMainWindow();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('transcription-progress', { percent, message });
+      }
+    };
+    try {
+      const inputPaths = Array.isArray(opts?.paths) ? opts.paths : [];
+      if (inputPaths.length < 2) {
+        return { success: false, error: 'At least 2 recordings are required to merge' };
+      }
+
+      // Ensure recordings dir exists before realpath so symlink resolution can't
+      // throw on a fresh install. Containment: every input must then resolve
+      // inside that directory.
+      const recordingsDir = path.join(app.getPath('userData'), 'recordings');
+      await fs.promises.mkdir(recordingsDir, { recursive: true });
+      const resolvedRoot = await fs.promises.realpath(recordingsDir);
+      const resolvedInputs: string[] = [];
+      for (const p of inputPaths) {
+        if (typeof p !== 'string' || !p) {
+          return { success: false, error: 'Invalid input path' };
+        }
+        let resolved: string;
+        try {
+          resolved = await fs.promises.realpath(p);
+        } catch {
+          return { success: false, error: `Recording not found: ${path.basename(p)}` };
+        }
+        if (!resolved.startsWith(resolvedRoot + path.sep)) {
+          return { success: false, error: 'Source path is outside the recordings directory' };
+        }
+        resolvedInputs.push(resolved);
+      }
+
+      const geminiService = ctx.ensureGeminiService();
+      if (!geminiService) {
+        return { success: false, error: ctx.formatAiCredentialsError() };
+      }
+
+      const ffmpegPath = await ctx.ffmpegManager.ensureFFmpeg();
+      if (!ffmpegPath) {
+        return {
+          success: false,
+          code: 'ffmpeg-missing',
+          error: 'FFmpeg is required to merge recordings.',
+        };
+      }
+
+      const rawTitle = opts.title?.trim() || 'Merged Meeting';
+      const safeTitle = sanitizeForPath(rawTitle) || 'Merged Meeting';
+      // Always emit webm/opus -- matches MediaRecorder native output and survives
+      // the stream-copy fast path when all inputs are also webm. UUID suffix
+      // avoids collisions when two merges with the same title start in the same
+      // second (formatTimestamp is second-granularity).
+      const mergedExt = extensionForMimeType('audio/webm');
+      const mergedAudioPath = path.join(
+        recordingsDir,
+        `${safeTitle}_${formatTimestamp()}_${randomUUID().slice(0, 8)}.${mergedExt}`,
+      );
+
+      sendProgress(5, 'Merging audio files...');
+
+      // Run the metadata lookup concurrently with the ffmpeg concat -- they're
+      // independent and concat is the long pole, so the metadata reads are free.
+      // Recordings without a transcription contribute nothing to mergedFrom; we
+      // also drop entries whose transcription folder no longer exists on disk
+      // so the merged note's Sources section never references stale ghosts.
+      const [, metas] = await Promise.all([
+        concatAudioFiles({ ffmpegPath, inputPaths: resolvedInputs, outputPath: mergedAudioPath }),
+        Promise.all(resolvedInputs.map((p) => metadataService.getMetadata(p))),
+      ]);
+      const sourceFolders = metas
+        .filter((m): m is NonNullable<typeof m> => !!m?.transcriptionPath)
+        .filter((m) => fs.existsSync(m.transcriptionPath!))
+        .map((m) => path.basename(m.transcriptionPath!));
+
+      sendProgress(15, 'Transcribing merged recording...');
+
+      // Compress the transcription progress into 15-95% to leave room for the
+      // concat phase at the start and the save phase at the end.
+      const progressCallback = (percent: number, message: string) => {
+        sendProgress(15 + Math.round(percent * 0.8), message);
+      };
+
+      const summaryPrompt = ctx.configService.getSummaryPrompt();
+      const result = await geminiService.transcribeAudio(
+        mergedAudioPath,
+        progressCallback,
+        summaryPrompt,
+      );
+
+      // User-supplied title takes precedence; only fall back to Gemini's
+      // suggestion when the user didn't provide one. Gemini almost always
+      // returns a suggestedTitle, so the previous order silently overrode the
+      // user's --title flag / dialog input.
+      const finalTitle = opts.title?.trim() || result.suggestedTitle || rawTitle;
+      let transcriptionPath: string;
+      try {
+        transcriptionPath = saveTranscription({
+          title: finalTitle,
+          result,
+          audioFilePath: mergedAudioPath,
+          dataPath: app.getPath('userData'),
+          mergedFrom: sourceFolders,
+        });
+        ctx.maybeAutoSync();
+      } catch (error) {
+        console.error('Failed to save merged transcription files:', error);
+        const message = error instanceof Error ? error.message : String(error);
+        ctx.notificationService.notifyTranscriptionFailed(
+          'Merge failed: could not save the transcription.',
+        );
+        return { success: false, error: `Failed to save merged transcription: ${message}` };
+      }
+
+      try {
+        await metadataService.saveMetadata(mergedAudioPath, {
+          title: finalTitle,
+          suggestedTitle: result.suggestedTitle,
+          transcriptionPath,
+          customFields: result.customFields,
+          transcribedAt: new Date().toISOString(),
+        });
+      } catch (error) {
+        // Metadata write is best-effort -- the transcription folder is the
+        // source of truth. Log and continue rather than fail the merge.
+        console.error('Failed to save merged metadata:', error);
+      }
+
+      sendProgress(100, 'Merge complete');
+
+      ctx.notificationService.notifyTranscriptionComplete(finalTitle);
+      return {
+        success: true,
+        data: result,
+        mergedAudioPath,
+        transcriptionPath,
+        mergedFrom: sourceFolders,
+      };
+    } catch (error) {
+      console.error('Error merging recordings:', error);
+      const stderr = (error as { stderr?: string } | null)?.stderr;
+      const baseMessage = error instanceof Error ? error.message : String(error);
+      const message = stderr ? `${baseMessage.split('\n')[0]} — ${stderr.trim()}` : baseMessage;
+      ctx.notificationService.notifyTranscriptionFailed('Merge failed. Check the app for details.');
+      return { success: false, error: message };
+    } finally {
+      mergeInFlight = false;
+    }
+  });
+}

--- a/src/ipc/register.ts
+++ b/src/ipc/register.ts
@@ -1,0 +1,12 @@
+import * as meetingsManagementIpc from './meetingsManagement';
+import type { IpcContext } from './types';
+
+// Single wiring point for every src/ipc/<domain>.ts module that has been
+// split out of main.ts. main.ts builds one IpcContext, calls this once, and
+// each domain registers its own ipcMain handlers against the shared context.
+//
+// New domain modules added in follow-up PRs append themselves here -- main.ts
+// stays touched only when the context surface changes.
+export function registerAllIpc(ctx: IpcContext): void {
+  meetingsManagementIpc.register(ctx);
+}

--- a/src/ipc/types.ts
+++ b/src/ipc/types.ts
@@ -1,0 +1,38 @@
+import type { BrowserWindow } from 'electron';
+import type { ConfigService } from '../configService';
+import type { GeminiService } from '../geminiService';
+import type { NotificationService } from '../services/notificationService';
+import type { FFmpegManager } from '../services/ffmpegManager';
+
+// Context handed to every src/ipc/<domain>.ts module's register() entry point.
+//
+// This is the seam between main.ts (which still owns process-wide state -- the
+// main window handle, the GeminiService cache slot, the Drive sync trigger) and
+// the per-domain IPC handlers that have been split out of main.ts.
+//
+// Discipline: only add a field here when an IPC module that this PR is
+// extracting actually consumes it. Pre-emptively widening the surface forces
+// every future caller of registerAllIpc() to wire up plumbing for handlers
+// that haven't moved yet -- which leads to half-initialised contexts and
+// silent nulls. Each domain extraction adds its own dependencies as it lands.
+export interface IpcContext {
+  getMainWindow(): BrowserWindow | null;
+  configService: ConfigService;
+  notificationService: NotificationService;
+  ffmpegManager: FFmpegManager;
+  // GeminiService is module-cached in main.ts and re-created on relevant
+  // config changes (model, provider, OAuth). Handlers that may be the first
+  // caller after a config flip use this to get-or-create instead of reaching
+  // for a stale reference.
+  ensureGeminiService(): GeminiService | null;
+  // Fire-and-forget Google Drive sync trigger. No-ops when sync is disabled
+  // or unauthenticated; safe to call from any handler that mutates a meeting
+  // (save, merge, delete) so tombstones / new content propagate promptly.
+  maybeAutoSync(): void;
+  // Defense in depth: validates that a renderer-supplied transcription folder
+  // path lives inside the transcriptions directory before any fs write hits it.
+  isContainedTranscriptionPath(folderPath: string | undefined): folderPath is string;
+  // Formats the provider-aware "you need credentials" message so handlers
+  // can surface a consistent error string regardless of aiProvider.
+  formatAiCredentialsError(): string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,5 @@
-import { execFile } from 'child_process';
-import { randomUUID } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
-import { promisify } from 'util';
 import {
   BrowserWindow,
   Menu,
@@ -22,11 +19,7 @@ import {
   AgentService,
   type ConfigProposal,
 } from './agentService';
-import {
-  extensionForMimeType,
-  isSupportedAudioExtension,
-  isTranscriptionTempFile,
-} from './audioFormats';
+import { isSupportedAudioExtension, isTranscriptionTempFile } from './audioFormats';
 import { type AppConfig, ConfigService } from './configService';
 import { loginCodexOAuth } from './codexOAuth';
 import { getDataPath } from './dataPath';
@@ -44,17 +37,14 @@ import { MenuBarManager } from './menuBarManager';
 import { NotionService } from './notionService';
 import {
   autoMigrateLegacyOnStartup,
-  formatTimestamp,
   gcLegacyBackups,
   getTranscriptionsDir,
   type LiveNote,
   readTranscription,
-  sanitizeForPath,
   saveTranscription,
   updateTranscriptionStatus,
 } from './outputService';
 import { ALL_FIELDS, type SearchField, searchTranscriptions } from './searchService';
-import { concatAudioFiles } from './services/audioConcatService';
 import { autoUpdaterService } from './services/autoUpdaterService';
 import { FFmpegManager } from './services/ffmpegManager';
 import { FileHandlerService } from './services/fileHandlerService';
@@ -70,6 +60,7 @@ import {
 import { SYSTEM_AUDIO_FORMAT, SystemAudioService } from './services/systemAudioService';
 import { SimpleAudioRecorder } from './simpleAudioRecorder';
 import { SLACK_WEBHOOK_PREFIX, SlackService, isLikelySlackWebhookUrl } from './slackService';
+import { registerAllIpc } from './ipc/register';
 
 // Enable macOS system-audio loopback capture so getDisplayMedia({audio: 'loopback'})
 // can pull Zoom/Meet participant audio alongside the mic.
@@ -200,6 +191,16 @@ function createGeminiService(): GeminiService | null {
     codexTranscriptionModel: configService.getCodexTranscriptionModel(),
     dataPath: app.getPath('userData'),
   });
+}
+
+// Lazy get-or-create for the module-scope geminiService slot. Handlers that
+// may run before the eager init in createWindow() (e.g. merge-recordings
+// triggered immediately after a credentials change) use this so they don't
+// hit a stale null. Returns null when no AI credentials are configured.
+function ensureGeminiService(): GeminiService | null {
+  if (geminiService) return geminiService;
+  geminiService = createGeminiService();
+  return geminiService;
 }
 
 function registerGlobalShortcut() {
@@ -848,319 +849,19 @@ ipcMain.handle('cancel-ffmpeg-download', async () => {
   return { success: true };
 });
 
-const execFileAsync = promisify(execFile);
-
-// Returns `code: 'ffmpeg-missing'` so the renderer can route users into the
-// existing ffmpeg-download UI (triggered by transcription) rather than
-// duplicating that flow here.
-// Permanently removes a meeting: audio file, metadata JSON, and the
-// transcription folder (if one exists). Containment-checks every path
-// before touching disk so a buggy or compromised renderer can't aim
-// fs.rmSync at arbitrary locations. Triggers a Drive sync immediately
-// afterward so the Phase 3C tombstone propagation kicks in -- otherwise
-// the user wouldn't see the deletion mirrored on their other devices
-// until the next 60s timer tick.
-ipcMain.handle('delete-meeting', async (_, audioFilePath: string) => {
-  try {
-    if (!audioFilePath || typeof audioFilePath !== 'string') {
-      return { success: false as const, error: 'Invalid audio file path' };
-    }
-    const recordingsDir = path.join(app.getPath('userData'), 'recordings');
-    const resolved = path.resolve(audioFilePath);
-    if (!resolved.startsWith(recordingsDir + path.sep)) {
-      return { success: false as const, error: 'Path is outside the recordings directory' };
-    }
-
-    // Pull metadata first so we know whether to clean up a transcription
-    // folder. Missing metadata is fine (raw recording never transcribed).
-    const meta = await metadataService.getMetadata(resolved);
-    if (meta?.transcriptionPath && isContainedTranscriptionPath(meta.transcriptionPath)) {
-      try {
-        fs.rmSync(meta.transcriptionPath, { recursive: true, force: true });
-      } catch (err) {
-        console.error('Failed to remove transcription folder:', err);
-        // Continue -- audio cleanup still useful even if folder rm partially failed.
-      }
-    }
-
-    try {
-      fs.rmSync(resolved, { force: true });
-    } catch (err) {
-      console.error('Failed to remove audio file:', err);
-    }
-
-    await metadataService.deleteMetadata(resolved);
-
-    // Refresh the renderer's list immediately; auto-sync to Drive in the
-    // background so the deletion propagates to other devices via tombstone.
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('recordings-changed');
-    }
-    maybeAutoSync();
-
-    return { success: true as const };
-  } catch (error) {
-    console.error('delete-meeting failed:', error);
-    return {
-      success: false as const,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
-});
-
-ipcMain.handle('export-recording-m4a', async (_, srcPath: string) => {
-  try {
-    if (!srcPath || typeof srcPath !== 'string') {
-      return { success: false, error: 'Invalid source path' };
-    }
-    // Containment: the renderer is trusted today, but bound srcPath to the
-    // recordings directory so a future renderer bug can't transcode arbitrary
-    // local files. realpath resolves symlinks before the prefix check.
-    const recordingsDir = path.join(app.getPath('userData'), 'recordings');
-    let resolvedSrc: string;
-    try {
-      resolvedSrc = await fs.promises.realpath(srcPath);
-    } catch {
-      return { success: false, error: 'Source recording not found' };
-    }
-    const resolvedRoot = await fs.promises.realpath(recordingsDir).catch(() => recordingsDir);
-    if (!resolvedSrc.startsWith(resolvedRoot + path.sep)) {
-      return { success: false, error: 'Source path is outside the recordings directory' };
-    }
-
-    const ffmpegPath = await ffmpegManager.ensureFFmpeg();
-    if (!ffmpegPath) {
-      return {
-        success: false,
-        code: 'ffmpeg-missing',
-        error: 'FFmpeg is required for M4A export.',
-      };
-    }
-
-    const baseName = path.basename(resolvedSrc, path.extname(resolvedSrc));
-    const dialogOptions = {
-      title: 'Export recording as M4A',
-      defaultPath: `${baseName}.m4a`,
-      filters: [{ name: 'M4A Audio', extensions: ['m4a'] }],
-    };
-    const saveResult = mainWindow
-      ? await dialog.showSaveDialog(mainWindow, dialogOptions)
-      : await dialog.showSaveDialog(dialogOptions);
-    if (saveResult.canceled || !saveResult.filePath) {
-      return { canceled: true };
-    }
-    const destPath = saveResult.filePath;
-    // Write to a sibling temp file and atomically rename on success so a
-    // failed encode never overwrites the user's picked path with a partial.
-    const tmpPath = `${destPath}.partial`;
-
-    try {
-      // Force -f ipod (M4A muxer) because the `.partial` extension defeats
-      // ffmpeg's format-by-extension detection otherwise.
-      await execFileAsync(ffmpegPath, [
-        '-y',
-        '-loglevel',
-        'error',
-        '-i',
-        resolvedSrc,
-        '-vn',
-        '-c:a',
-        'aac',
-        '-b:a',
-        '128k',
-        '-movflags',
-        '+faststart',
-        '-f',
-        'ipod',
-        tmpPath,
-      ]);
-      await fs.promises.rename(tmpPath, destPath);
-    } catch (encodeError) {
-      await fs.promises.unlink(tmpPath).catch(() => {});
-      throw encodeError;
-    }
-
-    return { success: true, path: destPath };
-  } catch (error) {
-    console.error('Error exporting M4A:', error);
-    // execFileAsync rejections carry stderr on the error object — surface it
-    // so renderer-side toasts aren't reduced to "Command failed".
-    const stderr = (error as { stderr?: string } | null)?.stderr;
-    const baseMessage = error instanceof Error ? error.message : String(error);
-    const message = stderr ? `${baseMessage.split('\n')[0]} — ${stderr.trim()}` : baseMessage;
-    return { success: false, error: message };
-  }
-});
-
-// Merge multiple recordings: concat audio files, then run the standard
-// transcription pipeline on the merged file. Originals are left untouched.
-// Resolves source folder names from per-recording metadata so the merged note's
-// `mergedFrom` frontmatter (and "Sources" body section) can reference them.
-//
-// Single-flight: a second click while a merge is running returns
-// `{ code: 'merge-busy' }` rather than racing against the in-flight one for
-// the shared geminiService and the merged-output filename slot.
-let mergeInFlight = false;
-ipcMain.handle('merge-recordings', async (_, opts: { paths: string[]; title?: string }) => {
-  if (mergeInFlight) {
-    return {
-      success: false,
-      code: 'merge-busy',
-      error: 'Another merge is already running. Wait for it to finish.',
-    };
-  }
-  mergeInFlight = true;
-  const sendProgress = (percent: number, message: string) => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('transcription-progress', { percent, message });
-    }
-  };
-  try {
-    const inputPaths = Array.isArray(opts?.paths) ? opts.paths : [];
-    if (inputPaths.length < 2) {
-      return { success: false, error: 'At least 2 recordings are required to merge' };
-    }
-
-    // Ensure recordings dir exists before realpath so symlink resolution can't
-    // throw on a fresh install. Containment: every input must then resolve
-    // inside that directory.
-    const recordingsDir = path.join(app.getPath('userData'), 'recordings');
-    await fs.promises.mkdir(recordingsDir, { recursive: true });
-    const resolvedRoot = await fs.promises.realpath(recordingsDir);
-    const resolvedInputs: string[] = [];
-    for (const p of inputPaths) {
-      if (typeof p !== 'string' || !p) {
-        return { success: false, error: 'Invalid input path' };
-      }
-      let resolved: string;
-      try {
-        resolved = await fs.promises.realpath(p);
-      } catch {
-        return { success: false, error: `Recording not found: ${path.basename(p)}` };
-      }
-      if (!resolved.startsWith(resolvedRoot + path.sep)) {
-        return { success: false, error: 'Source path is outside the recordings directory' };
-      }
-      resolvedInputs.push(resolved);
-    }
-
-    if (!geminiService) {
-      if (!configService.hasAiAuth()) {
-        return { success: false, error: formatAiCredentialsError() };
-      }
-      geminiService = createGeminiService()!;
-    }
-
-    const ffmpegPath = await ffmpegManager.ensureFFmpeg();
-    if (!ffmpegPath) {
-      return {
-        success: false,
-        code: 'ffmpeg-missing',
-        error: 'FFmpeg is required to merge recordings.',
-      };
-    }
-
-    const rawTitle = opts.title?.trim() || 'Merged Meeting';
-    const safeTitle = sanitizeForPath(rawTitle) || 'Merged Meeting';
-    // Always emit webm/opus -- matches MediaRecorder native output and survives
-    // the stream-copy fast path when all inputs are also webm. UUID suffix
-    // avoids collisions when two merges with the same title start in the same
-    // second (formatTimestamp is second-granularity).
-    const mergedExt = extensionForMimeType('audio/webm');
-    const mergedAudioPath = path.join(
-      recordingsDir,
-      `${safeTitle}_${formatTimestamp()}_${randomUUID().slice(0, 8)}.${mergedExt}`,
-    );
-
-    sendProgress(5, 'Merging audio files...');
-
-    // Run the metadata lookup concurrently with the ffmpeg concat -- they're
-    // independent and concat is the long pole, so the metadata reads are free.
-    // Recordings without a transcription contribute nothing to mergedFrom; we
-    // also drop entries whose transcription folder no longer exists on disk
-    // so the merged note's Sources section never references stale ghosts.
-    const [, metas] = await Promise.all([
-      concatAudioFiles({ ffmpegPath, inputPaths: resolvedInputs, outputPath: mergedAudioPath }),
-      Promise.all(resolvedInputs.map((p) => metadataService.getMetadata(p))),
-    ]);
-    const sourceFolders = metas
-      .filter((m): m is NonNullable<typeof m> => !!m?.transcriptionPath)
-      .filter((m) => fs.existsSync(m.transcriptionPath!))
-      .map((m) => path.basename(m.transcriptionPath!));
-
-    sendProgress(15, 'Transcribing merged recording...');
-
-    // Compress the transcription progress into 15-95% to leave room for the
-    // concat phase at the start and the save phase at the end.
-    const progressCallback = (percent: number, message: string) => {
-      sendProgress(15 + Math.round(percent * 0.8), message);
-    };
-
-    const summaryPrompt = configService.getSummaryPrompt();
-    const result = await geminiService.transcribeAudio(
-      mergedAudioPath,
-      progressCallback,
-      summaryPrompt,
-    );
-
-    // User-supplied title takes precedence; only fall back to Gemini's
-    // suggestion when the user didn't provide one. Gemini almost always
-    // returns a suggestedTitle, so the previous order silently overrode the
-    // user's --title flag / dialog input.
-    const finalTitle = opts.title?.trim() || result.suggestedTitle || rawTitle;
-    let transcriptionPath: string;
-    try {
-      transcriptionPath = saveTranscription({
-        title: finalTitle,
-        result,
-        audioFilePath: mergedAudioPath,
-        dataPath: app.getPath('userData'),
-        mergedFrom: sourceFolders,
-      });
-      maybeAutoSync();
-    } catch (error) {
-      console.error('Failed to save merged transcription files:', error);
-      const message = error instanceof Error ? error.message : String(error);
-      notificationService.notifyTranscriptionFailed(
-        'Merge failed: could not save the transcription.',
-      );
-      return { success: false, error: `Failed to save merged transcription: ${message}` };
-    }
-
-    try {
-      await metadataService.saveMetadata(mergedAudioPath, {
-        title: finalTitle,
-        suggestedTitle: result.suggestedTitle,
-        transcriptionPath,
-        customFields: result.customFields,
-        transcribedAt: new Date().toISOString(),
-      });
-    } catch (error) {
-      // Metadata write is best-effort -- the transcription folder is the
-      // source of truth. Log and continue rather than fail the merge.
-      console.error('Failed to save merged metadata:', error);
-    }
-
-    sendProgress(100, 'Merge complete');
-
-    notificationService.notifyTranscriptionComplete(finalTitle);
-    return {
-      success: true,
-      data: result,
-      mergedAudioPath,
-      transcriptionPath,
-      mergedFrom: sourceFolders,
-    };
-  } catch (error) {
-    console.error('Error merging recordings:', error);
-    const stderr = (error as { stderr?: string } | null)?.stderr;
-    const baseMessage = error instanceof Error ? error.message : String(error);
-    const message = stderr ? `${baseMessage.split('\n')[0]} — ${stderr.trim()}` : baseMessage;
-    notificationService.notifyTranscriptionFailed('Merge failed. Check the app for details.');
-    return { success: false, error: message };
-  } finally {
-    mergeInFlight = false;
-  }
+// Domain-grouped IPC handlers (delete-meeting / export-recording-m4a /
+// merge-recordings) live in src/ipc/meetingsManagement.ts. Phase 1 of the
+// main.ts module split -- additional clusters move out in follow-up PRs and
+// register themselves alongside this one in src/ipc/register.ts.
+registerAllIpc({
+  getMainWindow: () => mainWindow,
+  configService,
+  notificationService,
+  ffmpegManager,
+  ensureGeminiService,
+  maybeAutoSync,
+  isContainedTranscriptionPath,
+  formatAiCredentialsError,
 });
 
 // Audio capture runs in the renderer via MediaRecorder; chunks stream over IPC as


### PR DESCRIPTION
## Summary

- First step toward modularizing `src/main.ts` (currently 2,476 lines with 46 IPC handlers + module state + lifecycle interleaved)
- Introduces `IpcContext` pattern (`src/ipc/types.ts`) and a single registration entry point (`src/ipc/register.ts`)
- Extracts the meetings-management cluster (`delete-meeting`, `export-recording-m4a`, `merge-recordings`) into `src/ipc/meetingsManagement.ts` along with its module-local `mergeInFlight` flag
- `src/main.ts`: ~300 lines removed, `registerAllIpc(buildContext())` call added. No behavior change

The `IpcContext` interface only carries what this PR needs (mainWindow accessor, configService, notificationService, ffmpegManager, ensureGeminiService callback, maybeAutoSync trigger, isContainedTranscriptionPath guard, formatAiCredentialsError helper). Subsequent PRs (google-drive sync, recording, transcription, ...) will extend it as needed and register more modules in `registerAllIpc`.

A small smoke test (`src/ipc/meetingsManagement.test.ts`) pins the three IPC channel names so a future typo can't silently break the renderer.

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm run build:check-renderer` passes
- [x] `pnpm run lint` passes (0 warnings, 0 errors)
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (321/321 — adds 1 new test for channel registration)
- [ ] Manual smoke test: delete a meeting via UI, export a recording to M4A, merge two recordings — verify each handler still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)