### PR TITLE
fix: keep Meet active during Space switches

### DIFF
--- a/src/meetingDetectorService.test.ts
+++ b/src/meetingDetectorService.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { hasSleepAssertionFrom } from './meetingDetectorService';
+import {
+  MEETING_DETECTION_TRANSIENT_MISS_GRACE_MS,
+  hasSleepAssertionFrom,
+  shouldHoldDuringTransientMiss,
+} from './meetingDetectorService';
 
 // Sample pmset -g assertions output with a Microsoft Teams call in progress.
 // Format is taken from real macOS output.
@@ -86,5 +90,27 @@ describe('hasSleepAssertionFrom', () => {
     assert.equal(hasSleepAssertionFrom(input, /^Microsoft Teams$/), false);
     // But the raw-string check would match, which is why detectMacOS ANDs the two.
     assert.ok(input.includes('Microsoft Teams Call in progress'));
+  });
+});
+
+describe('shouldHoldDuringTransientMiss', () => {
+  it('holds Google Meet active during the transient miss grace window', () => {
+    const missingSince = 1_000;
+    const now = missingSince + MEETING_DETECTION_TRANSIENT_MISS_GRACE_MS - 1;
+
+    assert.equal(shouldHoldDuringTransientMiss('Google Meet', missingSince, now), true);
+  });
+
+  it('lets Google Meet end after the transient miss grace window', () => {
+    const missingSince = 1_000;
+    const now = missingSince + MEETING_DETECTION_TRANSIENT_MISS_GRACE_MS;
+
+    assert.equal(shouldHoldDuringTransientMiss('Google Meet', missingSince, now), false);
+  });
+
+  it('keeps non-window-title detectors on the normal end debounce', () => {
+    assert.equal(shouldHoldDuringTransientMiss('Zoom', 1_000, 2_000), false);
+    assert.equal(shouldHoldDuringTransientMiss('Microsoft Teams', 1_000, 2_000), false);
+    assert.equal(shouldHoldDuringTransientMiss('Google Meet', null, 2_000), false);
   });
 });

--- a/src/meetingDetectorService.ts
+++ b/src/meetingDetectorService.ts
@@ -9,6 +9,22 @@ interface MeetingInfo {
   detectedAt: Date;
 }
 
+// macOS Space/Mission Control switches can briefly hide browser window titles
+// from System Events. Keep active browser-title detections alive through that.
+export const MEETING_DETECTION_TRANSIENT_MISS_GRACE_MS = 90_000;
+
+const TRANSIENT_MISS_GRACE_APPS = new Set(['Google Meet']);
+
+export function shouldHoldDuringTransientMiss(
+  app: string | undefined,
+  missingSinceMs: number | null,
+  nowMs: number,
+  graceMs = MEETING_DETECTION_TRANSIENT_MISS_GRACE_MS,
+): boolean {
+  if (!app || missingSinceMs === null || !TRANSIENT_MISS_GRACE_APPS.has(app)) return false;
+  return nowMs - missingSinceMs < graceMs;
+}
+
 // True if `pmset -g assertions` output has any `PreventUserIdle{Display,System}Sleep`
 // assertion whose owning process matches `processPattern`. Video-call apps raise
 // these assertions only while a call is active, so this distinguishes "app open"
@@ -32,6 +48,7 @@ export class MeetingDetectorService extends EventEmitter {
   private currentMeeting: MeetingInfo | null = null;
   private consecutiveDetections = 0;
   private consecutiveNonDetections = 0;
+  private missingSinceMs: number | null = null;
   private static readonly POLL_MS = 5000;
   private static readonly START_THRESHOLD = 2; // 2 consecutive detections to confirm start
   private static readonly END_THRESHOLD = 3; // 3 consecutive non-detections to confirm end
@@ -57,6 +74,7 @@ export class MeetingDetectorService extends EventEmitter {
     }
     this.consecutiveDetections = 0;
     this.consecutiveNonDetections = 0;
+    this.missingSinceMs = null;
     console.log('Meeting detector stopped');
   }
 
@@ -88,6 +106,7 @@ export class MeetingDetectorService extends EventEmitter {
             : null;
 
       if (detected) {
+        this.missingSinceMs = null;
         this.consecutiveNonDetections = 0;
         this.consecutiveDetections++;
 
@@ -103,16 +122,22 @@ export class MeetingDetectorService extends EventEmitter {
           console.log(`Meeting started: ${detected}`);
         }
       } else {
+        const now = Date.now();
+        if (this.currentMeeting && this.missingSinceMs === null) {
+          this.missingSinceMs = now;
+        }
         this.consecutiveDetections = 0;
         this.consecutiveNonDetections++;
 
         if (
           this.currentMeeting &&
+          !shouldHoldDuringTransientMiss(this.currentMeeting.app, this.missingSinceMs, now) &&
           this.consecutiveNonDetections >= MeetingDetectorService.END_THRESHOLD
         ) {
           const duration = Date.now() - this.currentMeeting.detectedAt.getTime();
           const app = this.currentMeeting.app;
           this.currentMeeting = null;
+          this.missingSinceMs = null;
           this.emit('meeting-ended', { app, duration });
           console.log(`Meeting ended: ${app} (${Math.round(duration / 1000)}s)`);
         }


### PR DESCRIPTION
## Summary

Fixes the Google Meet auto-stop false positive when macOS Space/Mission Control switches temporarily hide browser window titles from System Events. The detector now keeps an already-active Google Meet session alive through a 90-second transient miss grace window before allowing the existing end debounce to stop recording.

The 90-second window is intentionally longer than a quick Space switch but still bounded so real meeting endings are delayed by at most about a minute and a half.

## Key changes

- Add a 90-second transient miss grace for active Google Meet detections.
- Reset the miss timer when detection resumes or the detector stops/ends.
- Add regression coverage for the grace boundary and non-Google Meet detectors.

## Type of change

Bug fix

## Testing performed

- `./node_modules/.bin/oxfmt --check src/meetingDetectorService.ts src/meetingDetectorService.test.ts`
- `./node_modules/.bin/oxlint src/meetingDetectorService.ts src/meetingDetectorService.test.ts`
- `./node_modules/.bin/tsc && NODE_ENV=test node --test dist/meetingDetectorService.test.js`
- Full test suite: `NODE_ENV=test node --test "dist/**/*.test.js"` (329 passed)

Note: `pnpm run` commands were blocked before script execution by pnpm 11 dependency status/build-script approval checks in this worktree, so validation was run through the installed project binaries directly.

## Related issues

Closes #167