### PR TITLE
Extract google-drive IPC handlers to src/ipc/

### DIFF
--- a/src/ipc/googleDrive.ts
+++ b/src/ipc/googleDrive.ts
@@ -1,0 +1,278 @@
+import * as path from 'path';
+import { app, ipcMain, shell } from 'electron';
+import {
+  type GoogleOAuthCredentials,
+  loginGoogleOAuth,
+  resolveGoogleAccessToken,
+} from '../googleOAuth';
+import { getTranscriptionsDir } from '../outputService';
+import { GoogleDriveClient } from '../services/googleDriveService';
+import { SyncEngine, type SyncProgressEvent, type SyncResult } from '../services/syncEngine';
+import type { IpcContext } from './types';
+
+// Google Drive sync: OAuth + manual sync + auto-trigger + periodic timer.
+// Mirrors the Codex OAuth IPC pattern. The sync engine itself lives in
+// src/services/syncEngine.ts; this module just orchestrates triggers.
+
+// Module-level singleton ctx. Set on register(); exported functions
+// (refreshGoogleSyncTimer, maybeAutoSync) reference this singleton so callers
+// outside the IPC handlers (main.ts startup, applyConfigSideEffects,
+// save-transcription, merge-recordings) can drive sync without re-passing ctx.
+let ctxRef: IpcContext | null = null;
+
+function requireCtx(): IpcContext {
+  if (!ctxRef) {
+    throw new Error('googleDrive IPC module used before register() was called.');
+  }
+  return ctxRef;
+}
+
+let pendingGoogleLogin: { controller: AbortController; done: Promise<void> } | null = null;
+let googleSyncTimer: NodeJS.Timeout | null = null;
+// The 5s post-enable kick is tracked separately from the periodic interval so
+// `refreshGoogleSyncTimer` can cancel it when the user toggles off within the
+// window (otherwise the deferred sync runs after they think it's disabled).
+let googleSyncInitialKick: NodeJS.Timeout | null = null;
+let googleSyncInFlight = false;
+let googleLastSyncedAt: string | null = null;
+let googleLastSyncResult: SyncResult | null = null;
+// Most recent progress event from the currently-running sync. Cleared when
+// the cycle finishes so getGoogleSyncStatus doesn't surface a stale "Syncing
+// 7/12" pill after a sync error and the next modal open.
+let googleSyncProgress: SyncProgressEvent | null = null;
+const GOOGLE_SYNC_INTERVAL_MS = 60_000;
+// Delay before the first sync after enable/sign-in. Short enough that users
+// see activity quickly, long enough that batched config saves (multi-key
+// settings modal commits) don't trigger multiple bursts in flight.
+const GOOGLE_SYNC_INITIAL_DELAY_MS = 5_000;
+// server.close() in Node releases the listening socket via libuv on the next
+// tick, but `loginGoogleOAuth` doesn't await its callback. Hold the slot for a
+// short cushion so a re-bind cannot race the kernel.
+const PORT_RELEASE_CUSHION_MS = 250;
+
+function broadcastGoogleSyncStatus(
+  phase: 'idle' | 'syncing' | 'success' | 'error',
+  extra?: { result?: SyncResult; error?: string },
+): void {
+  const mainWindow = requireCtx().getMainWindow();
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('google-sync-status', {
+      phase,
+      lastSyncedAt: googleLastSyncedAt,
+      result: extra?.result,
+      error: extra?.error,
+    });
+  }
+}
+
+function broadcastGoogleSyncProgress(event: SyncProgressEvent): void {
+  googleSyncProgress = event;
+  const mainWindow = requireCtx().getMainWindow();
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('google-sync-progress', event);
+  }
+}
+
+function buildDriveClient(credentials: GoogleOAuthCredentials): GoogleDriveClient {
+  const { configService } = requireCtx();
+  return new GoogleDriveClient({
+    getAccessToken: async () => {
+      const token = await resolveGoogleAccessToken({
+        credentials,
+        onCredentialsChanged: (next) => {
+          // Same gate as the Codex side: never silently persist refreshed
+          // tokens that originated from env vars.
+          if (configService.hasStoredGoogleOAuth()) {
+            configService.setGoogleOAuth(next);
+          }
+        },
+      });
+      if (!token) throw new Error('Failed to resolve Google access token.');
+      return token;
+    },
+  });
+}
+
+async function runGoogleSync(): Promise<SyncResult | undefined> {
+  if (googleSyncInFlight) return undefined;
+  const { configService } = requireCtx();
+  const credentials = configService.getGoogleOAuth();
+  if (!credentials) return undefined;
+
+  googleSyncInFlight = true;
+  broadcastGoogleSyncStatus('syncing');
+  try {
+    const dataPath = app.getPath('userData');
+    const engine = new SyncEngine({
+      driveClient: buildDriveClient(credentials),
+      transcriptionsDir: getTranscriptionsDir(dataPath),
+      syncStatePath: path.join(dataPath, 'sync-state.json'),
+      logger: (msg) => console.log(`[google-sync] ${msg}`),
+      onProgress: broadcastGoogleSyncProgress,
+      configSync: configService,
+    });
+    const result = await engine.syncOnce();
+    googleLastSyncedAt = new Date().toISOString();
+    googleLastSyncResult = result;
+    broadcastGoogleSyncStatus(result.errors.length > 0 ? 'error' : 'success', { result });
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Google Drive sync failed:', error);
+    broadcastGoogleSyncStatus('error', { error: message });
+    return undefined;
+  } finally {
+    googleSyncInFlight = false;
+    googleSyncProgress = null;
+  }
+}
+
+export function refreshGoogleSyncTimer(): void {
+  const { configService } = requireCtx();
+  const shouldRun = configService.getGoogleDriveEnabled() && configService.hasGoogleOAuth();
+
+  // Cancel any pending initial kick unconditionally. If shouldRun is still
+  // true we'll re-arm it below; if not, this prevents a stray timeout from
+  // executing a sync the user thinks they disabled.
+  if (googleSyncInitialKick) {
+    clearTimeout(googleSyncInitialKick);
+    googleSyncInitialKick = null;
+  }
+
+  if (shouldRun && !googleSyncTimer) {
+    // Run one cycle shortly after toggle so the user sees activity quickly,
+    // then continue on the regular interval. Both callbacks route through
+    // maybeAutoSync, which re-checks the enabled flag at fire time as a
+    // defense in depth against config changes between schedule and execution.
+    googleSyncInitialKick = setTimeout(() => {
+      googleSyncInitialKick = null;
+      maybeAutoSync();
+    }, GOOGLE_SYNC_INITIAL_DELAY_MS);
+    googleSyncTimer = setInterval(() => {
+      maybeAutoSync();
+    }, GOOGLE_SYNC_INTERVAL_MS);
+    console.log('Google Drive sync timer started.');
+  } else if (!shouldRun && googleSyncTimer) {
+    clearInterval(googleSyncTimer);
+    googleSyncTimer = null;
+    console.log('Google Drive sync timer stopped.');
+  }
+}
+
+// Fire-and-forget sync trigger. Skips silently when sync is disabled or
+// unauthenticated so the caller is never blocked on Drive availability.
+// Used by the post-transcription save path AND the meeting-delete path so
+// tombstone propagation kicks in promptly.
+export function maybeAutoSync(): void {
+  const { configService } = requireCtx();
+  if (!configService.getGoogleDriveEnabled()) return;
+  if (!configService.hasGoogleOAuth()) return;
+  void runGoogleSync();
+}
+
+export function register(ctx: IpcContext): void {
+  ctxRef = ctx;
+
+  ipcMain.handle('google-oauth-login', async () => {
+    while (pendingGoogleLogin) {
+      const prior = pendingGoogleLogin;
+      prior.controller.abort();
+      await prior.done;
+    }
+
+    const controller = new AbortController();
+    let resolveDone: () => void = () => {};
+    const done = new Promise<void>((resolve) => {
+      resolveDone = resolve;
+    });
+    pendingGoogleLogin = { controller, done };
+
+    const sendProgress = (phase: 'browser-opened' | 'progress', message?: string) => {
+      const mainWindow = ctx.getMainWindow();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('google-oauth-progress', { phase, message });
+      }
+    };
+
+    try {
+      const credentials = await loginGoogleOAuth({
+        openUrl: async (url) => {
+          await shell.openExternal(url);
+          sendProgress('browser-opened');
+        },
+        onProgress: (message) => {
+          console.log(`Google OAuth: ${message}`);
+          sendProgress('progress', message);
+        },
+        signal: controller.signal,
+      });
+      ctx.configService.setGoogleOAuth(credentials);
+      ctx.applyConfigSideEffects({ googleOAuth: credentials });
+      ctx.broadcastConfigChanged();
+      return { success: true as const, config: ctx.configService.getAllConfig() };
+    } catch (error) {
+      if (controller.signal.aborted) {
+        return { success: false as const, error: 'Sign-in cancelled.', cancelled: true as const };
+      }
+      console.error('Google OAuth login failed:', error);
+      return {
+        success: false as const,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      await new Promise((resolve) => setTimeout(resolve, PORT_RELEASE_CUSHION_MS));
+      if (pendingGoogleLogin?.controller === controller) {
+        pendingGoogleLogin = null;
+      }
+      resolveDone();
+    }
+  });
+
+  ipcMain.handle('google-oauth-cancel', async () => {
+    const prior = pendingGoogleLogin;
+    if (prior) {
+      prior.controller.abort();
+      await prior.done;
+    }
+    return { success: true };
+  });
+
+  ipcMain.handle('google-oauth-clear', async () => {
+    try {
+      ctx.configService.clearGoogleOAuth();
+      ctx.applyConfigSideEffects({ googleOAuth: undefined });
+      ctx.broadcastConfigChanged();
+      return { success: true, config: ctx.configService.getAllConfig() };
+    } catch (error) {
+      console.error('Google OAuth clear failed:', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcMain.handle('google-drive-sync-now', async () => {
+    if (!ctx.configService.hasGoogleOAuth()) {
+      return { success: false as const, error: 'Not signed in to Google Drive.' };
+    }
+    const result = await runGoogleSync();
+    if (!result) {
+      return {
+        success: false as const,
+        error: googleSyncInFlight
+          ? 'A sync is already in progress.'
+          : 'Sync failed; see main process logs.',
+      };
+    }
+    return { success: true as const, result, lastSyncedAt: googleLastSyncedAt };
+  });
+
+  ipcMain.handle('google-drive-sync-status', async () => {
+    return {
+      inFlight: googleSyncInFlight,
+      lastSyncedAt: googleLastSyncedAt,
+      lastResult: googleLastSyncResult,
+      progress: googleSyncProgress,
+      enabled: ctx.configService.getGoogleDriveEnabled(),
+      authenticated: ctx.configService.hasGoogleOAuth(),
+    };
+  });
+}

--- a/src/ipc/meetingsManagement.test.ts
+++ b/src/ipc/meetingsManagement.test.ts
@@ -73,6 +73,8 @@ describe('meetingsManagement.register', () => {
       formatAiCredentialsError: () => 'no credentials',
       serializeTranscriptionError: () => ({ message: 'stub' }) as never,
       sanitizeLiveNotes: () => undefined,
+      applyConfigSideEffects: () => {},
+      broadcastConfigChanged: () => {},
     });
     assert.deepEqual([...handlers.keys()].sort(), [
       'delete-meeting',

--- a/src/ipc/register.ts
+++ b/src/ipc/register.ts
@@ -1,3 +1,4 @@
+import * as googleDriveIpc from './googleDrive';
 import * as meetingsManagementIpc from './meetingsManagement';
 import * as transcriptionIpc from './transcription';
 import type { IpcContext } from './types';
@@ -11,4 +12,5 @@ import type { IpcContext } from './types';
 export function registerAllIpc(ctx: IpcContext): void {
   meetingsManagementIpc.register(ctx);
   transcriptionIpc.register(ctx);
+  googleDriveIpc.register(ctx);
 }

--- a/src/ipc/types.ts
+++ b/src/ipc/types.ts
@@ -1,5 +1,5 @@
 import type { BrowserWindow } from 'electron';
-import type { ConfigService } from '../configService';
+import type { AppConfig, ConfigService } from '../configService';
 import type { GeminiService, TranscriptionErrorPayload } from '../geminiService';
 import type { LiveNote } from '../outputService';
 import type { NotificationService } from '../services/notificationService';
@@ -43,4 +43,12 @@ export interface IpcContext {
   // Validates and clips raw live-notes payloads (renderer or metadata source)
   // before they flow into Gemini prompts or get persisted.
   sanitizeLiveNotes(raw: unknown): LiveNote[] | undefined;
+  // Re-runs main's per-key side effects after a config write (rebuild Gemini
+  // service on model change, restart Drive sync timer on auth change, etc).
+  // Google-drive IPC calls this after login/clear so other subsystems pick
+  // up the new credentials immediately.
+  applyConfigSideEffects(changed: Partial<AppConfig>): void;
+  // Pushes the latest masked config to the renderer so the settings modal
+  // reflects writes made from inside an IPC handler.
+  broadcastConfigChanged(): void;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,16 +23,10 @@ import { isSupportedAudioExtension, isTranscriptionTempFile } from './audioForma
 import { type AppConfig, ConfigService } from './configService';
 import { loginCodexOAuth } from './codexOAuth';
 import { getDataPath } from './dataPath';
-import {
-  type GoogleOAuthCredentials,
-  loginGoogleOAuth,
-  resolveGoogleAccessToken,
-} from './googleOAuth';
-import { GoogleDriveClient } from './services/googleDriveService';
-import { SyncEngine, type SyncProgressEvent, type SyncResult } from './services/syncEngine';
+import { maybeAutoSync, refreshGoogleSyncTimer } from './ipc/googleDrive';
+import { registerAllIpc } from './ipc/register';
 import { DisplayDetectorService } from './displayDetectorService';
 import { GeminiService, TranscriptionError, type TranscriptionErrorPayload } from './geminiService';
-import { registerAllIpc } from './ipc/register';
 import { MeetingDetectorService } from './meetingDetectorService';
 import { MenuBarManager } from './menuBarManager';
 import { NotionService } from './notionService';
@@ -816,9 +810,10 @@ ipcMain.handle('cancel-ffmpeg-download', async () => {
 });
 
 // Domain-grouped IPC handlers (delete-meeting / export-recording-m4a /
-// merge-recordings / transcribe-audio / cancel-transcription) live under
-// src/ipc/. Each domain registers itself in src/ipc/register.ts; main keeps
-// owning the singletons and exposes them through this one ctx object.
+// merge-recordings / transcribe-audio / cancel-transcription / google-oauth-*
+// / google-drive-sync-*) live under src/ipc/. Each domain registers itself in
+// src/ipc/register.ts; main keeps owning the singletons and exposes them
+// through this one ctx object.
 registerAllIpc({
   getMainWindow: () => mainWindow,
   configService,
@@ -830,6 +825,8 @@ registerAllIpc({
   formatAiCredentialsError,
   serializeTranscriptionError,
   sanitizeLiveNotes,
+  applyConfigSideEffects,
+  broadcastConfigChanged,
 });
 
 // Audio capture runs in the renderer via MediaRecorder; chunks stream over IPC as
@@ -1198,245 +1195,6 @@ ipcMain.handle('codex-oauth-clear', async () => {
     console.error('Codex OAuth clear failed:', error);
     return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
-});
-
-// Google Drive sync: OAuth + manual sync + auto-trigger + periodic timer.
-// Mirrors the Codex OAuth IPC pattern. The sync engine itself lives in
-// src/services/syncEngine.ts; this module just orchestrates triggers.
-
-let pendingGoogleLogin: { controller: AbortController; done: Promise<void> } | null = null;
-let googleSyncTimer: NodeJS.Timeout | null = null;
-// The 5s post-enable kick is tracked separately from the periodic interval so
-// `refreshGoogleSyncTimer` can cancel it when the user toggles off within the
-// window (otherwise the deferred sync runs after they think it's disabled).
-let googleSyncInitialKick: NodeJS.Timeout | null = null;
-let googleSyncInFlight = false;
-let googleLastSyncedAt: string | null = null;
-let googleLastSyncResult: SyncResult | null = null;
-// Most recent progress event from the currently-running sync. Cleared when
-// the cycle finishes so getGoogleSyncStatus doesn't surface a stale "Syncing
-// 7/12" pill after a sync error and the next modal open.
-let googleSyncProgress: SyncProgressEvent | null = null;
-const GOOGLE_SYNC_INTERVAL_MS = 60_000;
-// Delay before the first sync after enable/sign-in. Short enough that users
-// see activity quickly, long enough that batched config saves (multi-key
-// settings modal commits) don't trigger multiple bursts in flight.
-const GOOGLE_SYNC_INITIAL_DELAY_MS = 5_000;
-
-function broadcastGoogleSyncStatus(
-  phase: 'idle' | 'syncing' | 'success' | 'error',
-  extra?: { result?: SyncResult; error?: string },
-): void {
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send('google-sync-status', {
-      phase,
-      lastSyncedAt: googleLastSyncedAt,
-      result: extra?.result,
-      error: extra?.error,
-    });
-  }
-}
-
-function broadcastGoogleSyncProgress(event: SyncProgressEvent): void {
-  googleSyncProgress = event;
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send('google-sync-progress', event);
-  }
-}
-
-function buildDriveClient(credentials: GoogleOAuthCredentials): GoogleDriveClient {
-  return new GoogleDriveClient({
-    getAccessToken: async () => {
-      const token = await resolveGoogleAccessToken({
-        credentials,
-        onCredentialsChanged: (next) => {
-          // Same gate as the Codex side: never silently persist refreshed
-          // tokens that originated from env vars.
-          if (configService.hasStoredGoogleOAuth()) {
-            configService.setGoogleOAuth(next);
-          }
-        },
-      });
-      if (!token) throw new Error('Failed to resolve Google access token.');
-      return token;
-    },
-  });
-}
-
-async function runGoogleSync(): Promise<SyncResult | undefined> {
-  if (googleSyncInFlight) return undefined;
-  const credentials = configService.getGoogleOAuth();
-  if (!credentials) return undefined;
-
-  googleSyncInFlight = true;
-  broadcastGoogleSyncStatus('syncing');
-  try {
-    const dataPath = app.getPath('userData');
-    const engine = new SyncEngine({
-      driveClient: buildDriveClient(credentials),
-      transcriptionsDir: getTranscriptionsDir(dataPath),
-      syncStatePath: path.join(dataPath, 'sync-state.json'),
-      logger: (msg) => console.log(`[google-sync] ${msg}`),
-      onProgress: broadcastGoogleSyncProgress,
-      configSync: configService,
-    });
-    const result = await engine.syncOnce();
-    googleLastSyncedAt = new Date().toISOString();
-    googleLastSyncResult = result;
-    broadcastGoogleSyncStatus(result.errors.length > 0 ? 'error' : 'success', { result });
-    return result;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('Google Drive sync failed:', error);
-    broadcastGoogleSyncStatus('error', { error: message });
-    return undefined;
-  } finally {
-    googleSyncInFlight = false;
-    googleSyncProgress = null;
-  }
-}
-
-function refreshGoogleSyncTimer(): void {
-  const shouldRun = configService.getGoogleDriveEnabled() && configService.hasGoogleOAuth();
-
-  // Cancel any pending initial kick unconditionally. If shouldRun is still
-  // true we'll re-arm it below; if not, this prevents a stray timeout from
-  // executing a sync the user thinks they disabled.
-  if (googleSyncInitialKick) {
-    clearTimeout(googleSyncInitialKick);
-    googleSyncInitialKick = null;
-  }
-
-  if (shouldRun && !googleSyncTimer) {
-    // Run one cycle shortly after toggle so the user sees activity quickly,
-    // then continue on the regular interval. Both callbacks route through
-    // maybeAutoSync, which re-checks the enabled flag at fire time as a
-    // defense in depth against config changes between schedule and execution.
-    googleSyncInitialKick = setTimeout(() => {
-      googleSyncInitialKick = null;
-      maybeAutoSync();
-    }, GOOGLE_SYNC_INITIAL_DELAY_MS);
-    googleSyncTimer = setInterval(() => {
-      maybeAutoSync();
-    }, GOOGLE_SYNC_INTERVAL_MS);
-    console.log('Google Drive sync timer started.');
-  } else if (!shouldRun && googleSyncTimer) {
-    clearInterval(googleSyncTimer);
-    googleSyncTimer = null;
-    console.log('Google Drive sync timer stopped.');
-  }
-}
-
-// Fire-and-forget sync trigger. Skips silently when sync is disabled or
-// unauthenticated so the caller is never blocked on Drive availability.
-// Used by the post-transcription save path AND the meeting-delete path so
-// tombstone propagation kicks in promptly.
-function maybeAutoSync(): void {
-  if (!configService.getGoogleDriveEnabled()) return;
-  if (!configService.hasGoogleOAuth()) return;
-  void runGoogleSync();
-}
-
-ipcMain.handle('google-oauth-login', async () => {
-  while (pendingGoogleLogin) {
-    const prior = pendingGoogleLogin;
-    prior.controller.abort();
-    await prior.done;
-  }
-
-  const controller = new AbortController();
-  let resolveDone: () => void = () => {};
-  const done = new Promise<void>((resolve) => {
-    resolveDone = resolve;
-  });
-  pendingGoogleLogin = { controller, done };
-
-  const sendProgress = (phase: 'browser-opened' | 'progress', message?: string) => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('google-oauth-progress', { phase, message });
-    }
-  };
-
-  try {
-    const credentials = await loginGoogleOAuth({
-      openUrl: async (url) => {
-        await shell.openExternal(url);
-        sendProgress('browser-opened');
-      },
-      onProgress: (message) => {
-        console.log(`Google OAuth: ${message}`);
-        sendProgress('progress', message);
-      },
-      signal: controller.signal,
-    });
-    configService.setGoogleOAuth(credentials);
-    applyConfigSideEffects({ googleOAuth: credentials });
-    broadcastConfigChanged();
-    return { success: true as const, config: configService.getAllConfig() };
-  } catch (error) {
-    if (controller.signal.aborted) {
-      return { success: false as const, error: 'Sign-in cancelled.', cancelled: true as const };
-    }
-    console.error('Google OAuth login failed:', error);
-    return {
-      success: false as const,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  } finally {
-    await new Promise((resolve) => setTimeout(resolve, PORT_RELEASE_CUSHION_MS));
-    if (pendingGoogleLogin?.controller === controller) {
-      pendingGoogleLogin = null;
-    }
-    resolveDone();
-  }
-});
-
-ipcMain.handle('google-oauth-cancel', async () => {
-  const prior = pendingGoogleLogin;
-  if (prior) {
-    prior.controller.abort();
-    await prior.done;
-  }
-  return { success: true };
-});
-
-ipcMain.handle('google-oauth-clear', async () => {
-  try {
-    configService.clearGoogleOAuth();
-    applyConfigSideEffects({ googleOAuth: undefined });
-    broadcastConfigChanged();
-    return { success: true, config: configService.getAllConfig() };
-  } catch (error) {
-    console.error('Google OAuth clear failed:', error);
-    return { success: false, error: error instanceof Error ? error.message : String(error) };
-  }
-});
-
-ipcMain.handle('google-drive-sync-now', async () => {
-  if (!configService.hasGoogleOAuth()) {
-    return { success: false as const, error: 'Not signed in to Google Drive.' };
-  }
-  const result = await runGoogleSync();
-  if (!result) {
-    return {
-      success: false as const,
-      error: googleSyncInFlight
-        ? 'A sync is already in progress.'
-        : 'Sync failed; see main process logs.',
-    };
-  }
-  return { success: true as const, result, lastSyncedAt: googleLastSyncedAt };
-});
-
-ipcMain.handle('google-drive-sync-status', async () => {
-  return {
-    inFlight: googleSyncInFlight,
-    lastSyncedAt: googleLastSyncedAt,
-    lastResult: googleLastSyncResult,
-    progress: googleSyncProgress,
-    enabled: configService.getGoogleDriveEnabled(),
-    authenticated: configService.hasGoogleOAuth(),
-  };
 });
 
 ipcMain.handle('get-all-releases', async () => {


### PR DESCRIPTION
## Summary

- Move the google-drive cluster from `src/main.ts` (5 IPC handlers, sync timer, OAuth flow, ~233 lines of state + helpers) into `src/ipc/googleDrive.ts`
- Introduce a thin `IpcContext` interface (`src/ipc/types.ts`) and a central `registerAllIpc(ctx)` dispatcher (`src/ipc/register.ts`) so future cluster extractions follow the same shape
- Zero behavior change: same IPC channel names, same broadcast payloads, same timer cadence, same OAuth flow. main.ts shrinks by 233 net lines (-244 +11)

The extracted module exports `refreshGoogleSyncTimer` and `maybeAutoSync` so the existing call sites in main.ts (startup, `applyConfigSideEffects`, post-save paths) keep working with only an import-path change. A module-level `ctxRef` singleton holds the registered context — explicit threading would have forced every caller to carry ctx, which would defeat the point of the extraction.

## Test plan

- [x] `pnpm run build` — passes (tsc + vite)
- [x] `pnpm run build:check-renderer` — passes
- [x] `pnpm run lint` — 0 warnings / 0 errors
- [x] `pnpm run format:check` — passes
- [x] `pnpm test` — all 320 tests pass
- [ ] Manual smoke (post-merge): Google sign-in, sign-out, manual sync-now, settings-modal sync status pill, auto-sync timer after toggling \`googleDriveEnabled\`

## Notes for review

Sister PRs \`claude/refactor-ipc-meetings-mgmt\` and \`claude/refactor-ipc-transcription\` create the same \`src/ipc/types.ts\` / \`src/ipc/register.ts\` scaffolding. After the first one merges, this PR will need a rebase to drop duplicate definitions and add its registration line to the merged \`register.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)