### PR TITLE
Extract transcription IPC handlers to src/ipc/

### DIFF
--- a/src/ipc/meetingsManagement.test.ts
+++ b/src/ipc/meetingsManagement.test.ts
@@ -71,6 +71,8 @@ describe('meetingsManagement.register', () => {
       maybeAutoSync: () => {},
       isContainedTranscriptionPath: (p): p is string => typeof p === 'string',
       formatAiCredentialsError: () => 'no credentials',
+      serializeTranscriptionError: () => ({ message: 'stub' }) as never,
+      sanitizeLiveNotes: () => undefined,
     });
     assert.deepEqual([...handlers.keys()].sort(), [
       'delete-meeting',

--- a/src/ipc/register.ts
+++ b/src/ipc/register.ts
@@ -1,4 +1,5 @@
 import * as meetingsManagementIpc from './meetingsManagement';
+import * as transcriptionIpc from './transcription';
 import type { IpcContext } from './types';
 
 // Single wiring point for every src/ipc/<domain>.ts module that has been
@@ -9,4 +10,5 @@ import type { IpcContext } from './types';
 // stays touched only when the context surface changes.
 export function registerAllIpc(ctx: IpcContext): void {
   meetingsManagementIpc.register(ctx);
+  transcriptionIpc.register(ctx);
 }

--- a/src/ipc/transcription.ts
+++ b/src/ipc/transcription.ts
@@ -1,0 +1,212 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { app, ipcMain } from 'electron';
+import { saveTranscription } from '../outputService';
+import { metadataService } from '../services/metadataService';
+import { notificationService } from '../services/notificationService';
+import type { IpcContext } from './types';
+
+// In-flight transcriptions keyed by audio filePath. Each entry holds an
+// AbortController whose signal is plumbed through geminiService and the
+// underlying provider SDKs. `cancel-transcription` aborts the controller; the
+// transcribe-audio handler catches the abort and resolves with
+// `{ cancelled: true }` so the renderer can clean up without an alert.
+const activeTranscriptions = new Map<string, AbortController>();
+
+async function renameAudioFile(oldPath: string, suggestedTitle: string): Promise<string> {
+  try {
+    const dir = path.dirname(oldPath);
+    const ext = path.extname(oldPath);
+    const oldFileName = path.basename(oldPath, ext);
+
+    // Extract timestamp from old filename (format: Untitled_Meeting_2025-07-10T01-34-07-679Z)
+    const timestampMatch = oldFileName.match(/_(\d{4}-\d{2}-\d{2}T[\d-]+Z)$/);
+    const timestamp = timestampMatch
+      ? timestampMatch[1]
+      : new Date().toISOString().replace(/[:.]/g, '-');
+
+    // Sanitize the suggested title
+    const sanitizedTitle = suggestedTitle
+      .replace(/[<>:"/\\|?*]/g, '_') // Replace problematic characters
+      .replace(/\s+/g, '_') // Replace spaces with underscores
+      .trim();
+
+    const newFileName = `${sanitizedTitle}_${timestamp}${ext}`;
+    const newPath = path.join(dir, newFileName);
+
+    // Rename the file
+    await fs.promises.rename(oldPath, newPath);
+    console.log(`Renamed file from ${oldFileName} to ${newFileName}`);
+
+    return newPath;
+  } catch (error) {
+    console.error('Error renaming file:', error);
+    return oldPath; // Return original path if rename fails
+  }
+}
+
+export function register(ctx: IpcContext): void {
+  ipcMain.handle('transcribe-audio', async (_, filePath: string, liveNotesRaw?: unknown) => {
+    // Replace any prior controller for the same file so a re-trigger (e.g.
+    // Regenerate) supersedes the previous run.
+    activeTranscriptions.get(filePath)?.abort();
+    const controller = new AbortController();
+    activeTranscriptions.set(filePath, controller);
+    const signal = controller.signal;
+
+    const sendProgress = (percent: number, message: string) => {
+      const win = ctx.getMainWindow();
+      if (win && !win.isDestroyed()) {
+        win.webContents.send('transcription-progress', { percent, message, filePath });
+      }
+    };
+
+    try {
+      console.log('Transcription requested for:', filePath);
+      let liveNotes = ctx.sanitizeLiveNotes(liveNotesRaw);
+      if (!liveNotes || liveNotes.length === 0) {
+        // Fall back to whatever stop-recording persisted -- covers the
+        // record-now-transcribe-later flow when auto-mode is off.
+        try {
+          const existing = await metadataService.getMetadata(filePath);
+          const fromMetadata = ctx.sanitizeLiveNotes(existing?.liveNotes);
+          if (fromMetadata && fromMetadata.length > 0) {
+            liveNotes = fromMetadata;
+          }
+        } catch (err) {
+          console.warn('Failed to read live notes from metadata:', err);
+        }
+      }
+
+      sendProgress(0, 'Initializing AI service...');
+
+      // Lazy get-or-create against the main-owned slot. Returns null only when
+      // AI credentials are missing -- the slot lifecycle (reset on
+      // applyConfigSideEffects) stays in main and isn't part of this surface.
+      const geminiService = ctx.ensureGeminiService();
+      if (!geminiService) {
+        return { success: false, error: ctx.formatAiCredentialsError() };
+      }
+
+      sendProgress(10, 'Starting transcription...');
+
+      console.log('Starting transcription...');
+
+      const summaryPrompt = ctx.configService.getSummaryPrompt();
+      const result = await geminiService.transcribeAudio(
+        filePath,
+        sendProgress,
+        summaryPrompt,
+        liveNotes,
+        { signal },
+      );
+      console.log('Transcription completed successfully');
+      console.log('Saving metadata for:', filePath);
+
+      // Attach renderer-captured notes so downstream consumers (Notion upload,
+      // re-render in the modal) can read them off the result object.
+      if (liveNotes && liveNotes.length > 0) {
+        result.liveNotes = liveNotes;
+      }
+
+      // Save transcription files (summary.md + transcript.md)
+      const title = result.suggestedTitle || path.basename(filePath, path.extname(filePath));
+      let transcriptionPath: string | undefined;
+      try {
+        transcriptionPath = saveTranscription({
+          title,
+          result,
+          audioFilePath: filePath,
+          dataPath: app.getPath('userData'),
+          liveNotes,
+        });
+        console.log('Transcription saved to:', transcriptionPath);
+        ctx.maybeAutoSync();
+      } catch (error) {
+        console.error('Failed to save transcription files:', error);
+      }
+
+      // Save metadata - slim if transcription files saved, inline fallback otherwise
+      try {
+        if (transcriptionPath) {
+          await metadataService.saveMetadata(filePath, {
+            title,
+            suggestedTitle: result.suggestedTitle,
+            transcriptionPath,
+            customFields: result.customFields,
+            liveNotes,
+            transcribedAt: new Date().toISOString(),
+          });
+        } else {
+          // Fallback: store inline data when file write failed
+          await metadataService.saveMetadata(filePath, {
+            title,
+            suggestedTitle: result.suggestedTitle,
+            transcript: result.transcript,
+            summary: result.summary,
+            keyPoints: result.keyPoints,
+            actionItems: result.actionItems,
+            customFields: result.customFields,
+            liveNotes,
+            transcribedAt: new Date().toISOString(),
+          });
+        }
+        console.log('Metadata saved successfully');
+      } catch (error) {
+        console.error('Failed to save metadata:', error);
+      }
+
+      notificationService.notifyTranscriptionComplete(result.suggestedTitle || 'Meeting');
+
+      // Check if we need to rename the file (if it was untitled)
+      const fileName = path.basename(filePath);
+      if (fileName.includes('Untitled_Meeting') && result.suggestedTitle) {
+        const newFilePath = await renameAudioFile(filePath, result.suggestedTitle);
+
+        // Move metadata to new file path
+        const existingMetadata = await metadataService.getMetadata(filePath);
+        if (existingMetadata) {
+          await metadataService.deleteMetadata(filePath);
+          await metadataService.saveMetadata(newFilePath, existingMetadata);
+        }
+
+        return { success: true, data: result, newFilePath, transcriptionPath };
+      }
+
+      return { success: true, data: result, transcriptionPath };
+    } catch (error) {
+      // Cancellation is a normal outcome -- skip the failure notification and
+      // signal it cleanly so the renderer collapses the inline progress without
+      // an error toast. Since every cancellation originates from `controller
+      // .abort()` in this file, `signal.aborted` is the canonical check; matching
+      // on error name/message would risk mis-classifying legitimate provider
+      // failures whose body happens to contain "aborted".
+      if (signal.aborted) {
+        console.log('Transcription cancelled for:', filePath);
+        return { success: false, cancelled: true as const };
+      }
+      console.error('Error transcribing audio:', error);
+      notificationService.notifyTranscriptionFailed(
+        'Transcription failed. Check the app for details.',
+      );
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        errorDetails: ctx.serializeTranscriptionError(error),
+      };
+    } finally {
+      // Only clear if we're still the live controller for this file; a
+      // superseding run will have replaced us already.
+      if (activeTranscriptions.get(filePath) === controller) {
+        activeTranscriptions.delete(filePath);
+      }
+    }
+  });
+
+  ipcMain.handle('cancel-transcription', async (_, filePath: string) => {
+    const controller = activeTranscriptions.get(filePath);
+    if (!controller) return { success: false, reason: 'not-running' as const };
+    controller.abort();
+    return { success: true };
+  });
+}

--- a/src/ipc/types.ts
+++ b/src/ipc/types.ts
@@ -1,6 +1,7 @@
 import type { BrowserWindow } from 'electron';
 import type { ConfigService } from '../configService';
-import type { GeminiService } from '../geminiService';
+import type { GeminiService, TranscriptionErrorPayload } from '../geminiService';
+import type { LiveNote } from '../outputService';
 import type { NotificationService } from '../services/notificationService';
 import type { FFmpegManager } from '../services/ffmpegManager';
 
@@ -23,7 +24,7 @@ export interface IpcContext {
   // GeminiService is module-cached in main.ts and re-created on relevant
   // config changes (model, provider, OAuth). Handlers that may be the first
   // caller after a config flip use this to get-or-create instead of reaching
-  // for a stale reference.
+  // for a stale reference. Returns null when AI credentials are missing.
   ensureGeminiService(): GeminiService | null;
   // Fire-and-forget Google Drive sync trigger. No-ops when sync is disabled
   // or unauthenticated; safe to call from any handler that mutates a meeting
@@ -35,4 +36,11 @@ export interface IpcContext {
   // Formats the provider-aware "you need credentials" message so handlers
   // can surface a consistent error string regardless of aiProvider.
   formatAiCredentialsError(): string;
+  // Renderer-facing classification of provider errors (network/auth/quota/etc).
+  // Used by the transcription cluster so the inline progress UI can route
+  // users to the right remediation (settings dialog, retry, ffmpeg installer).
+  serializeTranscriptionError(error: unknown): TranscriptionErrorPayload;
+  // Validates and clips raw live-notes payloads (renderer or metadata source)
+  // before they flow into Gemini prompts or get persisted.
+  sanitizeLiveNotes(raw: unknown): LiveNote[] | undefined;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import { GoogleDriveClient } from './services/googleDriveService';
 import { SyncEngine, type SyncProgressEvent, type SyncResult } from './services/syncEngine';
 import { DisplayDetectorService } from './displayDetectorService';
 import { GeminiService, TranscriptionError, type TranscriptionErrorPayload } from './geminiService';
+import { registerAllIpc } from './ipc/register';
 import { MeetingDetectorService } from './meetingDetectorService';
 import { MenuBarManager } from './menuBarManager';
 import { NotionService } from './notionService';
@@ -41,7 +42,6 @@ import {
   getTranscriptionsDir,
   type LiveNote,
   readTranscription,
-  saveTranscription,
   updateTranscriptionStatus,
 } from './outputService';
 import { ALL_FIELDS, type SearchField, searchTranscriptions } from './searchService';
@@ -60,7 +60,6 @@ import {
 import { SYSTEM_AUDIO_FORMAT, SystemAudioService } from './services/systemAudioService';
 import { SimpleAudioRecorder } from './simpleAudioRecorder';
 import { SLACK_WEBHOOK_PREFIX, SlackService, isLikelySlackWebhookUrl } from './slackService';
-import { registerAllIpc } from './ipc/register';
 
 // Enable macOS system-audio loopback capture so getDisplayMedia({audio: 'loopback'})
 // can pull Zoom/Meet participant audio alongside the mic.
@@ -766,39 +765,6 @@ app.on('will-quit', () => {
   }
 });
 
-// Helper function to rename audio file with generated title
-async function renameAudioFile(oldPath: string, suggestedTitle: string): Promise<string> {
-  try {
-    const dir = path.dirname(oldPath);
-    const ext = path.extname(oldPath);
-    const oldFileName = path.basename(oldPath, ext);
-
-    // Extract timestamp from old filename (format: Untitled_Meeting_2025-07-10T01-34-07-679Z)
-    const timestampMatch = oldFileName.match(/_(\d{4}-\d{2}-\d{2}T[\d-]+Z)$/);
-    const timestamp = timestampMatch
-      ? timestampMatch[1]
-      : new Date().toISOString().replace(/[:.]/g, '-');
-
-    // Sanitize the suggested title
-    const sanitizedTitle = suggestedTitle
-      .replace(/[<>:"/\\|?*]/g, '_') // Replace problematic characters
-      .replace(/\s+/g, '_') // Replace spaces with underscores
-      .trim();
-
-    const newFileName = `${sanitizedTitle}_${timestamp}${ext}`;
-    const newPath = path.join(dir, newFileName);
-
-    // Rename the file
-    await fs.promises.rename(oldPath, newPath);
-    console.log(`Renamed file from ${oldFileName} to ${newFileName}`);
-
-    return newPath;
-  } catch (error) {
-    console.error('Error renaming file:', error);
-    return oldPath; // Return original path if rename fails
-  }
-}
-
 function clearRecordingTimers() {
   if (recordingMaxTimer) {
     clearTimeout(recordingMaxTimer);
@@ -850,9 +816,9 @@ ipcMain.handle('cancel-ffmpeg-download', async () => {
 });
 
 // Domain-grouped IPC handlers (delete-meeting / export-recording-m4a /
-// merge-recordings) live in src/ipc/meetingsManagement.ts. Phase 1 of the
-// main.ts module split -- additional clusters move out in follow-up PRs and
-// register themselves alongside this one in src/ipc/register.ts.
+// merge-recordings / transcribe-audio / cancel-transcription) live under
+// src/ipc/. Each domain registers itself in src/ipc/register.ts; main keeps
+// owning the singletons and exposes them through this one ctx object.
 registerAllIpc({
   getMainWindow: () => mainWindow,
   configService,
@@ -862,6 +828,8 @@ registerAllIpc({
   maybeAutoSync,
   isContainedTranscriptionPath,
   formatAiCredentialsError,
+  serializeTranscriptionError,
+  sanitizeLiveNotes,
 });
 
 // Audio capture runs in the renderer via MediaRecorder; chunks stream over IPC as
@@ -1528,179 +1496,6 @@ ipcMain.handle('get-meeting-status', async () => {
     active: meetingDetector.isActive(),
     app: meeting?.app,
   };
-});
-
-// In-flight transcriptions keyed by audio filePath. Each entry holds an
-// AbortController whose signal is plumbed through geminiService and the
-// underlying provider SDKs. `cancel-transcription` aborts the controller; the
-// transcribe-audio handler catches the abort and resolves with
-// `{ cancelled: true }` so the renderer can clean up without an alert.
-const activeTranscriptions = new Map<string, AbortController>();
-
-// Transcription handler
-ipcMain.handle('transcribe-audio', async (_, filePath: string, liveNotesRaw?: unknown) => {
-  // Replace any prior controller for the same file so a re-trigger (e.g.
-  // Regenerate) supersedes the previous run.
-  activeTranscriptions.get(filePath)?.abort();
-  const controller = new AbortController();
-  activeTranscriptions.set(filePath, controller);
-  const signal = controller.signal;
-
-  const sendProgress = (percent: number, message: string) => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('transcription-progress', { percent, message, filePath });
-    }
-  };
-
-  try {
-    console.log('Transcription requested for:', filePath);
-    let liveNotes = sanitizeLiveNotes(liveNotesRaw);
-    if (!liveNotes || liveNotes.length === 0) {
-      // Fall back to whatever stop-recording persisted -- covers the
-      // record-now-transcribe-later flow when auto-mode is off.
-      try {
-        const existing = await metadataService.getMetadata(filePath);
-        const fromMetadata = sanitizeLiveNotes(existing?.liveNotes);
-        if (fromMetadata && fromMetadata.length > 0) {
-          liveNotes = fromMetadata;
-        }
-      } catch (err) {
-        console.warn('Failed to read live notes from metadata:', err);
-      }
-    }
-
-    sendProgress(0, 'Initializing AI service...');
-
-    // Initialize AI service if not already initialized
-    if (!geminiService) {
-      console.log('AI credentials configured:', configService.hasAiAuth());
-
-      if (!configService.hasAiAuth()) {
-        return { success: false, error: formatAiCredentialsError() };
-      }
-      geminiService = createGeminiService()!;
-    }
-
-    sendProgress(10, 'Starting transcription...');
-
-    console.log('Starting transcription...');
-
-    const summaryPrompt = configService.getSummaryPrompt();
-    const result = await geminiService.transcribeAudio(
-      filePath,
-      sendProgress,
-      summaryPrompt,
-      liveNotes,
-      { signal },
-    );
-    console.log('Transcription completed successfully');
-    console.log('Saving metadata for:', filePath);
-
-    // Attach renderer-captured notes so downstream consumers (Notion upload,
-    // re-render in the modal) can read them off the result object.
-    if (liveNotes && liveNotes.length > 0) {
-      result.liveNotes = liveNotes;
-    }
-
-    // Save transcription files (summary.md + transcript.md)
-    const title = result.suggestedTitle || path.basename(filePath, path.extname(filePath));
-    let transcriptionPath: string | undefined;
-    try {
-      transcriptionPath = saveTranscription({
-        title,
-        result,
-        audioFilePath: filePath,
-        dataPath: app.getPath('userData'),
-        liveNotes,
-      });
-      console.log('Transcription saved to:', transcriptionPath);
-      maybeAutoSync();
-    } catch (error) {
-      console.error('Failed to save transcription files:', error);
-    }
-
-    // Save metadata - slim if transcription files saved, inline fallback otherwise
-    try {
-      if (transcriptionPath) {
-        await metadataService.saveMetadata(filePath, {
-          title,
-          suggestedTitle: result.suggestedTitle,
-          transcriptionPath,
-          customFields: result.customFields,
-          liveNotes,
-          transcribedAt: new Date().toISOString(),
-        });
-      } else {
-        // Fallback: store inline data when file write failed
-        await metadataService.saveMetadata(filePath, {
-          title,
-          suggestedTitle: result.suggestedTitle,
-          transcript: result.transcript,
-          summary: result.summary,
-          keyPoints: result.keyPoints,
-          actionItems: result.actionItems,
-          customFields: result.customFields,
-          liveNotes,
-          transcribedAt: new Date().toISOString(),
-        });
-      }
-      console.log('Metadata saved successfully');
-    } catch (error) {
-      console.error('Failed to save metadata:', error);
-    }
-
-    notificationService.notifyTranscriptionComplete(result.suggestedTitle || 'Meeting');
-
-    // Check if we need to rename the file (if it was untitled)
-    const fileName = path.basename(filePath);
-    if (fileName.includes('Untitled_Meeting') && result.suggestedTitle) {
-      const newFilePath = await renameAudioFile(filePath, result.suggestedTitle);
-
-      // Move metadata to new file path
-      const existingMetadata = await metadataService.getMetadata(filePath);
-      if (existingMetadata) {
-        await metadataService.deleteMetadata(filePath);
-        await metadataService.saveMetadata(newFilePath, existingMetadata);
-      }
-
-      return { success: true, data: result, newFilePath, transcriptionPath };
-    }
-
-    return { success: true, data: result, transcriptionPath };
-  } catch (error) {
-    // Cancellation is a normal outcome -- skip the failure notification and
-    // signal it cleanly so the renderer collapses the inline progress without
-    // an error toast. Since every cancellation originates from `controller
-    // .abort()` in this file, `signal.aborted` is the canonical check; matching
-    // on error name/message would risk mis-classifying legitimate provider
-    // failures whose body happens to contain "aborted".
-    if (signal.aborted) {
-      console.log('Transcription cancelled for:', filePath);
-      return { success: false, cancelled: true as const };
-    }
-    console.error('Error transcribing audio:', error);
-    notificationService.notifyTranscriptionFailed(
-      'Transcription failed. Check the app for details.',
-    );
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : String(error),
-      errorDetails: serializeTranscriptionError(error),
-    };
-  } finally {
-    // Only clear if we're still the live controller for this file; a
-    // superseding run will have replaced us already.
-    if (activeTranscriptions.get(filePath) === controller) {
-      activeTranscriptions.delete(filePath);
-    }
-  }
-});
-
-ipcMain.handle('cancel-transcription', async (_, filePath: string) => {
-  const controller = activeTranscriptions.get(filePath);
-  if (!controller) return { success: false, reason: 'not-running' as const };
-  controller.abort();
-  return { success: true };
 });
 
 // Notion upload handler


### PR DESCRIPTION
## Summary

- Move the `transcribe-audio` and `cancel-transcription` IPC handlers (plus the `activeTranscriptions` AbortController map and the `renameAudioFile` helper that only the post-transcription "Untitled_Meeting" rename uses) out of `src/main.ts` into `src/ipc/transcription.ts`.
- Introduce a new `IpcContext` (`src/ipc/types.ts`) + `registerAllIpc` (`src/ipc/register.ts`) scaffolding so main keeps owning the singletons (`mainWindow`, `geminiService`, `configService`, shared helpers, `maybeAutoSync`) and the moved module sees the live references through getters and DI.
- main shrinks by ~205 lines net; behavior is unchanged. This is the first slice of the main.ts modularization series.

The new module never imports from `main.ts` -- everything it needs (helpers, services, the Google Drive auto-sync trigger) flows through `IpcContext`, and the cluster owns its own state (`activeTranscriptions`, `renameAudioFile`).

Sister PRs `claude/refactor-ipc-meetings-mgmt` and `claude/refactor-ipc-google-drive` create the same `src/ipc/types.ts` / `src/ipc/register.ts` scaffolding. After the first one merges, this PR will need a rebase to drop duplicate definitions and add its registration line to the merged `register.ts`.

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm run build:check-renderer` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm test` passes (320/320)
- [ ] Manual smoke: start the app, record a short clip, verify transcription + summary land, verify cancel-transcription clears the inline progress and aborts the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)