### PR TITLE
feat: Add live translated session captions and Q&A

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ listener config set slackWebhookUrl <your-webhook-url>
 listener config set slackAutoShare true  # Auto-share when auto mode is enabled
 ```
 
+Optional live transcription streaming:
+
+```bash
+# Auto uses OpenAI Realtime with a direct OpenAI key, then Gemini Live,
+# then 12-second chunked fallback.
+listener config set liveSttProvider auto
+# Required for OpenAI Realtime live translation. Codex sign-in is not enough
+# for OpenAI Realtime live translation.
+listener config set openaiApiKey <your-openai-key>
+
+# Optional BCP-47 source hint and translation target.
+listener config set liveSttLanguage ko
+listener config set liveTranslationLanguage ko
+```
+
 ### Usage
 
 ```bash
@@ -138,7 +153,7 @@ CLI and desktop app share the same config file. Existing installs that already h
 2. Complete the browser sign-in to ChatGPT.
 3. Confirm `listener codex status` shows `codexOAuthConfigured=true`.
 
-Codex transcription, summarization, and the Ask Listener agent all go through your ChatGPT subscription -- no separate API key needed.
+Codex transcription, summarization, and the Ask Listener agent go through your ChatGPT subscription -- no separate API key needed for those features. OpenAI Realtime live translation still needs a standard OpenAI API key; Codex OAuth is not treated as live translation auth. Listener.AI prefers its own stored Codex OAuth credentials, then environment credentials, then the local Codex CLI auth file (`~/.codex/auth.json`) as a read-only fallback for Codex-backed features. Refreshes are only written back when the token came from Listener.AI's own Settings/login flow.
 
 #### Notion Integration
 

--- a/docs/model-pricing.md
+++ b/docs/model-pricing.md
@@ -1,6 +1,6 @@
 # AI Model Pricing Reference
 
-Pricing for the AI models Listener.AI uses (or could switch to) for transcription, summarization, and the chat agent. Verified May 2026.
+Pricing for the AI models Listener.AI uses (or could switch to) for transcription, live captions, summarization, and the chat agent. Verified June 2026.
 
 When prices drift, update the date in the cell and re-cite from the provider's own pricing page (not blogs).
 
@@ -12,6 +12,8 @@ When prices drift, update the date in the cell and re-cite from the provider's o
 | Summary (Gemini) | `geminiModel` | gemini-3.5-flash | $1.50/M input, $9.00/M output | Native thinking on (`thinking_level` configurable via `geminiThinkingLevel`: low/medium/high, default medium). Output billing includes thought tokens. |
 | Transcription (Codex) | `codexTranscriptionModel` | gpt-4o-transcribe | $0.006/min ($2.50/M audio in, $10.00/M text out) | No speaker diarization. `prompt` param is vocabulary/style hint only. |
 | Summary + agent (Codex) | `codexModel` | gpt-5.5 (via ChatGPT Codex Responses) | $5.00/M input, $30.00/M output (API price; ChatGPT subscription absorbs cost) | Rejects `temperature`/sampling params (reasoning model). Cached input $0.50/M. |
+| Live transcription (streaming) | `liveSttProvider`, `openaiLiveTranscriptionModel` | gpt-realtime-whisper or gemini-3.1-flash-live-preview | OpenAI: $0.017/min. Gemini: ~$0.005/min input audio | Auto mode tries OpenAI Realtime with a direct OpenAI API key, then Gemini Live, then chunked fallback. |
+| Live translation (streaming captions) | `liveSttProvider`, `openaiLiveTranslationModel`, `liveTranslationLanguage` | gpt-realtime-translate or gemini-3.5-live-translate-preview | OpenAI: $0.034/min. Gemini: $0.0053/min input audio + $0.0315/min output audio | OpenAI Realtime live translation requires a standard OpenAI API key; Codex OAuth is not treated as live translation auth. |
 
 ## Provider notes
 
@@ -104,6 +106,8 @@ For Korean meetings the data points are thin. AssemblyAI Universal-2 has confirm
 
 - [Google AI Pricing](https://ai.google.dev/pricing)
 - [OpenAI API Pricing](https://developers.openai.com/api/docs/pricing)
+- [OpenAI Realtime transcription](https://developers.openai.com/api/docs/guides/realtime-transcription)
+- [OpenAI Realtime translation](https://developers.openai.com/api/docs/guides/realtime-translation)
 - [OpenAI Codex Pricing](https://developers.openai.com/codex/pricing)
 - [OpenAI Transcription pricing aggregator](https://costgoat.com/pricing/openai-transcription)
 - [gpt-4o-transcribe-diarize model card](https://platform.openai.com/docs/models/gpt-4o-transcribe-diarize)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "dist/esmImport.js",
     "dist/geminiService.js",
     "dist/googleOAuth.js",
+    "dist/liveSessionService.js",
+    "dist/liveSttProvider.js",
+    "dist/openAiRealtimeClient.js",
     "dist/piAiClient.js",
     "dist/outputService.js",
     "dist/searchService.js",
@@ -71,6 +74,7 @@
     "@electron/notarize": "^3.0.1",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^24.0.12",
+    "@types/ws": "^8.18.1",
     "dotenv": "^17.2.0",
     "electron": "^39.8.5",
     "electron-builder": "^26.8.1",
@@ -82,22 +86,18 @@
   },
   "dependencies": {
     "@earendil-works/pi-ai": "0.74.0",
-    "@google/genai": "^1.13.0",
+    "@google/genai": "^2.8.0",
     "audiotee": "^0.0.7",
     "buffer-equal-constant-time": "^1.0.1",
     "fs-extra": "^11.2.0",
     "google-auth-library": "^10.6.2",
     "jwa": "^2.0.1",
-    "marked": "^15.0.0"
+    "marked": "^15.0.0",
+    "ws": "^8.21.0"
   },
   "optionalDependencies": {
     "@notionhq/client": "^4.0.0",
     "electron-updater": "^6.6.2"
-  },
-  "pnpm": {
-    "overrides": {
-      "js-yaml@>=4.0.0 <4.1.1": "^4.1.1"
-    }
   },
   "build": {
     "appId": "com.listenerai.app",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,11 @@
     "@notionhq/client": "^4.0.0",
     "electron-updater": "^6.6.2"
   },
+  "pnpm": {
+    "overrides": {
+      "js-yaml@>=4.0.0 <4.1.1": "^4.1.1"
+    }
+  },
   "build": {
     "appId": "com.listenerai.app",
     "productName": "Listener.AI",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: 0.74.0
-        version: 0.74.0(ws@8.18.3)(zod@4.4.3)
+        version: 0.74.0(ws@8.21.0)(zod@4.4.3)
       '@google/genai':
-        specifier: ^1.13.0
-        version: 1.13.0(encoding@0.1.13)
+        specifier: ^2.8.0
+        version: 2.8.0
       audiotee:
         specifier: ^0.0.7
         version: 0.0.7
@@ -35,13 +35,9 @@ importers:
       marked:
         specifier: ^15.0.0
         version: 15.0.12
-    optionalDependencies:
-      '@notionhq/client':
-        specifier: ^4.0.0
-        version: 4.0.1
-      electron-updater:
-        specifier: ^6.6.2
-        version: 6.6.2
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
     devDependencies:
       '@electron/notarize':
         specifier: ^3.0.1
@@ -52,6 +48,9 @@ importers:
       '@types/node':
         specifier: ^24.0.12
         version: 24.1.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       dotenv:
         specifier: ^17.2.0
         version: 17.2.1
@@ -76,6 +75,13 @@ importers:
       vite:
         specifier: ^6.4.2
         version: 6.4.2(@types/node@24.1.0)(jiti@2.6.1)
+    optionalDependencies:
+      '@notionhq/client':
+        specifier: ^4.0.0
+        version: 4.0.1
+      electron-updater:
+        specifier: ^6.6.2
+        version: 6.6.2
 
 packages:
 
@@ -453,17 +459,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@google/genai@1.13.0':
-    resolution: {integrity: sha512-BxilXzE8cJ0zt5/lXk6KwuBcIT9P2Lbi2WXhwWMbxf1RNeC68/8DmYQqMrzQP333CieRMdbDXs0eNCphLoScWg==}
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.11.0
+      '@modelcontextprotocol/sdk': ^1.25.2
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
 
-  '@google/genai@1.52.0':
-    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+  '@google/genai@2.8.0':
+    resolution: {integrity: sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -552,48 +558,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.48.0':
     resolution: {integrity: sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.48.0':
     resolution: {integrity: sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.48.0':
     resolution: {integrity: sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.48.0':
     resolution: {integrity: sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.48.0':
     resolution: {integrity: sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.48.0':
     resolution: {integrity: sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.48.0':
     resolution: {integrity: sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.48.0':
     resolution: {integrity: sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w==}
@@ -666,48 +680,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.63.0':
     resolution: {integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.63.0':
     resolution: {integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.63.0':
     resolution: {integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.63.0':
     resolution: {integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.63.0':
     resolution: {integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.63.0':
     resolution: {integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.63.0':
     resolution: {integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.63.0':
     resolution: {integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==}
@@ -801,66 +823,79 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -1108,6 +1143,9 @@ packages:
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -1642,17 +1680,9 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  gaxios@6.7.1:
-    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
-    engines: {node: '>=14'}
-
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
     engines: {node: '>=18'}
-
-  gcp-metadata@6.1.1:
-    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
-    engines: {node: '>=14'}
 
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
@@ -1699,14 +1729,6 @@ packages:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
 
-  google-auth-library@9.15.1:
-    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
-    engines: {node: '>=14'}
-
-  google-logging-utils@0.0.2:
-    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
-    engines: {node: '>=14'}
-
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
@@ -1721,10 +1743,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  gtoken@7.1.0:
-    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
-    engines: {node: '>=14.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1797,10 +1815,6 @@ packages:
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
-    engines: {node: '>=8'}
-
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
   is-unicode-supported@0.1.0:
@@ -1886,9 +1900,6 @@ packages:
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
-
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -2041,15 +2052,6 @@ packages:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -2429,9 +2431,6 @@ packages:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
@@ -2488,11 +2487,6 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
@@ -2544,12 +2538,6 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2573,6 +2561,18 @@ packages:
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3063,14 +3063,14 @@ snapshots:
       ajv: 6.14.0
       ajv-keywords: 3.5.2(ajv@6.14.0)
 
-  '@earendil-works/pi-ai@0.74.0(ws@8.18.3)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.74.0(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1045.0
       '@google/genai': 1.52.0
       '@mistralai/mistralai': 2.2.1
       chalk: 5.6.2
-      openai: 6.26.0(ws@8.18.3)(zod@4.4.3)
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       typebox: 1.1.38
@@ -3163,7 +3163,7 @@ snapshots:
       node-gyp: 11.5.0
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
-      semver: 7.7.2
+      semver: 7.7.4
       tar: 7.5.11
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -3175,7 +3175,7 @@ snapshots:
       '@malept/cross-spawn-promise': 2.0.0
       debug: 4.4.3
       dir-compare: 4.2.0
-      fs-extra: 11.3.0
+      fs-extra: 11.3.5
       minimatch: 9.0.9
       plist: 3.1.0
     transitivePeerDependencies:
@@ -3270,22 +3270,23 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@google/genai@1.13.0(encoding@0.1.13)':
-    dependencies:
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.52.0':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.8
       ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@google/genai@2.8.0':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.5.8
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -3312,7 +3313,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       fs-extra: 9.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3828,6 +3829,10 @@ snapshots:
 
   '@types/verror@1.10.11':
     optional: true
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.1.0
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -4444,7 +4449,7 @@ snapshots:
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 6.1.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   fs-extra@11.3.0:
@@ -4458,7 +4463,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
-    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -4490,32 +4494,12 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  gaxios@6.7.1(encoding@0.1.13):
-    dependencies:
-      extend: 3.0.2
-      https-proxy-agent: 7.0.6
-      is-stream: 2.0.1
-      node-fetch: 2.7.0(encoding@0.1.13)
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
     transitivePeerDependencies:
-      - supports-color
-
-  gcp-metadata@6.1.1(encoding@0.1.13):
-    dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)
-      google-logging-utils: 0.0.2
-      json-bigint: 1.0.0
-    transitivePeerDependencies:
-      - encoding
       - supports-color
 
   gcp-metadata@8.1.2:
@@ -4603,20 +4587,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  google-auth-library@9.15.1(encoding@0.1.13):
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1(encoding@0.1.13)
-      gcp-metadata: 6.1.1(encoding@0.1.13)
-      gtoken: 7.1.0(encoding@0.1.13)
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  google-logging-utils@0.0.2: {}
-
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
@@ -4636,14 +4606,6 @@ snapshots:
       responselike: 2.0.1
 
   graceful-fs@4.2.11: {}
-
-  gtoken@7.1.0(encoding@0.1.13):
-    dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   has-flag@4.0.0: {}
 
@@ -4713,8 +4675,6 @@ snapshots:
   is-fullwidth-code-point@3.0.0: {}
 
   is-interactive@1.0.0: {}
-
-  is-stream@2.0.1: {}
 
   is-unicode-supported@0.1.0: {}
 
@@ -4800,8 +4760,6 @@ snapshots:
 
   lodash.isequal@4.5.0:
     optional: true
-
-  lodash@4.17.23: {}
 
   lodash@4.18.1: {}
 
@@ -4938,12 +4896,6 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
-  node-fetch@2.7.0(encoding@0.1.13):
-    dependencies:
-      whatwg-url: 5.0.0
-    optionalDependencies:
-      encoding: 0.1.13
-
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -4982,9 +4934,9 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openai@6.26.0(ws@8.18.3)(zod@4.4.3):
+  openai@6.26.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
-      ws: 8.18.3
+      ws: 8.21.0
       zod: 4.4.3
 
   ora@5.4.1:
@@ -5405,8 +5357,6 @@ snapshots:
 
   tmp@0.2.5: {}
 
-  tr46@0.0.3: {}
-
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
@@ -5448,8 +5398,6 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@9.0.1: {}
-
   verror@1.10.1:
     dependencies:
       assert-plus: 1.0.0
@@ -5476,13 +5424,6 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
-
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -5506,6 +5447,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.3: {}
+
+  ws@8.21.0: {}
 
   xml-naming@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+overrides:
+  js-yaml@>=4.0.0 <4.1.1: ^4.1.1
+
+allowBuilds:
+  '@google/genai': true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,0 @@
-overrides:
-  js-yaml@>=4.0.0 <4.1.1: ^4.1.1
-
-allowBuilds:
-  '@google/genai': true

--- a/renderer/audio/graph.ts
+++ b/renderer/audio/graph.ts
@@ -5,6 +5,7 @@
 // Brick-wall limiter at the tail prevents Opus encoder clipping.
 
 import { state } from '../state';
+import livePcmTapUrl from './live-pcm-tap-processor.js?url';
 
 export function pickRecordingMimeType(): string {
   const candidates = [
@@ -70,6 +71,14 @@ export type ProcessedGraph = {
   head: AudioNode;
 };
 
+export type LivePcmFrame = {
+  audioData: ArrayBuffer;
+  sampleRate: number;
+  channelCount: number;
+  frames: number;
+  sequence: number;
+};
+
 // Mic keeps the voice-lift chain; system audio (Zoom/Meet, browser tabs) is digital-clean
 // so it only gets a gentle -2dB attenuation before the shared brick-wall limiter catches
 // any combined peaks before the Opus encoder.
@@ -80,6 +89,7 @@ export type ProcessedGraph = {
 export async function buildProcessedStream(
   micStream: MediaStream,
   addSystemAudio: ((ctx: AudioContext) => Promise<AudioNode | null>) | null = null,
+  onLivePcmFrame: ((frame: LivePcmFrame) => void) | null = null,
 ): Promise<ProcessedGraph> {
   const ctx = new AudioContext({ sampleRate: 48000 });
   const mic = buildMicChain(ctx, micStream);
@@ -98,7 +108,22 @@ export async function buildProcessedStream(
   }
 
   const destination = ctx.createMediaStreamDestination();
-  preLimit.connect(buildLimiter(ctx)).connect(destination);
+  const limiter = buildLimiter(ctx);
+  preLimit.connect(limiter).connect(destination);
+  if (onLivePcmFrame) {
+    await ctx.audioWorklet.addModule(livePcmTapUrl);
+    const tap = new AudioWorkletNode(ctx, 'live-pcm-tap', {
+      numberOfInputs: 1,
+      numberOfOutputs: 1,
+      outputChannelCount: [1],
+    });
+    const tapSink = ctx.createGain();
+    tapSink.gain.value = 0;
+    tap.port.onmessage = (event: MessageEvent<LivePcmFrame & { type?: string }>) => {
+      if (event.data?.type === 'pcm') onLivePcmFrame(event.data);
+    };
+    limiter.connect(tap).connect(tapSink).connect(destination);
+  }
   // source/head support hot-swapping the mic mid-recording (mic selector).
   return { ctx, stream: destination.stream, source: mic.source, head: mic.head };
 }

--- a/renderer/audio/live-pcm-tap-processor.js
+++ b/renderer/audio/live-pcm-tap-processor.js
@@ -1,0 +1,48 @@
+const FRAME_MS = 100;
+
+class LivePcmTapProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.frameSize = Math.max(1, Math.round((sampleRate * FRAME_MS) / 1000));
+    this.pending = new Float32Array(this.frameSize);
+    this.pendingLength = 0;
+    this.sequence = 0;
+  }
+
+  process(inputs, outputs) {
+    const input = inputs[0]?.[0];
+    const output = outputs[0]?.[0];
+    if (output) output.fill(0);
+    if (!input) return true;
+
+    let offset = 0;
+    while (offset < input.length) {
+      const n = Math.min(this.frameSize - this.pendingLength, input.length - offset);
+      this.pending.set(input.subarray(offset, offset + n), this.pendingLength);
+      this.pendingLength += n;
+      offset += n;
+      if (this.pendingLength === this.frameSize) {
+        const pcm = new Int16Array(this.frameSize);
+        for (let i = 0; i < this.frameSize; i++) {
+          const sample = Math.max(-1, Math.min(1, this.pending[i]));
+          pcm[i] = sample < 0 ? Math.round(sample * 32768) : Math.round(sample * 32767);
+        }
+        this.port.postMessage(
+          {
+            type: 'pcm',
+            audioData: pcm.buffer,
+            sampleRate,
+            channelCount: 1,
+            frames: this.frameSize,
+            sequence: this.sequence++,
+          },
+          [pcm.buffer],
+        );
+        this.pendingLength = 0;
+      }
+    }
+    return true;
+  }
+}
+
+registerProcessor('live-pcm-tap', LivePcmTapProcessor);

--- a/renderer/audio/recorder.ts
+++ b/renderer/audio/recorder.ts
@@ -3,11 +3,19 @@
 
 import { getDom, state } from '../state';
 import { hideLiveNotesPanel, showLiveNotesPanel } from '../ui/live-notes';
+import {
+  clearLiveSessionLauncher,
+  configureLiveSessionLauncher,
+  handleLivePcmFrame,
+  stopLiveSessionCapture,
+} from '../ui/live-session';
 import { showNotification, showToast } from '../ui/notifications';
 import { refreshRecordingsList } from '../ui/recordings-list';
 import { buildProcessedStream, cleanupAudioState, pickRecordingMimeType } from './graph';
 import { acquireMediaStream, attachTrackEndedHandlers } from './mic';
 import { createSystemAudioSource } from './system-audio';
+
+let stopRecordingInProgress = false;
 
 export async function startRecording(): Promise<void> {
   const { recordButton, statusIndicator, statusText, recordingTime, meetingTitle } = getDom();
@@ -75,7 +83,7 @@ export async function startRecording(): Promise<void> {
           return node;
         }
       : null;
-    graph = await buildProcessedStream(state.mediaStream, addSystemAudio);
+    graph = await buildProcessedStream(state.mediaStream, addSystemAudio, handleLivePcmFrame);
     state.audioContext = graph.ctx;
     state.processedStream = graph.stream;
     state.sourceNode = graph.source;
@@ -127,6 +135,7 @@ export async function startRecording(): Promise<void> {
   state.mediaRecorder.onerror = (event: Event) => {
     const err = (event as unknown as { error?: unknown }).error ?? event;
     console.error('MediaRecorder error:', err);
+    void stopLiveSessionCapture();
     cleanupAudioState();
     resetRecordingUI();
     window.electronAPI.stopRecording().catch(() => {});
@@ -144,9 +153,13 @@ export async function startRecording(): Promise<void> {
     );
     return;
   }
-
   state.isRecording = true;
   state.recordingStartTime = Date.now();
+  configureLiveSessionLauncher(
+    title,
+    state.processedStream,
+    state.mediaRecorder.mimeType || state.recordingMimeType || 'audio/webm',
+  );
 
   recordButton.textContent = 'Stop Recording';
   recordButton.classList.add('recording');
@@ -168,6 +181,7 @@ export function resetRecordingUI(): void {
   statusText.textContent = 'Ready to record';
   recordingTime.classList.remove('active');
   hideLiveNotesPanel();
+  clearLiveSessionLauncher();
 }
 
 function pickMeetingTitle(recordingTitle: string, suggestedTitle?: string): string {
@@ -313,60 +327,72 @@ export async function handleRecordingStopped(
 }
 
 export async function stopRecording(): Promise<void> {
-  // Snapshot live notes before they get cleared by the UI reset. Passed to
-  // main so they're persisted alongside the audio file regardless of whether
-  // auto-mode kicks off transcription right away, and forwarded into the
-  // auto-mode path so transcribe-audio gets them without re-reading state.
-  const liveNotesSnapshot = state.liveNotes.length > 0 ? state.liveNotes.slice() : undefined;
-  const liveNotesPayload = liveNotesSnapshot ? { liveNotes: liveNotesSnapshot } : undefined;
-
-  // If the recorder already transitioned to inactive on its own (e.g. USB mic
-  // unplugged, stream ended, Chromium force-stopped encoding), still unwind the
-  // session so the next recording isn't blocked by stuck state.
-  if (!state.mediaRecorder || state.mediaRecorder.state === 'inactive') {
-    cleanupAudioState();
-    try {
-      const result = await window.electronAPI.stopRecording(liveNotesPayload);
-      if (result?.success) {
-        await handleRecordingStopped(result.filePath, result.durationMs, liveNotesSnapshot);
-        return;
-      }
-    } catch {
-      // fall through to UI reset
-    }
-    resetRecordingUI();
-    return;
-  }
+  if (stopRecordingInProgress) return;
+  stopRecordingInProgress = true;
+  const { recordButton } = getDom();
+  recordButton.disabled = true;
 
   try {
-    // MediaRecorder.stop() flushes the final chunk via ondataavailable before
-    // firing onstop. We then await chunkSendChain so every in-flight arrayBuffer()
-    // conversion lands on main's IPC queue before stop-recording invoke — Electron
-    // multiplexes all IPC over one Mojo pipe, preserving delivery order.
-    const recorder = state.mediaRecorder;
-    const stopped = new Promise<void>((resolve) => {
-      recorder.onstop = () => resolve();
-    });
-    recorder.stop();
-    await stopped;
-    await state.chunkSendChain;
-    cleanupAudioState();
+    // Snapshot live notes before they get cleared by the UI reset. Passed to
+    // main so they're persisted alongside the audio file regardless of whether
+    // auto-mode kicks off transcription right away, and forwarded into the
+    // auto-mode path so transcribe-audio gets them without re-reading state.
+    const liveNotesSnapshot = state.liveNotes.length > 0 ? state.liveNotes.slice() : undefined;
+    const liveNotesPayload = liveNotesSnapshot ? { liveNotes: liveNotesSnapshot } : undefined;
 
-    const result = await window.electronAPI.stopRecording(liveNotesPayload);
-
-    if (result.success) {
-      await handleRecordingStopped(result.filePath, result.durationMs, liveNotesSnapshot);
-    } else if (result.reason === 'empty') {
-      alert('No audio captured.');
+    // If the recorder already transitioned to inactive on its own (e.g. USB mic
+    // unplugged, stream ended, Chromium force-stopped encoding), still unwind the
+    // session so the next recording isn't blocked by stuck state.
+    if (!state.mediaRecorder || state.mediaRecorder.state === 'inactive') {
+      await stopLiveSessionCapture({ hidePanel: true });
+      cleanupAudioState();
+      try {
+        const result = await window.electronAPI.stopRecording(liveNotesPayload);
+        if (result?.success) {
+          await handleRecordingStopped(result.filePath, result.durationMs, liveNotesSnapshot);
+          return;
+        }
+      } catch {
+        // fall through to UI reset
+      }
       resetRecordingUI();
-    } else {
-      alert(`Failed to save recording: ${result.error || 'Unknown error'}`);
+      return;
+    }
+
+    try {
+      // MediaRecorder.stop() flushes the final chunk via ondataavailable before
+      // firing onstop. We then await chunkSendChain so every in-flight arrayBuffer()
+      // conversion lands on main's IPC queue before stop-recording invoke — Electron
+      // multiplexes all IPC over one Mojo pipe, preserving delivery order.
+      const recorder = state.mediaRecorder;
+      const stopped = new Promise<void>((resolve) => {
+        recorder.onstop = () => resolve();
+      });
+      recorder.stop();
+      await stopped;
+      await state.chunkSendChain;
+      await stopLiveSessionCapture({ hidePanel: true });
+      cleanupAudioState();
+
+      const result = await window.electronAPI.stopRecording(liveNotesPayload);
+
+      if (result.success) {
+        await handleRecordingStopped(result.filePath, result.durationMs, liveNotesSnapshot);
+      } else if (result.reason === 'empty') {
+        alert('No audio captured.');
+        resetRecordingUI();
+      } else {
+        alert(`Failed to save recording: ${result.error || 'Unknown error'}`);
+        resetRecordingUI();
+      }
+    } catch (error) {
+      alert(`Failed to stop recording: ${error instanceof Error ? error.message : String(error)}`);
+      cleanupAudioState();
       resetRecordingUI();
     }
-  } catch (error) {
-    alert(`Failed to stop recording: ${error instanceof Error ? error.message : String(error)}`);
-    cleanupAudioState();
-    resetRecordingUI();
+  } finally {
+    stopRecordingInProgress = false;
+    if (!state.isAutoModeProcessing) recordButton.disabled = false;
   }
 }
 

--- a/renderer/electronAPI.d.ts
+++ b/renderer/electronAPI.d.ts
@@ -20,7 +20,70 @@ export type AgentChatMessage = {
   // through IPC unchanged so the next agent run can replay tool-use history.
   piaiMessages?: unknown[];
 };
-export type AgentScope = { kind: 'all' } | { kind: 'single'; folderName: string };
+export type AgentScope =
+  | { kind: 'all' }
+  | { kind: 'single'; folderName: string }
+  | {
+      kind: 'live';
+      title: string;
+      transcript: string;
+      interimTranscript?: string;
+      interimTranslation?: string;
+      translation?: string;
+    };
+
+export type LiveTranscriptSegment = {
+  id: string;
+  offsetMs: number;
+  durationMs: number;
+  transcript: string;
+  translation?: string;
+  translationError?: string;
+  final: boolean;
+  createdAt: string;
+};
+
+export type LiveSessionStartResult = {
+  sessionId: string;
+  title: string;
+  startedAt: string;
+  translate: boolean;
+  mode: 'streaming' | 'chunked';
+  provider: 'openai' | 'gemini' | 'chunked';
+  realtimeClient?: {
+    transport: 'webrtc';
+    endpoint: 'realtime' | 'translation';
+    clientSecret: string;
+  };
+};
+
+export type LiveSessionSnapshot = {
+  sessionId: string;
+  title: string;
+  startedAt: string;
+  active: boolean;
+  translate: boolean;
+  mode: 'streaming' | 'chunked';
+  provider: 'openai' | 'gemini' | 'chunked';
+  segments: LiveTranscriptSegment[];
+  interimTranscript: string;
+  interimTranslation: string;
+  transcript: string;
+  translation: string;
+};
+
+export type LiveSessionEvent =
+  | {
+      type: 'status';
+      sessionId: string;
+      status: string;
+      mode?: 'streaming' | 'chunked';
+      provider?: 'openai' | 'gemini' | 'chunked';
+    }
+  | { type: 'interim'; sessionId: string; text: string; offsetMs?: number }
+  | { type: 'translationInterim'; sessionId: string; text: string; offsetMs?: number }
+  | { type: 'segment'; sessionId: string; segment: LiveTranscriptSegment }
+  | { type: 'error'; sessionId: string; error: string };
 
 export type AgentConfirmRequest = {
   id: string;
@@ -36,8 +99,17 @@ export type AgentConfirmRequest = {
 export type ConfigPayload = {
   aiProvider?: 'gemini' | 'codex';
   geminiApiKey?: string;
+  geminiModel?: string;
+  geminiFlashModel?: string;
+  geminiThinkingLevel?: 'low' | 'medium' | 'high';
   codexModel?: string;
   codexTranscriptionModel?: string;
+  liveSttProvider?: 'auto' | 'openai' | 'gemini' | 'chunked';
+  openaiApiKey?: string;
+  openaiLiveTranscriptionModel?: string;
+  openaiLiveTranslationModel?: string;
+  liveSttLanguage?: string;
+  liveTranslationLanguage?: string;
   notionApiKey?: string;
   notionDatabaseId?: string;
   autoMode?: boolean;
@@ -51,6 +123,13 @@ export type ConfigPayload = {
   slackWebhookUrl?: string;
   slackAutoShare?: boolean;
   googleDriveEnabled?: boolean;
+};
+
+export type RendererLogPayload = {
+  level: 'debug' | 'log' | 'info' | 'warn' | 'error';
+  timestamp: string;
+  url: string;
+  args: unknown[];
 };
 
 export type GoogleSyncResult = {
@@ -88,6 +167,7 @@ export type SystemAudioStartResult =
 
 export type ElectronAPI = {
   platform: NodeJS.Platform;
+  logRenderer: (payload: RendererLogPayload) => void;
   startRecording: (payload: { title: string; mimeType: string }) => Promise<{
     success: boolean;
     error?: string;
@@ -184,6 +264,72 @@ export type ElectronAPI = {
     fields?: string[];
     limit?: number;
   }) => Promise<Array<Record<string, any>>>;
+  startLiveSession: (opts: {
+    title?: string;
+    translate?: boolean;
+  }) => Promise<
+    { success: true; session: LiveSessionStartResult } | { success: false; error: string }
+  >;
+  handleLiveRealtimeFailure: (opts: {
+    sessionId: string;
+    error?: string;
+  }) => Promise<
+    { success: true; session: LiveSessionStartResult } | { success: false; error: string }
+  >;
+  processLiveAudioChunk: (opts: {
+    sessionId: string;
+    audioData: ArrayBuffer;
+    mimeType: string;
+    offsetMs: number;
+    durationMs: number;
+    translate?: boolean;
+  }) => Promise<
+    | { success: true; segment: LiveTranscriptSegment | null; snapshot: LiveSessionSnapshot | null }
+    | { success: false; error: string }
+  >;
+  sendLivePcmChunk: (opts: {
+    sessionId: string;
+    audioData: ArrayBuffer;
+    sampleRate: number;
+    channelCount: number;
+    offsetMs: number;
+    durationMs: number;
+    sequence: number;
+  }) => void;
+  updateLiveSessionInterim: (opts: {
+    sessionId: string;
+    text: string;
+    translation?: boolean;
+    offsetMs?: number;
+  }) => void;
+  completeLiveSessionSegment: (opts: {
+    sessionId: string;
+    text: string;
+    offsetMs?: number;
+    durationMs?: number;
+    translation?: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  stopLiveSession: (
+    sessionId: string,
+  ) => Promise<
+    { success: true; snapshot: LiveSessionSnapshot | null } | { success: false; error: string }
+  >;
+  getLiveSessionSnapshot: () => Promise<{
+    success: true;
+    snapshot: LiveSessionSnapshot | null;
+  }>;
+  setLiveSessionTranslate: (opts: {
+    sessionId: string;
+    translate: boolean;
+  }) => Promise<
+    { success: true; snapshot: LiveSessionSnapshot | null } | { success: false; error: string }
+  >;
+  askLiveSession: (opts: {
+    sessionId: string;
+    question: string;
+    history?: AgentChatMessage[];
+  }) => Promise<{ success: true; result: any } | { success: false; error: string }>;
+  onLiveSessionEvent: (cb: (event: LiveSessionEvent) => void) => void;
   agentChat: (opts: {
     question: string;
     history?: AgentChatMessage[];

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -48,6 +48,10 @@
 
       <div id="recordingTime" class="recording-time">00:00</div>
 
+      <button id="liveSessionStartButton" class="live-session-start-button" type="button" hidden>
+        Live Transcript
+      </button>
+
       <div id="liveNotesPanel" class="live-notes-panel" style="display: none;">
         <div class="live-notes-header">
           <span class="live-notes-title">🗒️ Highlights</span>
@@ -65,6 +69,52 @@
           autocomplete="off"
           spellcheck="false"
         />
+      </div>
+
+      <div id="liveSessionPanel" class="live-session-modal" role="dialog" aria-modal="true" aria-labelledby="liveSessionHeading" hidden>
+        <div class="live-session-card">
+          <div class="live-session-header">
+            <div>
+              <h2 id="liveSessionHeading">Live Session</h2>
+              <p id="liveSessionStatus" class="live-session-status">Idle</p>
+            </div>
+            <div class="live-session-header-actions">
+              <label class="live-translate-toggle">
+                <input type="checkbox" id="liveTranslateToggle" checked>
+                <span>Translation</span>
+              </label>
+              <button type="button" id="liveSessionCloseButton" class="live-session-close-button">
+                Stop Live
+              </button>
+            </div>
+          </div>
+          <div class="live-session-columns">
+            <section class="live-session-column" aria-labelledby="liveTranscriptHeading">
+              <h3 id="liveTranscriptHeading">Transcript</h3>
+              <div id="liveTranscriptList" class="live-session-list" aria-live="polite">
+                <p class="live-session-empty">Waiting for speech...</p>
+              </div>
+            </section>
+            <section class="live-session-column" id="liveTranslationColumn" aria-labelledby="liveTranslationHeading">
+              <h3 id="liveTranslationHeading">Translation</h3>
+              <div id="liveTranslationList" class="live-session-list" aria-live="polite">
+                <p class="live-session-empty">Waiting for transcript...</p>
+              </div>
+            </section>
+          </div>
+          <div class="live-ask-panel">
+            <div class="live-ask-header">
+              <h3>Ask</h3>
+            </div>
+            <div class="chat-messages" id="liveChatMessages" role="log" aria-live="polite">
+              <p class="chat-empty">Ask about what has been heard so far.</p>
+            </div>
+            <form class="chat-input-row" id="liveChatForm">
+              <input type="text" id="liveChatInput" class="chat-input" placeholder="Ask about the live session..." autocomplete="off" spellcheck="false" disabled />
+              <button type="submit" id="liveChatSend" class="chat-send-button" disabled>Send</button>
+            </form>
+          </div>
+        </div>
       </div>
 
       <div class="auto-mode-container">
@@ -178,6 +228,35 @@
                 <option value="codex">Codex (ChatGPT Plus/Pro)</option>
               </select>
             </div>
+            <fieldset class="config-subgroup">
+              <legend>Live transcription</legend>
+              <div class="form-group">
+                <label for="liveSttProvider">Provider</label>
+                <select id="liveSttProvider">
+                  <option value="auto">Auto (OpenAI key, Gemini Live, then fallback)</option>
+                  <option value="openai">OpenAI Realtime</option>
+                  <option value="gemini">Gemini Live</option>
+                  <option value="chunked">12s fallback</option>
+                </select>
+                <small>Used only while recording. Auto tries a direct OpenAI key first, then Gemini Live, then 12-second chunks.</small>
+              </div>
+              <div class="form-group">
+                <label for="openaiApiKey">OpenAI API Key</label>
+                <input type="password" id="openaiApiKey" placeholder="sk-...">
+                <small>Required for OpenAI Realtime live translation. Codex sign-in does not currently authorize this live translation call.</small>
+                <div id="liveProviderNotice" class="config-notice" role="status" aria-live="polite"></div>
+              </div>
+              <div class="form-group">
+                <label for="liveSttLanguage">Language Hint <span class="config-optional">optional</span></label>
+                <input type="text" id="liveSttLanguage" placeholder="auto, en, ko, ja">
+                <small>Optional source-language hint for live transcription.</small>
+              </div>
+              <div class="form-group">
+                <label for="liveTranslationLanguage">Translation Target</label>
+                <input type="text" id="liveTranslationLanguage" placeholder="ko">
+                <small>BCP-47 target language for live translated captions. Default: ko.</small>
+              </div>
+            </fieldset>
             <fieldset class="config-subgroup" data-provider="gemini">
               <legend>Gemini</legend>
               <div class="form-group">
@@ -200,8 +279,8 @@
                   <button type="button" id="resetGeminiFlashModel" class="reset-prompt-button">Reset to Default</button>
                 </div>
                 <select id="geminiFlashModelSelect"></select>
-                <input type="text" id="geminiFlashModel" placeholder="gemini-2.5-flash" hidden>
-                <small>Default: gemini-2.5-flash</small>
+                <input type="text" id="geminiFlashModel" placeholder="gemini-3.5-flash" hidden>
+                <small>Default: gemini-3.5-flash</small>
               </div>
               <div class="form-group">
                 <label for="geminiThinkingLevel">Summary Thinking Level <span class="config-optional">optional</span></label>

--- a/renderer/main.ts
+++ b/renderer/main.ts
@@ -4,12 +4,14 @@
 
 import { setupRecorder } from './audio/recorder';
 import { setupFileHandler } from './services/file-handler';
+import { setupRendererLogger } from './services/renderer-logger';
 import { getDom, initDom } from './state';
 import { setupAgentConfirmHandler, setupHomeChat, setupModalChat } from './ui/chat-panel';
 import { checkAndPromptForConfig, setupConfigModal, showConfigModal } from './ui/config-modal';
 import { setupDragAndDrop, setupPasteListener } from './ui/drag-drop';
 import { setupHomeToggles } from './ui/home-toggles';
 import { setupLiveNotes } from './ui/live-notes';
+import { setupLiveSession } from './ui/live-session';
 import { setupMicSelector } from './ui/mic-selector';
 import { setupNotifications } from './ui/notifications';
 import { setupPermissionStatus } from './ui/permission-status';
@@ -35,6 +37,8 @@ if (!window.electronAPI) {
     '<div style="padding: 20px; color: red;">Error: Application failed to load properly. Please restart.</div>';
   throw new Error('electronAPI not available');
 }
+
+setupRendererLogger();
 
 // File handler is a service singleton consumed by drag-drop, paste, and
 // dialog flows. Set up at module load (no DOM dependency) so callers can
@@ -82,6 +86,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     setupNotifications();
     setupRecorder();
     setupLiveNotes();
+    setupLiveSession();
     setupHomeToggles();
     setupMicSelector();
     setupPermissionStatus();

--- a/renderer/services/renderer-logger.ts
+++ b/renderer/services/renderer-logger.ts
@@ -1,0 +1,68 @@
+type RendererLogLevel = 'debug' | 'log' | 'info' | 'warn' | 'error';
+
+const LOG_LEVELS: RendererLogLevel[] = ['debug', 'log', 'info', 'warn', 'error'];
+const SENSITIVE_KEY_RE =
+  /(authorization|api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|client[-_]?secret|secret|webhook)/i;
+
+let installed = false;
+
+function redactString(value: string): string {
+  return value
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/g, 'Bearer [REDACTED]')
+    .replace(/sk-[A-Za-z0-9_-]{20,}/g, 'sk-[REDACTED]');
+}
+
+function serializeLogValue(value: unknown, depth = 0, seen = new WeakSet<object>()): unknown {
+  if (typeof value === 'string') return redactString(value);
+  if (typeof value === 'number' || typeof value === 'boolean' || value == null) return value;
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'function') return `[Function ${value.name || 'anonymous'}]`;
+  if (typeof value !== 'object') return String(value);
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: redactString(value.message),
+      stack: value.stack ? redactString(value.stack) : undefined,
+    };
+  }
+
+  if (seen.has(value)) return '[Circular]';
+  if (depth >= 4) return '[MaxDepth]';
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => serializeLogValue(item, depth + 1, seen));
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = SENSITIVE_KEY_RE.test(key) ? '[REDACTED]' : serializeLogValue(item, depth + 1, seen);
+  }
+  return out;
+}
+
+export function setupRendererLogger(): void {
+  if (installed) return;
+  installed = true;
+
+  const original = Object.fromEntries(
+    LOG_LEVELS.map((level) => [level, console[level].bind(console)]),
+  ) as Record<RendererLogLevel, (...args: unknown[]) => void>;
+
+  for (const level of LOG_LEVELS) {
+    console[level] = (...args: unknown[]) => {
+      original[level](...args);
+      window.electronAPI.logRenderer({
+        level,
+        timestamp: new Date().toISOString(),
+        url: window.location.href,
+        args: args.map((arg) => serializeLogValue(arg)),
+      });
+    };
+  }
+
+  window.addEventListener('unhandledrejection', (event) => {
+    console.error('Unhandled renderer promise rejection:', event.reason);
+  });
+}

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -346,6 +346,39 @@ h1 {
   box-shadow: none;
 }
 
+.live-session-start-button {
+  width: 100%;
+  margin-top: 10px;
+  padding: 10px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  color: #155e75;
+  background: #ecfeff;
+  border: 1px solid #a5f3fc;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s, transform 0.05s;
+}
+
+.live-session-start-button:hover {
+  background: #cffafe;
+  border-color: #67e8f9;
+}
+
+.live-session-start-button:active {
+  transform: translateY(1px);
+}
+
+.live-session-start-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.live-session-start-button[hidden] {
+  display: none;
+}
+
 .recording-time {
   text-align: center;
   font-size: 26px;
@@ -476,6 +509,208 @@ h1 {
   outline: none;
   border-color: rgba(52, 152, 219, 0.55);
   box-shadow: var(--focus-ring);
+}
+
+.live-session-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(15, 23, 42, 0.38);
+}
+
+.live-session-modal[hidden] {
+  display: none;
+}
+
+.live-session-card {
+  width: min(960px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: auto;
+  padding: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  border-radius: 10px;
+  background: white;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.24);
+}
+
+.live-session-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 10px;
+}
+
+.live-session-header h2 {
+  margin: 0 0 3px;
+  color: #0f172a;
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.live-session-status {
+  margin: 0;
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.live-session-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.live-session-close-button {
+  padding: 7px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: inherit;
+  color: #334155;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 7px;
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+.live-session-close-button:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+
+.live-translate-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex: 0 0 auto;
+  color: #334155;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.live-translate-toggle input {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+}
+
+.live-session-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 10px;
+}
+
+.live-session-column {
+  min-width: 0;
+}
+
+.live-session-column[hidden] {
+  display: none;
+}
+
+.live-session-column h3,
+.live-ask-header h3 {
+  margin: 0 0 7px;
+  color: #334155;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.live-session-list {
+  min-height: 128px;
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 8px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+.live-session-empty {
+  margin: 0;
+  padding: 28px 8px;
+  color: #94a3b8;
+  font-size: 12px;
+  text-align: center;
+}
+
+.live-session-item {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 8px;
+  padding: 7px 0;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.live-session-item:last-child {
+  border-bottom: 0;
+}
+
+.live-session-time {
+  color: #64748b;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.55;
+  white-space: nowrap;
+}
+
+.live-session-text {
+  margin: 0;
+  min-width: 0;
+  color: #0f172a;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.live-session-item-translation .live-session-text {
+  color: #1e293b;
+}
+
+.live-session-item-error .live-session-text {
+  color: #b91c1c;
+}
+
+.live-ask-panel {
+  margin-top: 12px;
+}
+
+.live-ask-panel .chat-messages {
+  max-height: 180px;
+  min-height: 92px;
+}
+
+@media (max-width: 760px) {
+  .live-session-modal {
+    align-items: stretch;
+    padding: 12px;
+  }
+
+  .live-session-card {
+    max-height: calc(100vh - 24px);
+  }
+
+  .live-session-header {
+    flex-direction: column;
+  }
+
+  .live-session-header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .live-session-columns {
+    grid-template-columns: 1fr;
+  }
 }
 
 .recordings-section {
@@ -933,6 +1168,39 @@ h1 {
   text-transform: uppercase;
   letter-spacing: 0.04em;
   vertical-align: middle;
+}
+
+.config-notice {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+  background-color: #eff6ff;
+  color: #1e40af;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.config-notice[hidden] {
+  display: none;
+}
+
+.config-notice.is-success {
+  border-color: #a7f3d0;
+  background-color: #ecfdf5;
+  color: #065f46;
+}
+
+.config-notice.is-warning {
+  border-color: #fde68a;
+  background-color: #fffbeb;
+  color: #92400e;
+}
+
+.config-notice.is-error {
+  border-color: #fecaca;
+  background-color: #fef2f2;
+  color: #991b1b;
 }
 
 .chip-input {

--- a/renderer/ui/config-modal.ts
+++ b/renderer/ui/config-modal.ts
@@ -20,6 +20,11 @@ let cancelConfigBtn: HTMLButtonElement | null = null;
 let aiProviderSelect: HTMLSelectElement | null = null;
 let geminiApiKeyInput: HTMLInputElement | null = null;
 let geminiThinkingLevelSelect: HTMLSelectElement | null = null;
+let liveSttProviderSelect: HTMLSelectElement | null = null;
+let openaiApiKeyInput: HTMLInputElement | null = null;
+let liveProviderNotice: HTMLElement | null = null;
+let liveSttLanguageInput: HTMLInputElement | null = null;
+let liveTranslationLanguageInput: HTMLInputElement | null = null;
 let loginCodexOAuthBtn: HTMLButtonElement | null = null;
 let clearCodexOAuthBtn: HTMLButtonElement | null = null;
 let codexOAuthStatus: HTMLElement | null = null;
@@ -40,6 +45,8 @@ let knownWordsContainer: HTMLElement | null = null;
 let knownWordsField: HTMLInputElement | null = null;
 let knownWordsValues: string[] = [];
 let aiPane: HTMLElement | null = null;
+let codexOAuthConfigured = false;
+let codexOAuthSource: 'config' | 'env' | 'codexCli' | null = null;
 
 // Each Codex sign-in click bumps this; the in-flight click checks its captured
 // token against the current one after `await`, discarding stale results from
@@ -156,6 +163,109 @@ function setGoogleSyncStatus(text: string, state: 'idle' | 'success' | 'error' =
   setStatusEl(googleDriveSyncStatusEl, text, state);
 }
 
+function codexOAuthStatusLabel(source: typeof codexOAuthSource): string {
+  if (source === 'codexCli') return 'Signed in via Codex CLI';
+  if (source === 'env') return 'Signed in via env';
+  return 'Signed in';
+}
+
+function applyCodexOAuthState(config: {
+  codexOAuthConfigured?: unknown;
+  codexOAuthSource?: unknown;
+}): void {
+  codexOAuthConfigured = !!config.codexOAuthConfigured;
+  codexOAuthSource =
+    config.codexOAuthSource === 'config' ||
+    config.codexOAuthSource === 'env' ||
+    config.codexOAuthSource === 'codexCli'
+      ? config.codexOAuthSource
+      : null;
+}
+
+function readLiveProvider(): 'auto' | 'openai' | 'gemini' | 'chunked' {
+  const value = liveSttProviderSelect?.value;
+  if (value === 'openai' || value === 'gemini' || value === 'chunked') return value;
+  return 'auto';
+}
+
+function setLiveProviderNotice(
+  text: string,
+  state: 'info' | 'success' | 'warning' | 'error' = 'info',
+): void {
+  if (!liveProviderNotice) return;
+  liveProviderNotice.textContent = text;
+  liveProviderNotice.hidden = text.length === 0;
+  liveProviderNotice.className = `config-notice is-${state}`;
+}
+
+function updateLiveProviderNotice(): void {
+  const provider = readLiveProvider();
+  const hasOpenAiKey = (openaiApiKeyInput?.value.trim() ?? '').length > 0;
+  const hasGeminiKey = (geminiApiKeyInput?.value.trim() ?? '').length > 0;
+
+  if (provider === 'chunked') {
+    setLiveProviderNotice(
+      'Live captions will use 12-second chunks through the saved AI provider. This is slower but avoids live API credentials.',
+      'info',
+    );
+    return;
+  }
+
+  if (provider === 'gemini') {
+    if (hasGeminiKey) {
+      setLiveProviderNotice(
+        'Gemini Live will handle live transcription and translation.',
+        'success',
+      );
+    } else {
+      setLiveProviderNotice(
+        'Gemini Live needs a Gemini API key. Add one or choose 12s fallback.',
+        'warning',
+      );
+    }
+    return;
+  }
+
+  if (hasOpenAiKey) {
+    setLiveProviderNotice(
+      'OpenAI Realtime live translation will use this OpenAI API key.',
+      'success',
+    );
+    return;
+  }
+
+  if (provider === 'openai') {
+    if (hasGeminiKey) {
+      setLiveProviderNotice(
+        'OpenAI Realtime live translation needs an OpenAI API key. Without one, Listener.AI will fall back to Gemini Live.',
+        'warning',
+      );
+    } else {
+      setLiveProviderNotice(
+        'OpenAI Realtime live translation needs an OpenAI API key. Codex sign-in is not enough for this live translation call.',
+        'warning',
+      );
+    }
+    return;
+  }
+
+  if (hasGeminiKey) {
+    setLiveProviderNotice(
+      codexOAuthConfigured
+        ? 'Codex sign-in is available for Codex features, but OpenAI live translation needs an OpenAI API key. Auto will use Gemini Live.'
+        : 'Auto will use Gemini Live unless you add an OpenAI API key for OpenAI Realtime.',
+      'info',
+    );
+  } else {
+    setLiveProviderNotice(
+      codexOAuthConfigured
+        ? 'Codex sign-in is available for Codex features, but live streaming needs an OpenAI API key or Gemini API key.'
+        : 'Auto needs an OpenAI API key or Gemini API key for streaming live translation; otherwise use 12s fallback.',
+      'warning',
+    );
+  }
+}
+
 // Translate a progress event into the pill label. Kept separate from the
 // onGoogleSyncStatus handler because the same shape arrives from two paths:
 // live `google-sync-progress` IPC events, and the snapshot returned by
@@ -206,7 +316,12 @@ export async function showConfigModal(): Promise<void> {
     geminiThinkingLevel?: 'low' | 'medium' | 'high';
     codexModel?: string;
     codexTranscriptionModel?: string;
+    liveSttProvider?: 'auto' | 'openai' | 'gemini' | 'chunked';
+    openaiApiKey?: string;
+    liveSttLanguage?: string;
+    liveTranslationLanguage?: string;
     codexOAuthConfigured?: boolean;
+    codexOAuthSource?: 'config' | 'env' | 'codexCli';
     notionApiKey?: string;
     notionDatabaseId?: string;
     slackWebhookUrl?: string;
@@ -228,6 +343,18 @@ export async function showConfigModal(): Promise<void> {
   if (geminiApiKeyInput && config.geminiApiKey) {
     geminiApiKeyInput.value = config.geminiApiKey;
   }
+  if (liveSttProviderSelect) {
+    liveSttProviderSelect.value = config.liveSttProvider || 'auto';
+  }
+  if (openaiApiKeyInput) {
+    openaiApiKeyInput.value = config.openaiApiKey || '';
+  }
+  if (liveSttLanguageInput) {
+    liveSttLanguageInput.value = config.liveSttLanguage || '';
+  }
+  if (liveTranslationLanguageInput) {
+    liveTranslationLanguageInput.value = config.liveTranslationLanguage || 'ko';
+  }
   applyModelValue('geminiModel', config.geminiModel);
   applyModelValue('geminiFlashModel', config.geminiFlashModel);
   applyModelValue('codexModel', config.codexModel);
@@ -236,9 +363,10 @@ export async function showConfigModal(): Promise<void> {
     // Defensive fallback; backend's getGeminiThinkingLevel normalizes first.
     geminiThinkingLevelSelect.value = config.geminiThinkingLevel || 'medium';
   }
+  applyCodexOAuthState(config);
   setCodexOAuthStatus(
-    config.codexOAuthConfigured ? 'Signed in' : 'Not signed in',
-    config.codexOAuthConfigured ? 'success' : 'idle',
+    codexOAuthConfigured ? codexOAuthStatusLabel(codexOAuthSource) : 'Not signed in',
+    codexOAuthConfigured ? 'success' : 'idle',
   );
   setGoogleOAuthStatus(
     config.googleOAuthConfigured ? 'Signed in' : 'Not signed in',
@@ -320,6 +448,7 @@ export async function showConfigModal(): Promise<void> {
   }
 
   applyAiProviderVisibility();
+  updateLiveProviderNotice();
 
   // Refresh "Usage this month" card on each open so the totals stay current
   // even if the user has been recording in the same session. Fire-and-forget;
@@ -478,6 +607,13 @@ export function setupConfigModal(): void {
   cancelConfigBtn = document.getElementById('cancelConfig') as HTMLButtonElement | null;
   aiProviderSelect = document.getElementById('aiProvider') as HTMLSelectElement | null;
   geminiApiKeyInput = document.getElementById('geminiApiKey') as HTMLInputElement | null;
+  liveSttProviderSelect = document.getElementById('liveSttProvider') as HTMLSelectElement | null;
+  openaiApiKeyInput = document.getElementById('openaiApiKey') as HTMLInputElement | null;
+  liveProviderNotice = document.getElementById('liveProviderNotice');
+  liveSttLanguageInput = document.getElementById('liveSttLanguage') as HTMLInputElement | null;
+  liveTranslationLanguageInput = document.getElementById(
+    'liveTranslationLanguage',
+  ) as HTMLInputElement | null;
   setupModelControls();
   geminiThinkingLevelSelect = document.getElementById(
     'geminiThinkingLevel',
@@ -558,6 +694,9 @@ export function setupConfigModal(): void {
   if (aiProviderSelect) {
     aiProviderSelect.addEventListener('change', applyAiProviderVisibility);
   }
+  liveSttProviderSelect?.addEventListener('change', updateLiveProviderNotice);
+  openaiApiKeyInput?.addEventListener('input', updateLiveProviderNotice);
+  geminiApiKeyInput?.addEventListener('input', updateLiveProviderNotice);
 
   const openSlackAppCreatorBtn = document.getElementById(
     'openSlackAppCreator',
@@ -612,9 +751,11 @@ export function setupConfigModal(): void {
       const result = await window.electronAPI.loginCodexOAuth();
       if (myToken !== codexLoginToken) return;
       if (result.success) {
+        applyCodexOAuthState(result.config);
         if (aiProviderSelect) aiProviderSelect.value = 'codex';
         applyAiProviderVisibility();
-        setCodexOAuthStatus('Signed in', 'success');
+        updateLiveProviderNotice();
+        setCodexOAuthStatus(codexOAuthStatusLabel(codexOAuthSource), 'success');
       } else if (result.cancelled) {
         return;
       } else {
@@ -629,7 +770,12 @@ export function setupConfigModal(): void {
       try {
         const result = await window.electronAPI.clearCodexOAuth();
         if (result.success) {
-          setCodexOAuthStatus('Not signed in');
+          applyCodexOAuthState(result.config);
+          updateLiveProviderNotice();
+          setCodexOAuthStatus(
+            codexOAuthConfigured ? codexOAuthStatusLabel(codexOAuthSource) : 'Not signed in',
+            codexOAuthConfigured ? 'success' : 'idle',
+          );
         } else {
           setCodexOAuthStatus(result.error, 'error');
         }
@@ -752,6 +898,16 @@ export function setupConfigModal(): void {
     saveConfigBtn.addEventListener('click', async () => {
       const aiProvider = aiProviderSelect?.value === 'codex' ? 'codex' : 'gemini';
       const geminiKey = geminiApiKeyInput?.value.trim() ?? '';
+      const liveSttProviderValue = liveSttProviderSelect?.value;
+      const liveSttProvider =
+        liveSttProviderValue === 'openai' ||
+        liveSttProviderValue === 'gemini' ||
+        liveSttProviderValue === 'chunked'
+          ? liveSttProviderValue
+          : 'auto';
+      const openaiApiKey = openaiApiKeyInput?.value.trim() ?? '';
+      const liveSttLanguage = liveSttLanguageInput?.value.trim() ?? '';
+      const liveTranslationLanguage = liveTranslationLanguageInput?.value.trim() || 'ko';
       const geminiModel = readModelValue('geminiModel');
       const geminiFlashModel = readModelValue('geminiFlashModel');
       const codexModel = readModelValue('codexModel');
@@ -820,6 +976,10 @@ export function setupConfigModal(): void {
         geminiThinkingLevel: geminiThinkingLevel,
         codexModel: codexModel,
         codexTranscriptionModel: codexTranscriptionModel,
+        liveSttProvider: liveSttProvider,
+        openaiApiKey: openaiApiKey,
+        liveSttLanguage: liveSttLanguage,
+        liveTranslationLanguage: liveTranslationLanguage,
         notionApiKey: notionKey,
         notionDatabaseId: notionDb,
         slackWebhookUrl: slackWebhookUrl,

--- a/renderer/ui/live-session.ts
+++ b/renderer/ui/live-session.ts
@@ -388,7 +388,7 @@ function handleRealtimeMessage(sessionId: string, raw: string): void {
     const text = (payload.transcript || realtimeItemText.get(itemId) || '').trim();
     realtimeItemText.delete(itemId);
     realtimeInputTranscript = '';
-    void sendRealtimeFinal(sessionId, text);
+    realtimeFinalChain = realtimeFinalChain.then(() => sendRealtimeFinal(sessionId, text));
     return;
   }
   if (payload.type === 'session.input_transcript.delta') {
@@ -493,6 +493,10 @@ async function startRealtimeWebRtc(
 async function stopRealtimeWebRtc(sessionId?: string): Promise<void> {
   const peer = realtimePeer;
   const events = realtimeDataChannel;
+  if (realtimeCommitTimer) {
+    clearInterval(realtimeCommitTimer);
+    realtimeCommitTimer = null;
+  }
   if (sessionId && realtimeEndpoint === 'translation' && !realtimeTranslationFinalSent) {
     // Translation sessions flush their final output in response to
     // `session.close`; wait for `session.closed` (or a 1.5s cap) before tearing
@@ -520,6 +524,28 @@ async function stopRealtimeWebRtc(sessionId?: string): Promise<void> {
     if (!realtimeTranslationFinalSent) {
       await sendRealtimeFinal(sessionId, realtimeInputTranscript, realtimeOutputTranscript);
     }
+  } else if (sessionId && realtimeEndpoint === 'realtime' && events?.readyState === 'open') {
+    // Transcription sessions disable turn detection, so flush the buffered tail
+    // with a final commit and wait for the completion event (which queues the
+    // final segment via handleRealtimeMessage) before tearing down.
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, 1_500);
+      const previous = events.onmessage;
+      events.onmessage = (event) => {
+        previous?.call(events, event);
+        try {
+          const payload = JSON.parse(String(event.data)) as { type?: string };
+          if (payload.type === 'conversation.item.input_audio_transcription.completed') {
+            clearTimeout(timer);
+            resolve();
+          }
+        } catch {
+          // ignore
+        }
+      };
+      events.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
+    });
+    await realtimeFinalChain.catch(() => {});
   }
   realtimeDataChannel = null;
   realtimePeer = null;

--- a/renderer/ui/live-session.ts
+++ b/renderer/ui/live-session.ts
@@ -48,6 +48,7 @@ let hasInterimTranslation = false;
 let interimEl: HTMLElement | null = null;
 let interimTranslationEl: HTMLElement | null = null;
 let realtimePeer: RTCPeerConnection | null = null;
+let realtimeDataChannel: RTCDataChannel | null = null;
 let realtimeEndpoint: 'realtime' | 'translation' | null = null;
 let realtimeInputTranscript = '';
 let realtimeOutputTranscript = '';
@@ -430,6 +431,7 @@ async function startRealtimeWebRtc(
   };
 
   const events = peer.createDataChannel('oai-events');
+  realtimeDataChannel = events;
   events.onmessage = (event) => handleRealtimeMessage(sessionId, String(event.data));
   events.onerror = () => reportRealtimeError('OpenAI Realtime event channel failed.');
 
@@ -473,16 +475,36 @@ async function startRealtimeWebRtc(
 
 async function stopRealtimeWebRtc(sessionId?: string): Promise<void> {
   const peer = realtimePeer;
+  const events = realtimeDataChannel;
   if (sessionId && realtimeEndpoint === 'translation' && !realtimeTranslationFinalSent) {
-    // OpenAI Realtime has no `session.close` client event, so there is no
-    // `session.closed` to wait for; flush whatever translation we have and
-    // close the peer directly instead of stalling on a 1.5s timeout.
+    // Translation sessions flush their final output in response to
+    // `session.close`; wait for `session.closed` (or a 1.5s cap) before tearing
+    // down so the last translated segment isn't lost.
+    if (events?.readyState === 'open') {
+      events.send(JSON.stringify({ type: 'session.close' }));
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, 1_500);
+        const previous = events.onmessage;
+        events.onmessage = (event) => {
+          previous?.call(events, event);
+          try {
+            const payload = JSON.parse(String(event.data)) as { type?: string };
+            if (payload.type === 'session.closed') {
+              clearTimeout(timer);
+              resolve();
+            }
+          } catch {
+            // ignore
+          }
+        };
+      });
+    }
     await realtimeFinalChain.catch(() => {});
     if (!realtimeTranslationFinalSent) {
-      realtimeTranslationFinalSent = true;
       await sendRealtimeFinal(sessionId, realtimeInputTranscript, realtimeOutputTranscript);
     }
   }
+  realtimeDataChannel = null;
   realtimePeer = null;
   if (peer) peer.close();
   resetRealtimeState();
@@ -770,8 +792,11 @@ export async function stopLiveSessionCapture(opts: { hidePanel?: boolean } = {})
     }
     stoppingCapture = true;
     processingChain = Promise.resolve();
-    activeSessionId = null;
+    // Keep activeSessionId set through stopLiveSession: closing a streaming
+    // provider in main flushes its final `segment` events, and
+    // handleLiveSessionEvent drops any event whose sessionId != activeSessionId.
     await finalizeStoppedSession(sessionId, Promise.resolve(), opts);
+    activeSessionId = null;
   } finally {
     finalizingCapture = false;
   }

--- a/renderer/ui/live-session.ts
+++ b/renderer/ui/live-session.ts
@@ -49,6 +49,7 @@ let interimEl: HTMLElement | null = null;
 let interimTranslationEl: HTMLElement | null = null;
 let realtimePeer: RTCPeerConnection | null = null;
 let realtimeDataChannel: RTCDataChannel | null = null;
+let realtimeCommitTimer: ReturnType<typeof setInterval> | null = null;
 let realtimeEndpoint: 'realtime' | 'translation' | null = null;
 let realtimeInputTranscript = '';
 let realtimeOutputTranscript = '';
@@ -299,6 +300,10 @@ function realtimeOffsetMs(): number {
 }
 
 function resetRealtimeState(): void {
+  if (realtimeCommitTimer) {
+    clearInterval(realtimeCommitTimer);
+    realtimeCommitTimer = null;
+  }
   realtimeInputTranscript = '';
   realtimeOutputTranscript = '';
   realtimeItemText = new Map<string, string>();
@@ -434,6 +439,18 @@ async function startRealtimeWebRtc(
   realtimeDataChannel = events;
   events.onmessage = (event) => handleRealtimeMessage(sessionId, String(event.data));
   events.onerror = () => reportRealtimeError('OpenAI Realtime event channel failed.');
+  if (client.endpoint === 'realtime') {
+    // gpt-realtime-whisper transcription sessions disable turn detection, so the
+    // server never auto-commits the input buffer. Commit on an interval to keep
+    // incremental transcription events flowing (mirrors the WebSocket fallback).
+    events.onopen = () => {
+      realtimeCommitTimer = setInterval(() => {
+        if (events.readyState === 'open') {
+          events.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
+        }
+      }, 2_000);
+    };
+  }
 
   const offer = await peer.createOffer();
   await peer.setLocalDescription(offer);

--- a/renderer/ui/live-session.ts
+++ b/renderer/ui/live-session.ts
@@ -30,6 +30,7 @@ let liveStartedAt = 0;
 let liveWindowStartedAt = 0;
 let liveWindowChunks: Blob[] = [];
 let stoppingCapture = false;
+let finalizingCapture = false;
 let processingChain: Promise<void> = Promise.resolve();
 let launcher: {
   title: string;
@@ -47,7 +48,6 @@ let hasInterimTranslation = false;
 let interimEl: HTMLElement | null = null;
 let interimTranslationEl: HTMLElement | null = null;
 let realtimePeer: RTCPeerConnection | null = null;
-let realtimeDataChannel: RTCDataChannel | null = null;
 let realtimeEndpoint: 'realtime' | 'translation' | null = null;
 let realtimeInputTranscript = '';
 let realtimeOutputTranscript = '';
@@ -430,7 +430,6 @@ async function startRealtimeWebRtc(
   };
 
   const events = peer.createDataChannel('oai-events');
-  realtimeDataChannel = events;
   events.onmessage = (event) => handleRealtimeMessage(sessionId, String(event.data));
   events.onerror = () => reportRealtimeError('OpenAI Realtime event channel failed.');
 
@@ -474,33 +473,16 @@ async function startRealtimeWebRtc(
 
 async function stopRealtimeWebRtc(sessionId?: string): Promise<void> {
   const peer = realtimePeer;
-  const events = realtimeDataChannel;
   if (sessionId && realtimeEndpoint === 'translation' && !realtimeTranslationFinalSent) {
-    if (events?.readyState === 'open') {
-      events.send(JSON.stringify({ type: 'session.close' }));
-      await new Promise<void>((resolve) => {
-        const timer = setTimeout(resolve, 1_500);
-        const previous = events.onmessage;
-        events.onmessage = (event) => {
-          previous?.call(events, event);
-          try {
-            const payload = JSON.parse(String(event.data)) as { type?: string };
-            if (payload.type === 'session.closed') {
-              clearTimeout(timer);
-              resolve();
-            }
-          } catch {
-            // ignore
-          }
-        };
-      });
-    }
+    // OpenAI Realtime has no `session.close` client event, so there is no
+    // `session.closed` to wait for; flush whatever translation we have and
+    // close the peer directly instead of stalling on a 1.5s timeout.
     await realtimeFinalChain.catch(() => {});
     if (!realtimeTranslationFinalSent) {
+      realtimeTranslationFinalSent = true;
       await sendRealtimeFinal(sessionId, realtimeInputTranscript, realtimeOutputTranscript);
     }
   }
-  realtimeDataChannel = null;
   realtimePeer = null;
   if (peer) peer.close();
   resetRealtimeState();
@@ -587,7 +569,7 @@ function startFallbackWindow(stream: MediaStream, preferredMimeType: string): vo
   }, FALLBACK_SNIPPET_MS);
 }
 
-function stopActiveFallbackRecorder(): Promise<void> {
+function stopActiveFallbackRecorder(sessionId: string): Promise<void> {
   if (liveRecorderTimer) {
     clearTimeout(liveRecorderTimer);
     liveRecorderTimer = null;
@@ -595,9 +577,22 @@ function stopActiveFallbackRecorder(): Promise<void> {
   const recorder = liveRecorder;
   if (!recorder || recorder.state === 'inactive') return Promise.resolve();
   return new Promise((resolve) => {
-    const previous = recorder.onstop;
-    recorder.onstop = (event) => {
-      previous?.call(recorder, event);
+    // Final flush: queue this last window (the normal onstop refuses once we
+    // begin tearing down) and do NOT restart another window.
+    recorder.onstop = () => {
+      const chunks = liveWindowChunks;
+      const offsetMs = Math.max(0, liveWindowStartedAt - liveStartedAt);
+      const durationMs = Math.max(0, Date.now() - liveWindowStartedAt);
+      liveWindowChunks = [];
+      liveRecorder = null;
+      if (sessionId && chunks.length > 0) {
+        queueFallbackBlob(
+          new Blob(chunks, { type: recorder.mimeType || '' }),
+          offsetMs,
+          durationMs,
+          sessionId,
+        );
+      }
       resolve();
     };
     recorder.stop();
@@ -609,7 +604,12 @@ async function finalizeStoppedSession(
   chain: Promise<void>,
   opts: { hidePanel?: boolean } = {},
 ): Promise<void> {
-  const result = await window.electronAPI.stopLiveSession(sessionId);
+  let result: Awaited<ReturnType<typeof window.electronAPI.stopLiveSession>>;
+  try {
+    result = await window.electronAPI.stopLiveSession(sessionId);
+  } catch (err) {
+    result = { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
   await chain.catch(() => {});
   captureMode = null;
   stoppingCapture = false;
@@ -749,26 +749,32 @@ export function handleLivePcmFrame(frame: LivePcmFrame): void {
 export async function stopLiveSessionCapture(opts: { hidePanel?: boolean } = {}): Promise<void> {
   startCancellationVersion++;
   if (launcher) launcher.startVersion = startCancellationVersion;
-  if (!activeSessionId) {
+  if (!activeSessionId || finalizingCapture) {
     if (opts.hidePanel) hidePanel();
     return;
   }
+  finalizingCapture = true;
   const sessionId = activeSessionId;
   const mode = captureMode;
-  const chain = processingChain;
-  stoppingCapture = true;
-  processingChain = Promise.resolve();
   setStatus('Finalizing live transcript...');
   updateAskEnabled();
   if (startButtonEl) startButtonEl.textContent = 'Live Transcript';
-  await stopRealtimeWebRtc(sessionId);
-  activeSessionId = null;
-  if (mode === 'chunked') {
-    await stopActiveFallbackRecorder();
-    await finalizeStoppedSession(sessionId, chain, opts);
-    return;
+  try {
+    await stopRealtimeWebRtc(sessionId);
+    if (mode === 'chunked') {
+      // Flush the in-progress window and let any queued/in-flight fallback work
+      // finish while the main session is still active, so the final captions
+      // aren't dropped.
+      await stopActiveFallbackRecorder(sessionId);
+      await processingChain.catch(() => {});
+    }
+    stoppingCapture = true;
+    processingChain = Promise.resolve();
+    activeSessionId = null;
+    await finalizeStoppedSession(sessionId, Promise.resolve(), opts);
+  } finally {
+    finalizingCapture = false;
   }
-  await finalizeStoppedSession(sessionId, Promise.resolve(), opts);
 }
 
 async function submitLiveQuestion(question: string): Promise<void> {

--- a/renderer/ui/live-session.ts
+++ b/renderer/ui/live-session.ts
@@ -1,0 +1,886 @@
+import type {
+  AgentChatMessage,
+  LiveSessionEvent,
+  LiveSessionStartResult,
+  LiveTranscriptSegment,
+} from '../electronAPI';
+import type { LivePcmFrame } from '../audio/graph';
+
+const FALLBACK_SNIPPET_MS = 12_000;
+const MIN_LIVE_BLOB_BYTES = 1024;
+
+let panelEl: HTMLElement | null = null;
+let startButtonEl: HTMLButtonElement | null = null;
+let closeButtonEl: HTMLButtonElement | null = null;
+let statusEl: HTMLElement | null = null;
+let translateToggleEl: HTMLInputElement | null = null;
+let translationColumnEl: HTMLElement | null = null;
+let transcriptListEl: HTMLElement | null = null;
+let translationListEl: HTMLElement | null = null;
+let chatMessagesEl: HTMLElement | null = null;
+let chatFormEl: HTMLFormElement | null = null;
+let chatInputEl: HTMLInputElement | null = null;
+let chatSendEl: HTMLButtonElement | null = null;
+
+let activeSessionId: string | null = null;
+let captureMode: 'streaming' | 'chunked' | null = null;
+let liveRecorder: MediaRecorder | null = null;
+let liveRecorderTimer: ReturnType<typeof setTimeout> | null = null;
+let liveStartedAt = 0;
+let liveWindowStartedAt = 0;
+let liveWindowChunks: Blob[] = [];
+let stoppingCapture = false;
+let processingChain: Promise<void> = Promise.resolve();
+let launcher: {
+  title: string;
+  fallbackStream: MediaStream;
+  preferredMimeType: string;
+  startVersion: number;
+} | null = null;
+let startCancellationVersion = 0;
+let liveHistory: AgentChatMessage[] = [];
+let askBusy = false;
+let askInputComposing = false;
+let hasTranscript = false;
+let hasInterimTranscript = false;
+let hasInterimTranslation = false;
+let interimEl: HTMLElement | null = null;
+let interimTranslationEl: HTMLElement | null = null;
+let realtimePeer: RTCPeerConnection | null = null;
+let realtimeDataChannel: RTCDataChannel | null = null;
+let realtimeEndpoint: 'realtime' | 'translation' | null = null;
+let realtimeInputTranscript = '';
+let realtimeOutputTranscript = '';
+let realtimeItemText = new Map<string, string>();
+let realtimeRendererActive = false;
+let realtimeTranslationFinalSent = false;
+let realtimeFinalChain: Promise<void> = Promise.resolve();
+
+type RealtimeClientConfig = NonNullable<LiveSessionStartResult['realtimeClient']>;
+type RealtimeCallErrorDetails = {
+  endpoint: RealtimeClientConfig['endpoint'];
+  url: string;
+  status: number;
+  statusText: string;
+  requestId?: string;
+  body: string;
+  sdpLength: number;
+  audioTrackState: MediaStreamTrackState;
+};
+
+type RealtimeCallError = Error & { realtimeDetails?: RealtimeCallErrorDetails };
+
+function setStatus(text: string): void {
+  if (statusEl) statusEl.textContent = text;
+}
+
+function showPanel(): void {
+  if (panelEl) panelEl.hidden = false;
+}
+
+function hidePanel(): void {
+  if (panelEl) panelEl.hidden = true;
+}
+
+function clearList(el: HTMLElement | null, emptyText: string): void {
+  if (!el) return;
+  el.innerHTML = '';
+  const empty = document.createElement('p');
+  empty.className = 'live-session-empty';
+  empty.textContent = emptyText;
+  el.appendChild(empty);
+}
+
+function resetLiveUi(): void {
+  showPanel();
+  clearList(transcriptListEl, 'Waiting for speech...');
+  clearList(translationListEl, 'Waiting for transcript...');
+  interimEl = null;
+  if (chatMessagesEl) {
+    chatMessagesEl.innerHTML = '';
+    const empty = document.createElement('p');
+    empty.className = 'chat-empty';
+    empty.textContent = 'Ask about what has been heard so far.';
+    chatMessagesEl.appendChild(empty);
+  }
+  liveHistory = [];
+  hasTranscript = false;
+  hasInterimTranscript = false;
+  hasInterimTranslation = false;
+  interimTranslationEl = null;
+  updateAskEnabled();
+}
+
+function updateTranslationVisibility(): void {
+  const enabled = translateToggleEl?.checked !== false;
+  if (translationColumnEl) translationColumnEl.hidden = !enabled;
+  if (activeSessionId) {
+    window.electronAPI
+      .setLiveSessionTranslate({ sessionId: activeSessionId, translate: enabled })
+      .catch(() => {});
+  }
+}
+
+function formatOffset(offsetMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(offsetMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function removeEmpty(el: HTMLElement | null): void {
+  const empty = el?.querySelector('.live-session-empty, .chat-empty');
+  empty?.remove();
+}
+
+function makeLiveTextItem(
+  offsetMs: number,
+  text: string,
+  className: string,
+  id?: string,
+): HTMLElement {
+  const item = document.createElement('article');
+  item.className = `live-session-item ${className}`;
+  if (id) item.dataset.liveSegmentId = id;
+  const time = document.createElement('span');
+  time.className = 'live-session-time';
+  time.textContent = formatOffset(offsetMs);
+  const body = document.createElement('p');
+  body.className = 'live-session-text';
+  body.textContent = text.trim();
+  item.appendChild(time);
+  item.appendChild(body);
+  return item;
+}
+
+function upsertLiveText(
+  el: HTMLElement | null,
+  id: string,
+  offsetMs: number,
+  text: string,
+  className: string,
+): void {
+  if (!el || !text.trim()) return;
+  removeEmpty(el);
+  let item = el.querySelector<HTMLElement>(`[data-live-segment-id="${CSS.escape(id)}"]`);
+  if (!item) {
+    item = makeLiveTextItem(offsetMs, text, className, id);
+    el.appendChild(item);
+  } else {
+    item.className = `live-session-item ${className}`;
+    const time = item.querySelector<HTMLElement>('.live-session-time');
+    const body = item.querySelector<HTMLElement>('.live-session-text');
+    if (time) time.textContent = formatOffset(offsetMs);
+    if (body) body.textContent = text.trim();
+  }
+  el.scrollTop = el.scrollHeight;
+}
+
+function renderInterim(text: string, offsetMs = Math.max(0, Date.now() - liveStartedAt)): void {
+  if (!transcriptListEl) return;
+  if (!text.trim()) {
+    interimEl?.remove();
+    interimEl = null;
+    hasInterimTranscript = false;
+    updateAskEnabled();
+    return;
+  }
+  removeEmpty(transcriptListEl);
+  if (!interimEl) {
+    interimEl = makeLiveTextItem(offsetMs, text, 'live-session-item-interim');
+    transcriptListEl.appendChild(interimEl);
+  } else {
+    const time = interimEl.querySelector<HTMLElement>('.live-session-time');
+    const body = interimEl.querySelector<HTMLElement>('.live-session-text');
+    if (time) time.textContent = formatOffset(offsetMs);
+    if (body) body.textContent = text.trim();
+  }
+  hasInterimTranscript = true;
+  transcriptListEl.scrollTop = transcriptListEl.scrollHeight;
+  updateAskEnabled();
+}
+
+function renderTranslationInterim(
+  text: string,
+  offsetMs = Math.max(0, Date.now() - liveStartedAt),
+): void {
+  if (!translationListEl || translateToggleEl?.checked === false) return;
+  if (!text.trim()) {
+    interimTranslationEl?.remove();
+    interimTranslationEl = null;
+    hasInterimTranslation = false;
+    updateAskEnabled();
+    return;
+  }
+  removeEmpty(translationListEl);
+  if (!interimTranslationEl) {
+    interimTranslationEl = makeLiveTextItem(offsetMs, text, 'live-session-item-interim');
+    translationListEl.appendChild(interimTranslationEl);
+  } else {
+    const time = interimTranslationEl.querySelector<HTMLElement>('.live-session-time');
+    const body = interimTranslationEl.querySelector<HTMLElement>('.live-session-text');
+    if (time) time.textContent = formatOffset(offsetMs);
+    if (body) body.textContent = text.trim();
+  }
+  hasInterimTranslation = true;
+  translationListEl.scrollTop = translationListEl.scrollHeight;
+  updateAskEnabled();
+}
+
+function renderSegment(segment: LiveTranscriptSegment): void {
+  interimEl?.remove();
+  interimEl = null;
+  hasInterimTranscript = false;
+  interimTranslationEl?.remove();
+  interimTranslationEl = null;
+  hasInterimTranslation = false;
+  upsertLiveText(
+    transcriptListEl,
+    segment.id,
+    segment.offsetMs,
+    segment.transcript,
+    'live-session-item-source',
+  );
+  if (segment.translation) {
+    upsertLiveText(
+      translationListEl,
+      segment.id,
+      segment.offsetMs,
+      segment.translation,
+      'live-session-item-translation',
+    );
+  } else if (segment.translationError && translateToggleEl?.checked !== false) {
+    upsertLiveText(
+      translationListEl,
+      segment.id,
+      segment.offsetMs,
+      `Translation failed: ${segment.translationError}`,
+      'live-session-item-error',
+    );
+  }
+  hasTranscript = true;
+  updateAskEnabled();
+}
+
+function updateAskEnabled(): void {
+  const enabled =
+    !!activeSessionId &&
+    (hasTranscript || hasInterimTranscript || hasInterimTranslation) &&
+    !askBusy;
+  if (chatInputEl) chatInputEl.disabled = !enabled;
+  if (chatSendEl) chatSendEl.disabled = !enabled;
+}
+
+function appendChatMessage(role: 'user' | 'model' | 'error', text: string): HTMLElement | null {
+  if (!chatMessagesEl) return null;
+  removeEmpty(chatMessagesEl);
+  const el = document.createElement('div');
+  el.className = `chat-message chat-${role}`;
+  el.textContent = text;
+  chatMessagesEl.appendChild(el);
+  chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
+  return el;
+}
+
+function appendPendingChat(): HTMLElement | null {
+  if (!chatMessagesEl) return null;
+  removeEmpty(chatMessagesEl);
+  const el = document.createElement('div');
+  el.className = 'chat-message chat-model chat-pending';
+  el.textContent = 'Thinking...';
+  chatMessagesEl.appendChild(el);
+  chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
+  return el;
+}
+
+function realtimeOffsetMs(): number {
+  return Math.max(0, Date.now() - liveStartedAt);
+}
+
+function resetRealtimeState(): void {
+  realtimeInputTranscript = '';
+  realtimeOutputTranscript = '';
+  realtimeItemText = new Map<string, string>();
+  realtimeEndpoint = null;
+  realtimeRendererActive = false;
+  realtimeTranslationFinalSent = false;
+  realtimeFinalChain = Promise.resolve();
+}
+
+function reportRealtimeError(error: unknown, details?: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error('[live-realtime] error:', message, details ?? error);
+  setStatus(message);
+  appendChatMessage('error', message);
+}
+
+function getRealtimeErrorDetails(error: unknown): RealtimeCallErrorDetails | undefined {
+  if (error && typeof error === 'object' && 'realtimeDetails' in error) {
+    return (error as RealtimeCallError).realtimeDetails;
+  }
+  return undefined;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sendRealtimeInterim(sessionId: string, text: string, translation = false): void {
+  if (!text.trim()) return;
+  window.electronAPI.updateLiveSessionInterim({
+    sessionId,
+    text,
+    translation,
+    offsetMs: realtimeOffsetMs(),
+  });
+}
+
+async function sendRealtimeFinal(
+  sessionId: string,
+  text: string,
+  translation?: string,
+): Promise<void> {
+  const transcript = text.trim();
+  const translated = translation?.trim() || '';
+  if (!transcript && !translated) return;
+  await window.electronAPI.completeLiveSessionSegment({
+    sessionId,
+    text: transcript || translated,
+    translation: translated || undefined,
+    offsetMs: realtimeOffsetMs(),
+    durationMs: 0,
+  });
+}
+
+function handleRealtimeMessage(sessionId: string, raw: string): void {
+  let payload: {
+    type?: string;
+    item_id?: string;
+    delta?: string;
+    transcript?: string;
+    error?: { message?: string; type?: string; code?: string; param?: string };
+  };
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  if (payload.type === 'error') {
+    reportRealtimeError(payload.error?.message || 'OpenAI Realtime error.', payload);
+    return;
+  }
+  if (payload.type === 'conversation.item.input_audio_transcription.delta') {
+    const itemId = payload.item_id || 'current';
+    const text = `${realtimeItemText.get(itemId) ?? ''}${payload.delta ?? ''}`.trim();
+    realtimeItemText.set(itemId, text);
+    realtimeInputTranscript = text;
+    sendRealtimeInterim(sessionId, text);
+    return;
+  }
+  if (payload.type === 'conversation.item.input_audio_transcription.completed') {
+    const itemId = payload.item_id || 'current';
+    const text = (payload.transcript || realtimeItemText.get(itemId) || '').trim();
+    realtimeItemText.delete(itemId);
+    realtimeInputTranscript = '';
+    void sendRealtimeFinal(sessionId, text);
+    return;
+  }
+  if (payload.type === 'session.input_transcript.delta') {
+    realtimeInputTranscript = `${realtimeInputTranscript}${payload.delta ?? ''}`.trim();
+    sendRealtimeInterim(sessionId, realtimeInputTranscript);
+    return;
+  }
+  if (payload.type === 'session.output_transcript.delta') {
+    realtimeOutputTranscript = `${realtimeOutputTranscript}${payload.delta ?? ''}`.trim();
+    sendRealtimeInterim(sessionId, realtimeOutputTranscript, true);
+    return;
+  }
+  if (payload.type === 'session.closed' && realtimeEndpoint === 'translation') {
+    realtimeTranslationFinalSent = true;
+    realtimeFinalChain = sendRealtimeFinal(
+      sessionId,
+      realtimeInputTranscript,
+      realtimeOutputTranscript,
+    );
+  }
+}
+
+async function startRealtimeWebRtc(
+  sessionId: string,
+  client: RealtimeClientConfig,
+  stream: MediaStream,
+): Promise<void> {
+  await stopRealtimeWebRtc();
+  resetRealtimeState();
+  const track = stream.getAudioTracks()[0];
+  if (!track) throw new Error('Live Realtime needs an audio track.');
+
+  const peer = new RTCPeerConnection();
+  realtimePeer = peer;
+  realtimeEndpoint = client.endpoint;
+  realtimeRendererActive = true;
+  peer.addTrack(track, stream);
+  peer.ontrack = () => {
+    // Translation sessions may return audio; Listener.AI only displays text.
+  };
+  peer.onconnectionstatechange = () => {
+    if (peer.connectionState === 'failed') {
+      reportRealtimeError('OpenAI Realtime connection failed.');
+    }
+  };
+
+  const events = peer.createDataChannel('oai-events');
+  realtimeDataChannel = events;
+  events.onmessage = (event) => handleRealtimeMessage(sessionId, String(event.data));
+  events.onerror = () => reportRealtimeError('OpenAI Realtime event channel failed.');
+
+  const offer = await peer.createOffer();
+  await peer.setLocalDescription(offer);
+  const callsUrl =
+    client.endpoint === 'translation'
+      ? 'https://api.openai.com/v1/realtime/translations/calls'
+      : 'https://api.openai.com/v1/realtime/calls';
+  const response = await fetch(callsUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${client.clientSecret}`,
+      'Content-Type': 'application/sdp',
+    },
+    body: offer.sdp || '',
+  });
+  const answerSdp = await response.text();
+  if (!response.ok) {
+    const details: RealtimeCallErrorDetails = {
+      endpoint: client.endpoint,
+      url: callsUrl,
+      status: response.status,
+      statusText: response.statusText,
+      requestId: response.headers.get('x-request-id') ?? undefined,
+      body: answerSdp.slice(0, 1_000),
+      sdpLength: offer.sdp?.length ?? 0,
+      audioTrackState: track.readyState,
+    };
+    const message =
+      `OpenAI Realtime ${client.endpoint} call failed ` +
+      `(${response.status} ${response.statusText || 'HTTP error'}): ` +
+      (answerSdp.trim() || '<empty response>');
+    const error = new Error(message) as RealtimeCallError;
+    error.realtimeDetails = details;
+    throw error;
+  }
+  await peer.setRemoteDescription({ type: 'answer', sdp: answerSdp });
+  setStatus('Listening with OpenAI Realtime...');
+}
+
+async function stopRealtimeWebRtc(sessionId?: string): Promise<void> {
+  const peer = realtimePeer;
+  const events = realtimeDataChannel;
+  if (sessionId && realtimeEndpoint === 'translation' && !realtimeTranslationFinalSent) {
+    if (events?.readyState === 'open') {
+      events.send(JSON.stringify({ type: 'session.close' }));
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, 1_500);
+        const previous = events.onmessage;
+        events.onmessage = (event) => {
+          previous?.call(events, event);
+          try {
+            const payload = JSON.parse(String(event.data)) as { type?: string };
+            if (payload.type === 'session.closed') {
+              clearTimeout(timer);
+              resolve();
+            }
+          } catch {
+            // ignore
+          }
+        };
+      });
+    }
+    await realtimeFinalChain.catch(() => {});
+    if (!realtimeTranslationFinalSent) {
+      await sendRealtimeFinal(sessionId, realtimeInputTranscript, realtimeOutputTranscript);
+    }
+  }
+  realtimeDataChannel = null;
+  realtimePeer = null;
+  if (peer) peer.close();
+  resetRealtimeState();
+}
+
+function queueFallbackBlob(
+  blob: Blob,
+  offsetMs: number,
+  durationMs: number,
+  sessionId: string,
+): void {
+  if (blob.size < MIN_LIVE_BLOB_BYTES) return;
+  const translate = translateToggleEl?.checked !== false;
+  processingChain = processingChain
+    .catch(() => {})
+    .then(async () => {
+      if (stoppingCapture || activeSessionId !== sessionId) return;
+      setStatus('Processing fallback audio...');
+      const audioData = await blob.arrayBuffer();
+      if (stoppingCapture || activeSessionId !== sessionId) return;
+      const result = await window.electronAPI.processLiveAudioChunk({
+        sessionId,
+        audioData,
+        mimeType: blob.type || 'audio/webm',
+        offsetMs,
+        durationMs,
+        translate,
+      });
+      if (stoppingCapture || activeSessionId !== sessionId) return;
+      if (activeSessionId !== sessionId) return;
+      if (result.success) {
+        if (result.segment) renderSegment(result.segment);
+        setStatus(stoppingCapture ? 'Finalizing live transcript...' : 'Listening with fallback...');
+        return;
+      }
+      setStatus(result.error || 'Live transcript failed.');
+    })
+    .catch((err) => {
+      if (stoppingCapture || activeSessionId !== sessionId) return;
+      setStatus(err instanceof Error ? err.message : String(err));
+    });
+}
+
+function startFallbackWindow(stream: MediaStream, preferredMimeType: string): void {
+  if (!activeSessionId || stoppingCapture || captureMode !== 'chunked') return;
+  liveWindowChunks = [];
+  liveWindowStartedAt = Date.now();
+
+  let recorder: MediaRecorder;
+  try {
+    recorder = preferredMimeType
+      ? new MediaRecorder(stream, { mimeType: preferredMimeType })
+      : new MediaRecorder(stream);
+  } catch {
+    recorder = new MediaRecorder(stream);
+  }
+
+  liveRecorder = recorder;
+  recorder.ondataavailable = (event) => {
+    if (event.data && event.data.size > 0) liveWindowChunks.push(event.data);
+  };
+  recorder.onstop = () => {
+    const sessionId = activeSessionId;
+    const chunks = liveWindowChunks;
+    const offsetMs = Math.max(0, liveWindowStartedAt - liveStartedAt);
+    const durationMs = Math.max(0, Date.now() - liveWindowStartedAt);
+    liveWindowChunks = [];
+    liveRecorder = null;
+    if (!stoppingCapture && sessionId && chunks.length > 0) {
+      queueFallbackBlob(
+        new Blob(chunks, { type: recorder.mimeType || preferredMimeType }),
+        offsetMs,
+        durationMs,
+        sessionId,
+      );
+    }
+    if (!stoppingCapture && activeSessionId && captureMode === 'chunked') {
+      startFallbackWindow(stream, preferredMimeType);
+    }
+  };
+  recorder.start();
+  liveRecorderTimer = setTimeout(() => {
+    if (recorder.state === 'recording') recorder.stop();
+  }, FALLBACK_SNIPPET_MS);
+}
+
+function stopActiveFallbackRecorder(): Promise<void> {
+  if (liveRecorderTimer) {
+    clearTimeout(liveRecorderTimer);
+    liveRecorderTimer = null;
+  }
+  const recorder = liveRecorder;
+  if (!recorder || recorder.state === 'inactive') return Promise.resolve();
+  return new Promise((resolve) => {
+    const previous = recorder.onstop;
+    recorder.onstop = (event) => {
+      previous?.call(recorder, event);
+      resolve();
+    };
+    recorder.stop();
+  });
+}
+
+async function finalizeStoppedSession(
+  sessionId: string,
+  chain: Promise<void>,
+  opts: { hidePanel?: boolean } = {},
+): Promise<void> {
+  const result = await window.electronAPI.stopLiveSession(sessionId);
+  await chain.catch(() => {});
+  captureMode = null;
+  stoppingCapture = false;
+  updateAskEnabled();
+  if (result.success) {
+    setStatus(opts.hidePanel ? 'Live session stopped.' : 'Live transcript ready.');
+  } else {
+    setStatus(result.error || 'Live session stopped.');
+  }
+  if (opts.hidePanel) hidePanel();
+}
+
+export async function startLiveSession(
+  title: string,
+  fallbackStream: MediaStream,
+  preferredMimeType: string,
+  expectedStartVersion = startCancellationVersion,
+): Promise<void> {
+  let startVersion = expectedStartVersion;
+  if (activeSessionId) {
+    const oldSessionId = activeSessionId;
+    await stopLiveSessionCapture();
+    if (activeSessionId === oldSessionId) activeSessionId = null;
+    startVersion = startCancellationVersion;
+  }
+  resetLiveUi();
+  stoppingCapture = false;
+  processingChain = Promise.resolve();
+  liveStartedAt = Date.now();
+  const result = await window.electronAPI.startLiveSession({
+    title,
+    translate: translateToggleEl?.checked !== false,
+  });
+  if (!result.success) {
+    activeSessionId = null;
+    captureMode = null;
+    setStatus(result.error || 'Live session unavailable.');
+    updateAskEnabled();
+    return;
+  }
+  if (startVersion !== startCancellationVersion || !launcher) {
+    await window.electronAPI.stopLiveSession(result.session.sessionId).catch(() => {});
+    activeSessionId = null;
+    captureMode = null;
+    setStatus('Live session stopped.');
+    updateAskEnabled();
+    return;
+  }
+  activeSessionId = result.session.sessionId;
+  captureMode = result.session.mode;
+  setStatus(
+    result.session.mode === 'streaming'
+      ? `Listening with ${result.session.provider}...`
+      : 'Listening with fallback...',
+  );
+  if (result.session.realtimeClient) {
+    try {
+      await startRealtimeWebRtc(activeSessionId, result.session.realtimeClient, fallbackStream);
+    } catch (error) {
+      reportRealtimeError(error, getRealtimeErrorDetails(error));
+      await stopRealtimeWebRtc().catch(() => {});
+      const fallback = await window.electronAPI.handleLiveRealtimeFailure({
+        sessionId: activeSessionId,
+        error: getErrorMessage(error),
+      });
+      if (fallback.success) {
+        captureMode = fallback.session.mode;
+        setStatus(
+          fallback.session.mode === 'streaming'
+            ? `Listening with ${fallback.session.provider}...`
+            : 'Listening with fallback...',
+        );
+        if (fallback.session.mode === 'chunked') {
+          startFallbackWindow(fallbackStream, preferredMimeType);
+        }
+        updateAskEnabled();
+        return;
+      }
+      reportRealtimeError(fallback.error);
+      await window.electronAPI.stopLiveSession(activeSessionId).catch(() => {});
+      activeSessionId = null;
+      captureMode = null;
+      updateAskEnabled();
+    }
+    return;
+  }
+  if (result.session.mode === 'chunked') {
+    if (typeof MediaRecorder === 'undefined') {
+      setStatus('Live fallback is unavailable in this browser.');
+      return;
+    }
+    startFallbackWindow(fallbackStream, preferredMimeType);
+  }
+  updateAskEnabled();
+}
+
+export function configureLiveSessionLauncher(
+  title: string,
+  fallbackStream: MediaStream,
+  preferredMimeType: string,
+): void {
+  startCancellationVersion++;
+  launcher = { title, fallbackStream, preferredMimeType, startVersion: startCancellationVersion };
+  if (startButtonEl) {
+    startButtonEl.hidden = false;
+    startButtonEl.disabled = false;
+    startButtonEl.textContent = activeSessionId ? 'Open Live Transcript' : 'Live Transcript';
+  }
+}
+
+export function clearLiveSessionLauncher(): void {
+  startCancellationVersion++;
+  launcher = null;
+  if (startButtonEl) {
+    startButtonEl.hidden = true;
+    startButtonEl.disabled = true;
+    startButtonEl.textContent = 'Live Transcript';
+  }
+}
+
+export function handleLivePcmFrame(frame: LivePcmFrame): void {
+  if (!activeSessionId || captureMode !== 'streaming' || stoppingCapture || realtimeRendererActive)
+    return;
+  const durationMs = Math.round((frame.frames / frame.sampleRate) * 1000);
+  const offsetMs = Math.max(0, Date.now() - liveStartedAt - durationMs);
+  window.electronAPI.sendLivePcmChunk({
+    sessionId: activeSessionId,
+    audioData: frame.audioData,
+    sampleRate: frame.sampleRate,
+    channelCount: frame.channelCount,
+    offsetMs,
+    durationMs,
+    sequence: frame.sequence,
+  });
+}
+
+export async function stopLiveSessionCapture(opts: { hidePanel?: boolean } = {}): Promise<void> {
+  startCancellationVersion++;
+  if (launcher) launcher.startVersion = startCancellationVersion;
+  if (!activeSessionId) {
+    if (opts.hidePanel) hidePanel();
+    return;
+  }
+  const sessionId = activeSessionId;
+  const mode = captureMode;
+  const chain = processingChain;
+  stoppingCapture = true;
+  processingChain = Promise.resolve();
+  setStatus('Finalizing live transcript...');
+  updateAskEnabled();
+  if (startButtonEl) startButtonEl.textContent = 'Live Transcript';
+  await stopRealtimeWebRtc(sessionId);
+  activeSessionId = null;
+  if (mode === 'chunked') {
+    await stopActiveFallbackRecorder();
+    await finalizeStoppedSession(sessionId, chain, opts);
+    return;
+  }
+  await finalizeStoppedSession(sessionId, Promise.resolve(), opts);
+}
+
+async function submitLiveQuestion(question: string): Promise<void> {
+  if (!activeSessionId || !question.trim() || askBusy) return;
+  const sessionId = activeSessionId;
+  askBusy = true;
+  updateAskEnabled();
+  appendChatMessage('user', question);
+  if (chatInputEl) chatInputEl.value = '';
+  const pending = appendPendingChat();
+  try {
+    const result = await window.electronAPI.askLiveSession({
+      sessionId,
+      question,
+      history: liveHistory,
+    });
+    if (activeSessionId !== sessionId) return;
+    pending?.remove();
+    if (result.success) {
+      appendChatMessage('model', result.result.answer || '(no answer)');
+      liveHistory = result.result.history || liveHistory;
+    } else {
+      appendChatMessage('error', result.error || 'Live question failed.');
+    }
+  } catch (err) {
+    if (activeSessionId !== sessionId) return;
+    pending?.remove();
+    appendChatMessage('error', err instanceof Error ? err.message : String(err));
+  } finally {
+    askBusy = false;
+    updateAskEnabled();
+    chatInputEl?.focus();
+  }
+}
+
+function handleLiveSessionEvent(event: LiveSessionEvent): void {
+  if (event.sessionId !== activeSessionId) return;
+  if (event.type === 'status') {
+    setStatus(event.status);
+  } else if (event.type === 'interim') {
+    renderInterim(event.text, event.offsetMs);
+  } else if (event.type === 'translationInterim') {
+    renderTranslationInterim(event.text, event.offsetMs);
+  } else if (event.type === 'segment') {
+    renderSegment(event.segment);
+  } else {
+    setStatus(event.error);
+    appendChatMessage('error', event.error);
+  }
+}
+
+export function setupLiveSession(): void {
+  panelEl = document.getElementById('liveSessionPanel');
+  startButtonEl = document.getElementById('liveSessionStartButton') as HTMLButtonElement | null;
+  closeButtonEl = document.getElementById('liveSessionCloseButton') as HTMLButtonElement | null;
+  statusEl = document.getElementById('liveSessionStatus');
+  translateToggleEl = document.getElementById('liveTranslateToggle') as HTMLInputElement | null;
+  translationColumnEl = document.getElementById('liveTranslationColumn');
+  transcriptListEl = document.getElementById('liveTranscriptList');
+  translationListEl = document.getElementById('liveTranslationList');
+  chatMessagesEl = document.getElementById('liveChatMessages');
+  chatFormEl = document.getElementById('liveChatForm') as HTMLFormElement | null;
+  chatInputEl = document.getElementById('liveChatInput') as HTMLInputElement | null;
+  chatSendEl = document.getElementById('liveChatSend') as HTMLButtonElement | null;
+
+  translateToggleEl?.addEventListener('change', updateTranslationVisibility);
+  updateTranslationVisibility();
+
+  startButtonEl?.addEventListener('click', () => {
+    const button = startButtonEl;
+    if (!button) return;
+    if (activeSessionId) {
+      showPanel();
+      return;
+    }
+    if (!launcher) {
+      showPanel();
+      setStatus('Start recording before opening live transcript.');
+      return;
+    }
+    const currentLauncher = launcher;
+    button.disabled = true;
+    void startLiveSession(
+      currentLauncher.title,
+      currentLauncher.fallbackStream,
+      currentLauncher.preferredMimeType,
+      currentLauncher.startVersion,
+    ).finally(() => {
+      button.disabled = false;
+      button.textContent = activeSessionId ? 'Open Live Transcript' : 'Live Transcript';
+    });
+  });
+  closeButtonEl?.addEventListener('click', () => {
+    void stopLiveSessionCapture({ hidePanel: true });
+  });
+
+  chatInputEl?.addEventListener('compositionstart', () => {
+    askInputComposing = true;
+  });
+  chatInputEl?.addEventListener('compositionend', () => {
+    askInputComposing = false;
+  });
+  chatInputEl?.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' && event.isComposing) {
+      event.preventDefault();
+    }
+  });
+  chatFormEl?.addEventListener('submit', (event) => {
+    event.preventDefault();
+    if (askInputComposing) return;
+    void submitLiveQuestion(chatInputEl?.value.trim() || '');
+  });
+  window.electronAPI.onLiveSessionEvent(handleLiveSessionEvent);
+  updateAskEnabled();
+}

--- a/renderer/ui/live-session.ts
+++ b/renderer/ui/live-session.ts
@@ -55,6 +55,7 @@ let realtimeInputTranscript = '';
 let realtimeOutputTranscript = '';
 let realtimeItemText = new Map<string, string>();
 let realtimeRendererActive = false;
+let realtimeFailureHandled = false;
 let realtimeTranslationFinalSent = false;
 let realtimeFinalChain: Promise<void> = Promise.resolve();
 
@@ -415,9 +416,11 @@ async function startRealtimeWebRtc(
   sessionId: string,
   client: RealtimeClientConfig,
   stream: MediaStream,
+  preferredMimeType: string,
 ): Promise<void> {
   await stopRealtimeWebRtc();
   resetRealtimeState();
+  realtimeFailureHandled = false;
   const track = stream.getAudioTracks()[0];
   if (!track) throw new Error('Live Realtime needs an audio track.');
 
@@ -431,7 +434,14 @@ async function startRealtimeWebRtc(
   };
   peer.onconnectionstatechange = () => {
     if (peer.connectionState === 'failed') {
-      reportRealtimeError('OpenAI Realtime connection failed.');
+      // Failure after the SDP handshake succeeded: fall back instead of freezing
+      // captions (realtimeRendererActive otherwise blocks PCM from reaching main).
+      void fallbackFromRealtimeFailure(
+        sessionId,
+        new Error('OpenAI Realtime connection failed.'),
+        stream,
+        preferredMimeType,
+      );
     }
   };
 
@@ -551,6 +561,45 @@ async function stopRealtimeWebRtc(sessionId?: string): Promise<void> {
   realtimePeer = null;
   if (peer) peer.close();
   resetRealtimeState();
+}
+
+async function fallbackFromRealtimeFailure(
+  sessionId: string,
+  error: unknown,
+  fallbackStream: MediaStream,
+  preferredMimeType: string,
+): Promise<void> {
+  if (activeSessionId !== sessionId || realtimeFailureHandled) return;
+  realtimeFailureHandled = true;
+  realtimeRendererActive = false;
+  reportRealtimeError(error, getRealtimeErrorDetails(error));
+  await stopRealtimeWebRtc(sessionId).catch(() => {});
+  if (activeSessionId !== sessionId) return;
+  const fallback = await window.electronAPI.handleLiveRealtimeFailure({
+    sessionId,
+    error: getErrorMessage(error),
+  });
+  if (activeSessionId !== sessionId) return;
+  if (fallback.success) {
+    captureMode = fallback.session.mode;
+    setStatus(
+      fallback.session.mode === 'streaming'
+        ? `Listening with ${fallback.session.provider}...`
+        : 'Listening with fallback...',
+    );
+    if (fallback.session.mode === 'chunked') {
+      startFallbackWindow(fallbackStream, preferredMimeType);
+    }
+    updateAskEnabled();
+    return;
+  }
+  reportRealtimeError(fallback.error);
+  await window.electronAPI.stopLiveSession(sessionId).catch(() => {});
+  if (activeSessionId === sessionId) {
+    activeSessionId = null;
+    captureMode = null;
+  }
+  updateAskEnabled();
 }
 
 function queueFallbackBlob(
@@ -731,33 +780,16 @@ export async function startLiveSession(
       : 'Listening with fallback...',
   );
   if (result.session.realtimeClient) {
+    const sessionId = result.session.sessionId;
     try {
-      await startRealtimeWebRtc(activeSessionId, result.session.realtimeClient, fallbackStream);
+      await startRealtimeWebRtc(
+        sessionId,
+        result.session.realtimeClient,
+        fallbackStream,
+        preferredMimeType,
+      );
     } catch (error) {
-      reportRealtimeError(error, getRealtimeErrorDetails(error));
-      await stopRealtimeWebRtc().catch(() => {});
-      const fallback = await window.electronAPI.handleLiveRealtimeFailure({
-        sessionId: activeSessionId,
-        error: getErrorMessage(error),
-      });
-      if (fallback.success) {
-        captureMode = fallback.session.mode;
-        setStatus(
-          fallback.session.mode === 'streaming'
-            ? `Listening with ${fallback.session.provider}...`
-            : 'Listening with fallback...',
-        );
-        if (fallback.session.mode === 'chunked') {
-          startFallbackWindow(fallbackStream, preferredMimeType);
-        }
-        updateAskEnabled();
-        return;
-      }
-      reportRealtimeError(fallback.error);
-      await window.electronAPI.stopLiveSession(activeSessionId).catch(() => {});
-      activeSessionId = null;
-      captureMode = null;
-      updateAskEnabled();
+      await fallbackFromRealtimeFailure(sessionId, error, fallbackStream, preferredMimeType);
     }
     return;
   }

--- a/src/agentService.piai.test.ts
+++ b/src/agentService.piai.test.ts
@@ -217,4 +217,24 @@ describe('AgentService (pi-ai integration via faux provider)', () => {
     // from the prior model turn is replayed verbatim before the new user input.
     assert.equal(second.history.length, 4);
   });
+
+  it('answers against live-session scope without requiring a saved transcription', async () => {
+    const pi = await setupFauxAsGoogle();
+    registration!.setResponses([pi.fauxAssistantMessage('The launch is Friday.')]);
+
+    const config = new ConfigService(configDir);
+    const agent = makeAgent(config);
+    const result = await agent.run({
+      question: 'When is launch?',
+      scope: {
+        kind: 'live',
+        title: 'Planning',
+        transcript: 'Participant: The launch is on Friday.',
+        translation: '참가자: 출시는 금요일입니다.',
+      },
+    });
+
+    assert.equal(result.answer, 'The launch is Friday.');
+    assert.equal(result.appliedActions.length, 0);
+  });
 });

--- a/src/agentService.test.ts
+++ b/src/agentService.test.ts
@@ -38,6 +38,20 @@ describe('coerceConfigValue', () => {
     assert.equal(bad.ok, false);
   });
 
+  it('accepts live transcription provider and language values', () => {
+    const provider = coerceConfigValue('liveSttProvider', 'gemini');
+    const badProvider = coerceConfigValue('liveSttProvider', 'claude');
+    const language = coerceConfigValue('liveSttLanguage', ' ko ');
+    const targetLanguage = coerceConfigValue('liveTranslationLanguage', ' ko ');
+    assert.equal(provider.ok, true);
+    assert.equal(badProvider.ok, false);
+    assert.equal(language.ok, true);
+    assert.equal(targetLanguage.ok, true);
+    if (provider.ok) assert.equal(provider.value, 'gemini');
+    if (language.ok) assert.equal(language.value, 'ko');
+    if (targetLanguage.ok) assert.equal(targetLanguage.value, 'ko');
+  });
+
   it('accepts numeric strings and numbers for minute keys, floors them, rejects negatives', () => {
     const num = coerceConfigValue('maxRecordingMinutes', 30);
     const str = coerceConfigValue('recordingReminderMinutes', '45');
@@ -57,7 +71,7 @@ describe('coerceConfigValue', () => {
 
 describe('config key whitelists', () => {
   it('does not include API credentials or database IDs in writable keys', () => {
-    const dangerous = ['geminiApiKey', 'notionApiKey', 'notionDatabaseId'];
+    const dangerous = ['geminiApiKey', 'openaiApiKey', 'notionApiKey', 'notionDatabaseId'];
     for (const k of dangerous) {
       assert.equal(
         (WRITABLE_CONFIG_KEYS as readonly string[]).includes(k),
@@ -81,6 +95,9 @@ describe('config key whitelists', () => {
       'maxRecordingMinutes',
       'recordingReminderMinutes',
       'minRecordingSeconds',
+      'liveSttProvider',
+      'liveSttLanguage',
+      'liveTranslationLanguage',
     ];
     for (const k of expected) {
       assert.ok((WRITABLE_CONFIG_KEYS as readonly string[]).includes(k), `${k} should be writable`);

--- a/src/agentService.ts
+++ b/src/agentService.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { DEFAULT_CODEX_MODEL, type AiProvider } from './aiProvider';
+import { DEFAULT_CODEX_MODEL, type AiProvider, normalizeLiveSttProvider } from './aiProvider';
 import { type CodexOAuthCredentials } from './codexOAuth';
 import { CodexOAuthHolder } from './codexOAuthHolder';
 import type { ConfigService } from './configService';
@@ -23,7 +23,17 @@ import {
 } from './outputService';
 import { ALL_FIELDS, type SearchField, searchTranscriptions } from './searchService';
 
-export type AgentScope = { kind: 'all' } | { kind: 'single'; folderName: string };
+export type AgentScope =
+  | { kind: 'all' }
+  | { kind: 'single'; folderName: string }
+  | {
+      kind: 'live';
+      title: string;
+      transcript: string;
+      interimTranscript?: string;
+      interimTranslation?: string;
+      translation?: string;
+    };
 
 export interface ConfigProposal {
   kind: 'setConfig';
@@ -77,6 +87,9 @@ export const WRITABLE_CONFIG_KEYS = [
   'recordingReminderMinutes',
   'minRecordingSeconds',
   'recordSystemAudio',
+  'liveSttProvider',
+  'liveSttLanguage',
+  'liveTranslationLanguage',
 ] as const;
 
 export type WritableConfigKey = (typeof WRITABLE_CONFIG_KEYS)[number];
@@ -88,6 +101,8 @@ export const READABLE_CONFIG_KEYS = [
   'geminiFlashModel',
   'codexModel',
   'codexTranscriptionModel',
+  'openaiLiveTranscriptionModel',
+  'openaiLiveTranslationModel',
 ] as const;
 
 export type ReadableConfigKey = (typeof READABLE_CONFIG_KEYS)[number];
@@ -120,6 +135,19 @@ export function coerceConfigValue(
         return { ok: false, error: `${key} expects a non-empty string` };
       }
       return { ok: true, value: raw.trim() };
+    }
+    case 'liveSttProvider': {
+      const provider = normalizeLiveSttProvider(raw);
+      if (!provider) return { ok: false, error: `${key} expects auto, openai, gemini, or chunked` };
+      return { ok: true, value: provider };
+    }
+    case 'liveSttLanguage': {
+      if (typeof raw !== 'string') return { ok: false, error: `${key} expects a string` };
+      return { ok: true, value: raw.trim() };
+    }
+    case 'liveTranslationLanguage': {
+      if (typeof raw !== 'string') return { ok: false, error: `${key} expects a string` };
+      return { ok: true, value: raw.trim() || 'ko' };
     }
     case 'maxRecordingMinutes':
     case 'recordingReminderMinutes':
@@ -220,6 +248,10 @@ function systemInstructionFor(scope: AgentScope, currentTranscriptionTitle?: str
     return `${common}\n\nYou are currently focused on a single meeting titled "${currentTranscriptionTitle ?? 'this meeting'}". The full transcription data is already provided in the conversation. Prefer answering directly from that data. Do not call search_transcriptions or list_recent_transcriptions in this mode — they are disabled. You may still read or change app settings via get_config / set_config (set_config always requires user confirmation).`;
   }
 
+  if (scope.kind === 'live') {
+    return `${common}\n\nYou are currently focused on an in-progress live session titled "${scope.title || 'Live Session'}". The live transcript so far is provided in the conversation. Treat it as partial and time-local: answer from what has been heard so far, and say when the transcript does not contain enough information. Do not call search_transcriptions or list_recent_transcriptions in this mode -- they are disabled.`;
+  }
+
   return `${common}\n\nScope: ALL saved meetings. Use search_transcriptions to find relevant meetings (title/summary/key points are searched by default; pass include_transcript=true if keywords are likely only in the transcript body). Use list_recent_transcriptions for "recent/latest" questions. Use get_transcription to read a specific meeting when you have its folder name.`;
 }
 
@@ -250,6 +282,26 @@ function buildSinglePrimer(data: ReadTranscriptionResult): string {
   if (data.transcript) {
     lines.push('Transcript:');
     lines.push(data.transcript);
+  }
+  return lines.join('\n');
+}
+
+function buildLivePrimer(scope: Extract<AgentScope, { kind: 'live' }>): string {
+  const lines: string[] = [];
+  lines.push(`[Context: live session "${scope.title || 'Live Session'}"]`);
+  lines.push('Finalized transcript so far:');
+  lines.push(scope.transcript || '(empty)');
+  if (scope.interimTranscript?.trim()) {
+    lines.push('Current in-progress transcript:');
+    lines.push(scope.interimTranscript.trim());
+  }
+  if (scope.translation?.trim()) {
+    lines.push('Korean translation so far:');
+    lines.push(scope.translation.trim());
+  }
+  if (scope.interimTranslation?.trim()) {
+    lines.push('Current in-progress Korean translation:');
+    lines.push(scope.interimTranslation.trim());
   }
   return lines.join('\n');
 }
@@ -360,6 +412,7 @@ export class AgentService {
             path.join(getTranscriptionsDir(this.dataPath), opts.scope.folderName),
           )
         : null;
+    const livePrimer = opts.scope.kind === 'live' ? buildLivePrimer(opts.scope) : null;
 
     const history = opts.history ? [...opts.history] : [];
     const context: Context = {
@@ -376,6 +429,9 @@ export class AgentService {
         content: buildSinglePrimer(singleData),
         timestamp: Date.now(),
       });
+    }
+    if (livePrimer) {
+      context.messages.push({ role: 'user', content: livePrimer, timestamp: Date.now() });
     }
     for (const m of historyToMessages(history, this.provider)) context.messages.push(m);
     context.messages.push({ role: 'user', content: opts.question, timestamp: Date.now() });

--- a/src/aiProvider.ts
+++ b/src/aiProvider.ts
@@ -2,6 +2,10 @@ export const AI_PROVIDERS = ['gemini', 'codex'] as const;
 
 export type AiProvider = (typeof AI_PROVIDERS)[number];
 
+export const LIVE_STT_PROVIDERS = ['auto', 'openai', 'gemini', 'chunked'] as const;
+
+export type LiveSttProvider = (typeof LIVE_STT_PROVIDERS)[number];
+
 export const DEFAULT_GEMINI_MODEL = 'gemini-3.5-flash';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
 // Gemini 3.x replaces the older numeric `thinking_budget` knob with a coarse
@@ -41,6 +45,13 @@ export const DEFAULT_CODEX_TRANSCRIPTION_MODEL = 'gpt-4o-transcribe-diarize';
 // labels. Switch via `listener config set codexTranscriptionModel gpt-4o-transcribe`.
 export const CODEX_TRANSCRIPTION_NON_DIARIZE_MODEL = 'gpt-4o-transcribe';
 
+export const DEFAULT_LIVE_STT_PROVIDER: LiveSttProvider = 'auto';
+export const DEFAULT_OPENAI_LIVE_TRANSCRIPTION_MODEL = 'gpt-realtime-whisper';
+export const DEFAULT_OPENAI_LIVE_TRANSLATION_MODEL = 'gpt-realtime-translate';
+export const DEFAULT_OPENAI_REALTIME_SESSION_MODEL = 'gpt-realtime-2';
+export const DEFAULT_GEMINI_LIVE_TRANSCRIPTION_MODEL = 'gemini-3.1-flash-live-preview';
+export const DEFAULT_GEMINI_LIVE_TRANSLATION_MODEL = 'gemini-3.5-live-translate-preview';
+
 export function isAiProvider(value: string): value is AiProvider {
   return (AI_PROVIDERS as readonly string[]).includes(value);
 }
@@ -49,6 +60,16 @@ export function normalizeAiProvider(value: unknown): AiProvider | undefined {
   if (typeof value !== 'string') return undefined;
   const normalized = value.trim().toLowerCase();
   return isAiProvider(normalized) ? normalized : undefined;
+}
+
+export function isLiveSttProvider(value: string): value is LiveSttProvider {
+  return (LIVE_STT_PROVIDERS as readonly string[]).includes(value);
+}
+
+export function normalizeLiveSttProvider(value: unknown): LiveSttProvider | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim().toLowerCase();
+  return isLiveSttProvider(normalized) ? normalized : undefined;
 }
 
 // pi-ai uses different provider ids than our internal `AiProvider`. Map at the

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -118,6 +118,20 @@ describe('listener CLI basics', () => {
     assert.equal(get.stdout.trim(), 'codex');
   });
 
+  it('config set + get round-trips liveSttProvider', async () => {
+    const set = await runCli(['config', 'set', 'liveSttProvider', 'openai']);
+    assert.equal(set.code, 0);
+    const get = await runCli(['config', 'get', 'liveSttProvider']);
+    assert.equal(get.code, 0);
+    assert.equal(get.stdout.trim(), 'openai');
+  });
+
+  it('config set rejects invalid liveSttProvider', async () => {
+    const { stderr, code } = await runCli(['config', 'set', 'liveSttProvider', 'claude']);
+    assert.equal(code, 1);
+    assert.match(stderr, /liveSttProvider must be one of/);
+  });
+
   it('config set rejects invalid aiProvider', async () => {
     const { stderr, code } = await runCli(['config', 'set', 'aiProvider', 'openai']);
     assert.equal(code, 1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -328,9 +328,10 @@ function createTranscriptionService(config: ConfigService, dataPath: string): Ge
     // Persist refreshed tokens only when credentials are stored in config.json.
     // Env-only credentials must stay ephemeral; persisting them silently writes
     // env-provided OAuth tokens to disk on every refresh.
-    onCodexOAuthUpdate: config.hasStoredCodexOAuth()
-      ? (credentials) => config.setCodexOAuth(credentials)
-      : undefined,
+    onCodexOAuthUpdate:
+      config.getCodexOAuthSource()?.source === 'config'
+        ? (credentials) => config.setCodexOAuth(credentials)
+        : undefined,
     dataPath,
     knownWords: config.getKnownWords(),
     proModel: config.getGeminiModel(),
@@ -347,9 +348,10 @@ function createAgentService(config: ConfigService, dataPath: string): AgentServi
     apiKey: config.getGeminiApiKey(),
     codexOAuth: config.getCodexOAuth(),
     // See note in createTranscriptionService(): persist only for stored creds.
-    onCodexOAuthUpdate: config.hasStoredCodexOAuth()
-      ? (credentials) => config.setCodexOAuth(credentials)
-      : undefined,
+    onCodexOAuthUpdate:
+      config.getCodexOAuthSource()?.source === 'config'
+        ? (credentials) => config.setCodexOAuth(credentials)
+        : undefined,
     dataPath,
     configService: config,
     codexModel: config.getCodexModel(),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,13 @@ import * as fs from 'fs';
 import * as readline from 'readline';
 import * as path from 'path';
 import { type AgentScope, AgentService, type ConfigProposal } from './agentService';
-import { GEMINI_THINKING_LEVELS, isAiProvider, normalizeGeminiThinkingLevel } from './aiProvider';
+import {
+  GEMINI_THINKING_LEVELS,
+  LIVE_STT_PROVIDERS,
+  isAiProvider,
+  normalizeGeminiThinkingLevel,
+  normalizeLiveSttProvider,
+} from './aiProvider';
 import { extensionForMimeType, mimeTypeForFile } from './audioFormats';
 import { type AppConfig, ConfigService } from './configService';
 import { loginCodexOAuth } from './codexOAuth';
@@ -127,6 +133,12 @@ const KNOWN_CONFIG_KEYS = [
   'geminiThinkingLevel',
   'codexModel',
   'codexTranscriptionModel',
+  'liveSttProvider',
+  'openaiApiKey',
+  'openaiLiveTranscriptionModel',
+  'openaiLiveTranslationModel',
+  'liveSttLanguage',
+  'liveTranslationLanguage',
   'notionApiKey',
   'notionDatabaseId',
   'autoMode',
@@ -223,6 +235,32 @@ function applyConfigSet(config: ConfigService, key: ConfigKey, value: string): v
       return;
     case 'codexTranscriptionModel':
       config.setCodexTranscriptionModel(value);
+      return;
+    case 'liveSttProvider': {
+      const provider = normalizeLiveSttProvider(value);
+      if (!provider) {
+        process.stderr.write(
+          `Error: liveSttProvider must be one of: ${LIVE_STT_PROVIDERS.join(', ')}\n`,
+        );
+        process.exit(1);
+      }
+      config.setLiveSttProvider(provider);
+      return;
+    }
+    case 'openaiApiKey':
+      config.setOpenAiApiKey(value);
+      return;
+    case 'openaiLiveTranscriptionModel':
+      config.updateConfig({ openaiLiveTranscriptionModel: value });
+      return;
+    case 'openaiLiveTranslationModel':
+      config.updateConfig({ openaiLiveTranslationModel: value });
+      return;
+    case 'liveSttLanguage':
+      config.updateConfig({ liveSttLanguage: value });
+      return;
+    case 'liveTranslationLanguage':
+      config.updateConfig({ liveTranslationLanguage: value });
       return;
     case 'notionApiKey':
       config.setNotionApiKey(value);

--- a/src/codexOAuth.ts
+++ b/src/codexOAuth.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { importEsm } from './esmImport';
 
 type OAuthCredentials = {
@@ -36,6 +39,13 @@ export type CodexOAuthCredentials = OAuthCredentials & {
   email?: string;
 };
 
+export type CodexOAuthCredentialSourceName = 'config' | 'env' | 'codexCli';
+
+export interface CodexOAuthCredentialSource {
+  source: CodexOAuthCredentialSourceName;
+  credentials: CodexOAuthCredentials;
+}
+
 let runtimePromise: Promise<CodexOAuthRuntime> | undefined;
 
 async function loadCodexOAuthRuntime(): Promise<CodexOAuthRuntime> {
@@ -65,6 +75,94 @@ export function getCodexOAuthEnvCredentials(): CodexOAuthCredentials | undefined
 
 export function hasCodexOAuthEnvCredentials(): boolean {
   return !!getCodexOAuthEnvCredentials();
+}
+
+function decodeJwtPayload(token: string | undefined): Record<string, unknown> | undefined {
+  if (!token?.includes('.')) return undefined;
+  const payload = token.split('.')[1];
+  if (!payload) return undefined;
+  try {
+    return JSON.parse(
+      Buffer.from(payload.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'),
+    ) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function jwtExpiryMs(token: string | undefined): number | undefined {
+  const payload = decodeJwtPayload(token);
+  const exp = payload?.exp;
+  return typeof exp === 'number' && Number.isFinite(exp) ? exp * 1000 : undefined;
+}
+
+function accountIdFromJwt(token: string | undefined): string | undefined {
+  const payload = decodeJwtPayload(token);
+  const auth = payload?.['https://api.openai.com/auth'];
+  if (!auth || typeof auth !== 'object') return undefined;
+  const accountId = (auth as { chatgpt_account_id?: unknown }).chatgpt_account_id;
+  return typeof accountId === 'string' && accountId.trim() ? accountId : undefined;
+}
+
+export function getCodexCliAuthPath(): string | undefined {
+  const override = process.env.LISTENER_CODEX_AUTH_PATH?.trim();
+  if (override) return override;
+  // Unit tests must not accidentally read the developer's real Codex auth file.
+  if (process.env.NODE_ENV === 'test') return undefined;
+  return path.join(os.homedir(), '.codex', 'auth.json');
+}
+
+export function getCodexOAuthCliCredentials(): CodexOAuthCredentials | undefined {
+  const authPath = getCodexCliAuthPath();
+  if (!authPath) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(authPath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+  const root = parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  const tokens =
+    root.tokens && typeof root.tokens === 'object'
+      ? (root.tokens as Record<string, unknown>)
+      : root;
+  const access =
+    typeof tokens.access_token === 'string'
+      ? tokens.access_token.trim()
+      : typeof tokens.access === 'string'
+        ? tokens.access.trim()
+        : '';
+  const refresh =
+    typeof tokens.refresh_token === 'string'
+      ? tokens.refresh_token.trim()
+      : typeof tokens.refresh === 'string'
+        ? tokens.refresh.trim()
+        : '';
+  if (!access || !refresh) return undefined;
+
+  const expires =
+    (typeof tokens.expires === 'number' && Number.isFinite(tokens.expires)
+      ? tokens.expires
+      : undefined) ??
+    (typeof root.expires === 'number' && Number.isFinite(root.expires)
+      ? root.expires
+      : undefined) ??
+    jwtExpiryMs(access) ??
+    Date.now() + 30 * 60_000;
+  const accountId =
+    (typeof tokens.account_id === 'string' && tokens.account_id.trim()) ||
+    (typeof root.account_id === 'string' && root.account_id.trim()) ||
+    accountIdFromJwt(access);
+  return {
+    access,
+    refresh,
+    expires,
+    ...(accountId ? { accountId } : {}),
+  };
+}
+
+export function hasCodexOAuthCliCredentials(): boolean {
+  return !!getCodexOAuthCliCredentials();
 }
 
 export async function resolveCodexAccessToken(params: {

--- a/src/configService.test.ts
+++ b/src/configService.test.ts
@@ -19,7 +19,10 @@ const CODEX_ENV_KEYS = [
   'OPENAI_CODEX_ACCESS_TOKEN',
   'OPENAI_CODEX_REFRESH_TOKEN',
   'OPENAI_CODEX_EXPIRES',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
   'LISTENER_AI_PROVIDER',
+  'LISTENER_CODEX_AUTH_PATH',
 ];
 const savedEnv = new Map<string, string | undefined>();
 
@@ -48,6 +51,35 @@ function freshDataPath(suffix: string): string {
   const dir = path.join(workDir, suffix);
   fs.mkdirSync(dir, { recursive: true });
   return dir;
+}
+
+function fakeJwt(expMs: number, accountId = 'acct_cli'): string {
+  const payload = {
+    exp: Math.floor(expMs / 1000),
+    'https://api.openai.com/auth': { chatgpt_account_id: accountId },
+  };
+  const encoded = Buffer.from(JSON.stringify(payload))
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  return `header.${encoded}.sig`;
+}
+
+function writeCodexCliAuth(filePath: string, expMs = Date.now() + 60_000): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({
+      auth_mode: 'chatgpt',
+      tokens: {
+        access_token: fakeJwt(expMs),
+        refresh_token: 'cli-refresh',
+        account_id: 'acct_cli',
+      },
+    }),
+    'utf-8',
+  );
 }
 
 describe('ConfigService: Codex OAuth credential source', () => {
@@ -87,6 +119,52 @@ describe('ConfigService: Codex OAuth credential source', () => {
     cfg.setCodexOAuth({ access: 'config-access', refresh: 'r', expires: Date.now() + 60_000 });
 
     assert.equal(cfg.getCodexOAuth()?.access, 'config-access');
+  });
+
+  it('returns Codex CLI credentials when app config and env have none', () => {
+    const authPath = path.join(freshDataPath('cli-auth'), 'auth.json');
+    writeCodexCliAuth(authPath);
+    process.env.LISTENER_CODEX_AUTH_PATH = authPath;
+
+    const cfg = new ConfigService(freshDataPath('cli-only'));
+    const source = cfg.getCodexOAuthSource();
+
+    assert.equal(source?.source, 'codexCli');
+    assert.equal(source?.credentials.refresh, 'cli-refresh');
+    assert.equal(source?.credentials.accountId, 'acct_cli');
+    assert.equal(cfg.hasStoredCodexOAuth(), false);
+    assert.equal(cfg.hasCodexOAuth(), true);
+  });
+
+  it('prefers fresh Codex CLI credentials over stale app config credentials', () => {
+    const authPath = path.join(freshDataPath('cli-auth-over-stale'), 'auth.json');
+    writeCodexCliAuth(authPath, Date.now() + 60_000);
+    process.env.LISTENER_CODEX_AUTH_PATH = authPath;
+
+    const cfg = new ConfigService(freshDataPath('stale-config-cli-fallback'));
+    cfg.setCodexOAuth({ access: 'stale-config-access', refresh: 'stale-refresh', expires: 1 });
+    const source = cfg.getCodexOAuthSource();
+
+    assert.equal(source?.source, 'codexCli');
+    assert.equal(source?.credentials.refresh, 'cli-refresh');
+    assert.equal(cfg.getCodexOAuth()?.refresh, 'cli-refresh');
+    assert.equal(cfg.hasStoredCodexOAuth(), true);
+  });
+
+  it('keeps fresh app config credentials ahead of Codex CLI credentials', () => {
+    const authPath = path.join(freshDataPath('cli-auth-lower-priority'), 'auth.json');
+    writeCodexCliAuth(authPath);
+    process.env.LISTENER_CODEX_AUTH_PATH = authPath;
+
+    const cfg = new ConfigService(freshDataPath('fresh-config-cli-present'));
+    cfg.setCodexOAuth({
+      access: 'fresh-config-access',
+      refresh: 'fresh-config-refresh',
+      expires: Date.now() + 60_000,
+    });
+
+    assert.equal(cfg.getCodexOAuthSource()?.source, 'config');
+    assert.equal(cfg.getCodexOAuth()?.access, 'fresh-config-access');
   });
 
   it('clearCodexOAuth removes the key from disk (not resurrected by save-merge)', () => {
@@ -302,6 +380,66 @@ describe('ConfigService: updateConfig validation for aiProvider', () => {
     const cfg = new ConfigService(dataPath);
     cfg.updateConfig({ aiProvider: 'codex' });
     assert.equal(cfg.getAiProvider(), 'codex');
+  });
+});
+
+describe('ConfigService: live STT config', () => {
+  it('returns env live STT keys when config has none', () => {
+    process.env.OPENAI_API_KEY = 'env-openai';
+
+    const cfg = new ConfigService(freshDataPath('live-env'));
+    assert.equal(cfg.getOpenAiApiKey(), 'env-openai');
+    assert.equal(cfg.hasStreamingLiveSttAuth(), true);
+  });
+
+  it('does not count Codex OAuth as OpenAI live Realtime auth', () => {
+    const cfg = new ConfigService(freshDataPath('live-codex-oauth'));
+    cfg.updateConfig({ liveSttProvider: 'openai' });
+    cfg.setCodexOAuth({
+      access: 'codex-access',
+      refresh: 'codex-refresh',
+      expires: Date.now() + 60_000,
+    });
+
+    assert.equal(cfg.getOpenAiApiKey(), undefined);
+    assert.equal(cfg.hasStreamingLiveSttAuth(), false);
+  });
+
+  it('does not count Codex OAuth as auto live streaming auth', () => {
+    const cfg = new ConfigService(freshDataPath('live-auto-codex-oauth'));
+    cfg.updateConfig({ liveSttProvider: 'auto' });
+    cfg.setCodexOAuth({
+      access: 'codex-access',
+      refresh: 'codex-refresh',
+      expires: Date.now() + 60_000,
+    });
+
+    assert.equal(cfg.hasStreamingLiveSttAuth(), false);
+  });
+
+  it('accepts Gemini API key as Gemini live auth', () => {
+    process.env.GEMINI_API_KEY = 'env-gemini';
+
+    const cfg = new ConfigService(freshDataPath('live-gemini-env'));
+    cfg.updateConfig({ liveSttProvider: 'gemini' });
+    assert.equal(cfg.getGeminiApiKey(), 'env-gemini');
+    assert.equal(cfg.hasStreamingLiveSttAuth(), true);
+  });
+
+  it('config live STT keys win over env values', () => {
+    process.env.OPENAI_API_KEY = 'env-openai';
+
+    const cfg = new ConfigService(freshDataPath('live-config-wins'));
+    cfg.setOpenAiApiKey('config-openai');
+    assert.equal(cfg.getOpenAiApiKey(), 'config-openai');
+  });
+
+  it('drops invalid liveSttProvider values on updateConfig', () => {
+    const cfg = new ConfigService(freshDataPath('live-provider-validation'));
+    cfg.updateConfig({ liveSttProvider: 'openai' });
+    assert.equal(cfg.getLiveSttProvider(), 'openai');
+    cfg.updateConfig({ liveSttProvider: 'claude' as never });
+    assert.equal(cfg.getLiveSttProvider(), 'openai');
   });
 });
 

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -624,7 +624,9 @@ export class ConfigService {
       codexModel: this.getCodexModel(),
       codexTranscriptionModel: this.getCodexTranscriptionModel(),
       liveSttProvider: this.getLiveSttProvider(),
-      openaiApiKey: this.getOpenAiApiKey(),
+      // Stored value only -- never surface the OPENAI_API_KEY env fallback to the
+      // settings form, or saving any change would persist an env-only key to config.json.
+      openaiApiKey: this.config.openaiApiKey,
       openaiLiveTranscriptionModel: this.getOpenAiLiveTranscriptionModel(),
       openaiLiveTranslationModel: this.getOpenAiLiveTranslationModel(),
       liveSttLanguage: this.getLiveSttLanguage(),

--- a/src/configService.ts
+++ b/src/configService.ts
@@ -6,15 +6,21 @@ import {
   DEFAULT_GEMINI_FLASH_MODEL,
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_THINKING_LEVEL,
+  DEFAULT_LIVE_STT_PROVIDER,
+  DEFAULT_OPENAI_LIVE_TRANSCRIPTION_MODEL,
+  DEFAULT_OPENAI_LIVE_TRANSLATION_MODEL,
   type AiProvider,
   type GeminiThinkingLevel,
+  type LiveSttProvider,
   normalizeAiProvider,
   normalizeGeminiThinkingLevel,
+  normalizeLiveSttProvider,
 } from './aiProvider';
 import {
+  type CodexOAuthCredentialSource,
   type CodexOAuthCredentials,
+  getCodexOAuthCliCredentials,
   getCodexOAuthEnvCredentials,
-  hasCodexOAuthEnvCredentials,
 } from './codexOAuth';
 import {
   type GoogleOAuthCredentials,
@@ -30,8 +36,15 @@ export interface AppConfig {
   geminiThinkingLevel?: GeminiThinkingLevel;
   codexModel?: string;
   codexTranscriptionModel?: string;
+  liveSttProvider?: LiveSttProvider;
+  openaiApiKey?: string;
+  openaiLiveTranscriptionModel?: string;
+  openaiLiveTranslationModel?: string;
+  liveSttLanguage?: string;
+  liveTranslationLanguage?: string;
   codexOAuth?: CodexOAuthCredentials;
   codexOAuthConfigured?: boolean;
+  codexOAuthSource?: CodexOAuthCredentialSource['source'];
   googleOAuth?: GoogleOAuthCredentials;
   googleOAuthConfigured?: boolean;
   // When true, the app periodically syncs transcription folders to Drive
@@ -226,12 +239,39 @@ export class ConfigService {
     this.saveConfig();
   }
 
-  // Returns the active OAuth credentials whether they came from config or env.
+  // Returns the active OAuth credentials whether they came from config, env, or
+  // the Codex CLI auth file. Preference is:
+  //   1. Fresh config credentials (app sign-in)
+  //   2. Fresh env credentials (ephemeral automation)
+  //   3. Fresh Codex CLI credentials (~/.codex/auth.json, read-only fallback)
+  //   4. Any stale source in the same order, so the refresh helper can still try
+  //
+  // The source distinction matters: only config-sourced refreshes may be
+  // persisted back into config.json.
+  getCodexOAuthSource(): CodexOAuthCredentialSource | undefined {
+    const candidates: CodexOAuthCredentialSource[] = [];
+    const config = this.config.codexOAuth;
+    if (config?.access && config.refresh && Number.isFinite(config.expires)) {
+      candidates.push({ source: 'config', credentials: config });
+    }
+    const env = getCodexOAuthEnvCredentials();
+    if (env) candidates.push({ source: 'env', credentials: env });
+    const cli = getCodexOAuthCliCredentials();
+    if (cli) candidates.push({ source: 'codexCli', credentials: cli });
+    if (candidates.length === 0) return undefined;
+    return (
+      candidates.find((candidate) => candidate.credentials.expires > Date.now()) ?? candidates[0]
+    );
+  }
+
+  // Returns the active OAuth credentials whether they came from config, env, or
+  // the Codex CLI auth file.
   // Callers that intend to PERSIST refreshed credentials must additionally check
-  // `hasStoredCodexOAuth()` and skip the persistence callback when source is env --
-  // otherwise a normal token refresh writes env-sourced tokens to plaintext disk.
+  // `getCodexOAuthSource()?.source === 'config'` and skip the persistence
+  // callback for env/CLI sources. Otherwise a normal token refresh writes
+  // external credentials to plaintext app config.
   getCodexOAuth(): CodexOAuthCredentials | undefined {
-    return this.config.codexOAuth || getCodexOAuthEnvCredentials();
+    return this.getCodexOAuthSource()?.credentials;
   }
 
   // True only when credentials are stored in config.json. Env-only credentials
@@ -252,7 +292,7 @@ export class ConfigService {
   }
 
   hasCodexOAuth(): boolean {
-    return hasCodexOAuthEnvCredentials() || this.hasStoredCodexOAuth();
+    return !!this.getCodexOAuthSource();
   }
 
   // Mirrors the Codex OAuth surface. The stored-vs-env distinction matters
@@ -419,6 +459,49 @@ export class ConfigService {
     this.saveConfig();
   }
 
+  getLiveSttProvider(): LiveSttProvider {
+    return normalizeLiveSttProvider(this.config.liveSttProvider) ?? DEFAULT_LIVE_STT_PROVIDER;
+  }
+
+  setLiveSttProvider(provider: LiveSttProvider): void {
+    this.setKey('liveSttProvider', provider);
+    this.saveConfig();
+  }
+
+  getOpenAiApiKey(): string | undefined {
+    return this.config.openaiApiKey || process.env.OPENAI_API_KEY;
+  }
+
+  setOpenAiApiKey(apiKey: string): void {
+    this.setKey('openaiApiKey', apiKey);
+    this.saveConfig();
+  }
+
+  getOpenAiLiveTranscriptionModel(): string {
+    return this.config.openaiLiveTranscriptionModel || DEFAULT_OPENAI_LIVE_TRANSCRIPTION_MODEL;
+  }
+
+  getOpenAiLiveTranslationModel(): string {
+    return this.config.openaiLiveTranslationModel || DEFAULT_OPENAI_LIVE_TRANSLATION_MODEL;
+  }
+
+  getLiveSttLanguage(): string | undefined {
+    return this.config.liveSttLanguage?.trim() || undefined;
+  }
+
+  getLiveTranslationLanguage(): string {
+    return this.config.liveTranslationLanguage?.trim() || 'ko';
+  }
+
+  hasStreamingLiveSttAuth(): boolean {
+    const provider = this.getLiveSttProvider();
+    const hasOpenAiRealtimeAuth = !!this.getOpenAiApiKey();
+    if (provider === 'openai') return hasOpenAiRealtimeAuth;
+    if (provider === 'gemini') return !!this.getGeminiApiKey();
+    if (provider === 'chunked') return false;
+    return hasOpenAiRealtimeAuth || !!this.getGeminiApiKey();
+  }
+
   getMaxRecordingMinutes(): number {
     return this.config.maxRecordingMinutes || 0;
   }
@@ -515,6 +598,12 @@ export class ConfigService {
         this.setKey('geminiThinkingLevel', level);
         continue;
       }
+      if (key === 'liveSttProvider') {
+        const provider = normalizeLiveSttProvider(value);
+        if (!provider) continue;
+        this.setKey('liveSttProvider', provider);
+        continue;
+      }
       this.setKey(key as keyof AppConfig, value as AppConfig[keyof AppConfig]);
     }
     this.saveConfig();
@@ -534,7 +623,14 @@ export class ConfigService {
       geminiThinkingLevel: this.getGeminiThinkingLevel(),
       codexModel: this.getCodexModel(),
       codexTranscriptionModel: this.getCodexTranscriptionModel(),
+      liveSttProvider: this.getLiveSttProvider(),
+      openaiApiKey: this.getOpenAiApiKey(),
+      openaiLiveTranscriptionModel: this.getOpenAiLiveTranscriptionModel(),
+      openaiLiveTranslationModel: this.getOpenAiLiveTranslationModel(),
+      liveSttLanguage: this.getLiveSttLanguage(),
+      liveTranslationLanguage: this.getLiveTranslationLanguage(),
       codexOAuthConfigured: this.hasCodexOAuth(),
+      codexOAuthSource: this.getCodexOAuthSource()?.source,
       googleOAuthConfigured: this.hasGoogleOAuth(),
       googleDriveEnabled: this.getGoogleDriveEnabled(),
       notionApiKey: this.getNotionApiKey(),

--- a/src/geminiService.ts
+++ b/src/geminiService.ts
@@ -143,9 +143,11 @@ export interface TranscriptionOptions {
   /**
    * Override the default speaker-identification instruction sent to Gemini
    * during transcription. The user-supplied glossary (knownWords) and
-   * per-segment positional prefix are still applied automatically.
+   * per-segment positional prefix are still applied automatically unless
+   * includeGlossary is false.
    */
   transcriptionPrompt?: string;
+  includeGlossary?: boolean;
   /**
    * Cancellation signal. The pipeline checks `signal.aborted` at every stage
    * boundary and forwards it to the underlying provider SDKs (pi-ai, Gemini
@@ -494,6 +496,40 @@ export class GeminiService {
     return extractFinalText(response);
   }
 
+  private async completeTextTask(
+    systemPrompt: string,
+    promptText: string,
+    opts: {
+      signal?: AbortSignal;
+      maxTokens?: number;
+      temperature?: number;
+      reasoning?: GeminiThinkingLevel | 'xhigh';
+      modelId?: string;
+    } = {},
+  ): Promise<string> {
+    const modelId = opts.modelId ?? (this.provider === 'codex' ? this.codexModel : this.proModel);
+    const apiKey =
+      this.provider === 'codex' ? await this.getCodexToken() : this.requireGeminiApiKey();
+    const model = await getModel(this.provider, modelId);
+    const context: Context = {
+      systemPrompt,
+      messages: [{ role: 'user', content: promptText, timestamp: Date.now() }],
+    };
+    const response = await completeSimple(
+      model,
+      context,
+      {
+        apiKey,
+        temperature: opts.temperature ?? 0.2,
+        maxTokens: opts.maxTokens ?? 4096,
+        reasoning: opts.reasoning ?? 'low',
+        signal: opts.signal,
+      },
+      { kind: 'agent' },
+    );
+    return extractFinalText(response);
+  }
+
   private async prepareAudioForProvider(
     audioFilePath: string,
     signal?: AbortSignal,
@@ -618,6 +654,48 @@ export class GeminiService {
     } finally {
       prepared.cleanup?.();
     }
+  }
+
+  async transcribeLiveSnippet(
+    audioFilePath: string,
+    opts: { signal?: AbortSignal } = {},
+  ): Promise<string> {
+    const result = await this.transcribeAudio(audioFilePath, undefined, undefined, undefined, {
+      transcriptOnly: true,
+      includeGlossary: false,
+      transcriptionPrompt: `Please transcribe this short live meeting audio snippet.
+
+Requirements:
+- Keep the original spoken language.
+- Preserve proper nouns and technical terms.
+- Do not infer names, company names, or terms from context. Write them only when clearly spoken.
+- If there is no clearly intelligible speech, return exactly [NO_SPEECH].
+- If speakers are distinguishable, prefix turns with 참가자1, 참가자2, etc.
+- Return only transcript text. Do not summarize and do not add commentary.`,
+      signal: opts.signal,
+    });
+    const transcript = result.transcript.trim();
+    return transcript === '[NO_SPEECH]' ? '' : transcript;
+  }
+
+  async translateText(
+    text: string,
+    opts: { targetLanguage?: string; signal?: AbortSignal } = {},
+  ): Promise<string> {
+    const source = text.trim();
+    if (!source) return '';
+    const targetLanguage = opts.targetLanguage || 'Korean';
+    return await this.completeTextTask(
+      `You translate live meeting transcript snippets into ${targetLanguage}. Preserve speaker labels, names, numbers, and technical terms. If the source is already ${targetLanguage}, lightly clean it without changing meaning. Return only the translated text.`,
+      `Translate this live transcript snippet:\n\n${source}`,
+      {
+        signal: opts.signal,
+        maxTokens: 4096,
+        temperature: 0.1,
+        reasoning: 'low',
+        modelId: this.provider === 'gemini' ? this.flashModel : undefined,
+      },
+    );
   }
 
   // Get audio duration using ffmpeg
@@ -855,6 +933,7 @@ export class GeminiService {
           segmentDuration,
           signal,
           costSession,
+          options.includeGlossary !== false,
         );
       } else {
         // Get transcript for short audio
@@ -866,6 +945,7 @@ export class GeminiService {
           options.transcriptionPrompt,
           signal,
           costSession,
+          options.includeGlossary !== false,
         );
       }
 
@@ -994,6 +1074,7 @@ Return as JSON:
     customPrompt?: string,
     signal?: AbortSignal,
     session?: CostSession,
+    includeGlossary = true,
   ): Promise<string> {
     try {
       const stats = await fs.promises.stat(audioFilePath);
@@ -1003,7 +1084,7 @@ Return as JSON:
         progressCallback(20, 'Processing audio file...');
       }
 
-      const transcriptPrompt = `${this.buildGlossaryBlock()}${customPrompt ?? DEFAULT_TRANSCRIPT_PROMPT}`;
+      const transcriptPrompt = `${includeGlossary ? this.buildGlossaryBlock() : ''}${customPrompt ?? DEFAULT_TRANSCRIPT_PROMPT}`;
       if (this.provider === 'codex') {
         const text = await transcribeCodexAudio({
           getToken: () => this.getCodexToken(),
@@ -1155,10 +1236,11 @@ Return as JSON:
     segmentIndex: number,
     totalSegments: number,
     customPrompt?: string,
+    includeGlossary = true,
   ): string {
     const positional = `[Audio segment ${segmentIndex + 1} of ${totalSegments}]\n\n`;
     const body = customPrompt ?? DEFAULT_TRANSCRIPT_PROMPT;
-    return `${this.buildGlossaryBlock()}${positional}${body}`;
+    return `${includeGlossary ? this.buildGlossaryBlock() : ''}${positional}${body}`;
   }
 
   // Transcribe a single segment with retry logic
@@ -1171,11 +1253,17 @@ Return as JSON:
     customPrompt?: string,
     signal?: AbortSignal,
     session?: CostSession,
+    includeGlossary = true,
   ): Promise<{ index: number; content: string }> {
     const maxRetries = 3;
     let lastError: any = null;
     let attemptsMade = 0;
-    const segmentPrompt = this.createSegmentPrompt(segmentIndex, totalSegments, customPrompt);
+    const segmentPrompt = this.createSegmentPrompt(
+      segmentIndex,
+      totalSegments,
+      customPrompt,
+      includeGlossary,
+    );
     const segmentSeconds = Math.max(0, segmentEndTime - segmentStartTime);
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -1305,6 +1393,7 @@ Return as JSON:
     segmentDuration = 300,
     signal?: AbortSignal,
     session?: CostSession,
+    includeGlossary = true,
   ): Promise<string> {
     // Track segments outside the try so the finally can clean them up on
     // abort / mid-pipeline failure too. Without this, cancelled transcribes
@@ -1349,6 +1438,7 @@ Return as JSON:
           customPrompt,
           combinedSignal,
           session,
+          includeGlossary,
         ).catch((err) => {
           aborter.abort();
           throw err;

--- a/src/liveSessionService.test.ts
+++ b/src/liveSessionService.test.ts
@@ -1,0 +1,675 @@
+import * as fs from 'fs';
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import * as path from 'path';
+import type { AgentRunOptions, AgentRunResult, AgentService } from './agentService';
+import {
+  GeminiService,
+  type TranscriptionOptions,
+  type TranscriptionResult,
+} from './geminiService';
+import { LiveSessionService, type LiveSessionEvent } from './liveSessionService';
+import type { LiveSttCallbacks, LiveSttSession } from './liveSttProvider';
+import type { RecordInput } from './services/usageTracker';
+import { makeTempDir, rmDir } from './test-helpers';
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = makeTempDir('live-session');
+});
+
+afterEach(() => {
+  rmDir(workDir);
+});
+
+function makeAudioBytes(): Uint8Array {
+  return new Uint8Array(2048).fill(7);
+}
+
+function chunkedConfig() {
+  return { provider: 'chunked' as const };
+}
+
+describe('LiveSessionService', () => {
+  it('transcribes a live audio chunk, translates it, and stores a snapshot', async () => {
+    const tempPathsSeen: string[] = [];
+    const fakeGemini = {
+      async transcribeLiveSnippet(filePath: string): Promise<string> {
+        assert.equal(fs.existsSync(filePath), true);
+        tempPathsSeen.push(filePath);
+        return 'Speaker 1: Hello everyone.';
+      },
+      async translateText(text: string): Promise<string> {
+        assert.equal(text, 'Speaker 1: Hello everyone.');
+        return '참가자1: 모두 안녕하세요.';
+      },
+    };
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => fakeGemini as unknown as GeminiService,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: chunkedConfig,
+    });
+
+    const session = await service.start({ title: 'Bonjour', translate: false });
+    const segment = await service.processAudioChunk({
+      sessionId: session.sessionId,
+      audioData: makeAudioBytes(),
+      mimeType: 'audio/webm',
+      offsetMs: 12_000,
+      durationMs: 11_500,
+      translate: true,
+    });
+
+    assert.ok(segment);
+    assert.equal(segment.transcript, 'Speaker 1: Hello everyone.');
+    assert.equal(segment.translation, '참가자1: 모두 안녕하세요.');
+    const snapshot = service.snapshot();
+    assert.equal(snapshot?.transcript, 'Speaker 1: Hello everyone.');
+    assert.equal(snapshot?.translation, '참가자1: 모두 안녕하세요.');
+    assert.equal(tempPathsSeen.length, 1);
+    assert.equal(fs.existsSync(tempPathsSeen[0]), false);
+  });
+
+  it('answers questions against the accumulated live transcript', async () => {
+    let scopeSeen: AgentRunOptions['scope'] | undefined;
+    const fakeGemini = {
+      async transcribeLiveSnippet(): Promise<string> {
+        return 'Participant: The launch is on Friday.';
+      },
+      async translateText(): Promise<string> {
+        return '참가자: 출시는 금요일입니다.';
+      },
+    };
+    const fakeAgent = {
+      async run(opts: AgentRunOptions): Promise<AgentRunResult> {
+        scopeSeen = opts.scope;
+        return {
+          answer: 'Friday.',
+          appliedActions: [],
+          history: [
+            { role: 'user', text: opts.question },
+            { role: 'model', text: 'Friday.' },
+          ],
+        };
+      },
+    };
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => fakeGemini as unknown as GeminiService,
+      getAgentService: () => fakeAgent as unknown as AgentService,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: chunkedConfig,
+    });
+
+    const session = await service.start({ title: 'Planning' });
+    await service.processAudioChunk({
+      sessionId: session.sessionId,
+      audioData: makeAudioBytes(),
+      mimeType: 'audio/webm',
+      offsetMs: 0,
+      durationMs: 12_000,
+    });
+
+    const result = await service.ask({
+      sessionId: session.sessionId,
+      question: 'When is launch?',
+    });
+
+    assert.equal(result.answer, 'Friday.');
+    assert.equal(scopeSeen?.kind, 'live');
+    if (scopeSeen?.kind === 'live') {
+      assert.equal(scopeSeen.title, 'Planning');
+      assert.match(scopeSeen.transcript, /launch is on Friday/);
+      assert.match(scopeSeen.translation ?? '', /금요일/);
+    }
+  });
+
+  it('rejects live questions before any transcript exists', async () => {
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => null,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: chunkedConfig,
+    });
+
+    const session = await service.start();
+    await assert.rejects(
+      () => service.ask({ sessionId: session.sessionId, question: 'Anything?' }),
+      /No live transcript/,
+    );
+  });
+
+  it('ignores tiny empty chunks', async () => {
+    let called = false;
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () =>
+        ({
+          async transcribeLiveSnippet(): Promise<string> {
+            called = true;
+            return 'should not happen';
+          },
+        }) as unknown as GeminiService,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: chunkedConfig,
+    });
+
+    const session = await service.start();
+    const result = await service.processAudioChunk({
+      sessionId: session.sessionId,
+      audioData: new Uint8Array(10),
+      mimeType: 'audio/webm',
+      offsetMs: 0,
+      durationMs: 10,
+    });
+
+    assert.equal(result, null);
+    assert.equal(called, false);
+    assert.equal(service.snapshot()?.segments.length, 0);
+    assert.equal(fs.existsSync(path.join(workDir, 'live-snippets')), false);
+  });
+
+  it('ignores fallback chunks that arrive after the live session is stopped', async () => {
+    let called = false;
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () =>
+        ({
+          async transcribeLiveSnippet(): Promise<string> {
+            called = true;
+            return 'should not happen';
+          },
+        }) as unknown as GeminiService,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: chunkedConfig,
+    });
+
+    const session = await service.start();
+    await service.stop(session.sessionId);
+    const result = await service.processAudioChunk({
+      sessionId: session.sessionId,
+      audioData: makeAudioBytes(),
+      mimeType: 'audio/webm',
+      offsetMs: 0,
+      durationMs: 12_000,
+    });
+
+    assert.equal(result, null);
+    assert.equal(called, false);
+    assert.equal(service.snapshot()?.segments.length, 0);
+  });
+
+  it('aborts an in-flight fallback transcription when the live session stops', async () => {
+    let started!: () => void;
+    let seenSignal: AbortSignal | undefined;
+    const transcriptionStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const fakeGemini = {
+      transcribeLiveSnippet(
+        _filePath: string,
+        opts: { signal?: AbortSignal } = {},
+      ): Promise<string> {
+        seenSignal = opts.signal;
+        started();
+        return new Promise<string>((_resolve, reject) => {
+          if (opts.signal?.aborted) {
+            const error = new Error('Aborted');
+            error.name = 'AbortError';
+            reject(error);
+            return;
+          }
+          opts.signal?.addEventListener(
+            'abort',
+            () => {
+              const error = new Error('Aborted');
+              error.name = 'AbortError';
+              reject(error);
+            },
+            { once: true },
+          );
+        });
+      },
+      async translateText(): Promise<string> {
+        return 'should not happen';
+      },
+    };
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => fakeGemini as unknown as GeminiService,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: chunkedConfig,
+    });
+
+    const session = await service.start();
+    const processing = service.processAudioChunk({
+      sessionId: session.sessionId,
+      audioData: makeAudioBytes(),
+      mimeType: 'audio/webm',
+      offsetMs: 0,
+      durationMs: 12_000,
+      translate: true,
+    });
+    await transcriptionStarted;
+    await service.stop(session.sessionId);
+
+    assert.equal(await processing, null);
+    assert.equal(seenSignal?.aborted, true);
+    assert.equal(service.snapshot()?.segments.length, 0);
+  });
+
+  it('streams PCM frames into the live provider and emits interim/final transcript events', async () => {
+    let callbacks: LiveSttCallbacks | undefined;
+    const sentSequences: number[] = [];
+    const events: LiveSessionEvent[] = [];
+    const fakeGemini = {
+      async translateText(text: string): Promise<string> {
+        assert.equal(text, 'Speaker: Bonjour.');
+        return '발화자: 안녕하세요.';
+      },
+    };
+    const fakeStream: LiveSttSession = {
+      provider: 'openai',
+      kind: 'translation',
+      sendPcm(frame) {
+        sentSequences.push(frame.sequence);
+      },
+      async close() {},
+    };
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => fakeGemini as unknown as GeminiService,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: () => ({ provider: 'openai', openaiApiKey: 'oa' }),
+      emitEvent: (event) => events.push(event),
+      createLiveSttSession: async (_config, cbs) => {
+        callbacks = cbs;
+        return fakeStream;
+      },
+    });
+
+    const session = await service.start({ title: 'Live', translate: true });
+    assert.equal(session.mode, 'streaming');
+    service.appendPcm({
+      sessionId: session.sessionId,
+      audioData: makeAudioBytes(),
+      sampleRate: 48_000,
+      channelCount: 1,
+      offsetMs: 0,
+      durationMs: 100,
+      sequence: 7,
+    });
+    callbacks?.onInterim({ text: 'Speaker: Bon', offsetMs: 500 });
+    callbacks?.onTranslationInterim?.({ text: '발화자: 안녕', offsetMs: 600 });
+    callbacks?.onFinal({
+      text: 'Speaker: Bonjour.',
+      offsetMs: 1_000,
+      durationMs: 800,
+      translation: '발화자: 안녕하세요.',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.deepEqual(sentSequences, [7]);
+    assert.equal(service.snapshot()?.interimTranscript, '');
+    assert.equal(service.snapshot()?.interimTranslation, '');
+    assert.match(service.snapshot()?.transcript ?? '', /Bonjour/);
+    assert.match(service.snapshot()?.translation ?? '', /안녕하세요/);
+    assert.ok(events.some((event) => event.type === 'interim' && /Bon/.test(event.text)));
+    assert.ok(
+      events.some((event) => event.type === 'translationInterim' && /안녕/.test(event.text)),
+    );
+    assert.ok(
+      events.some(
+        (event) =>
+          event.type === 'segment' && event.segment.translation?.includes('안녕하세요') === true,
+      ),
+    );
+  });
+
+  it('starts a Gemini Live stream in auto mode when a Gemini key is configured', async () => {
+    const fakeStream: LiveSttSession = {
+      provider: 'gemini',
+      kind: 'translation',
+      sendPcm() {},
+      async close() {},
+    };
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => null,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: () => ({ provider: 'auto', geminiApiKey: 'gemini-key' }),
+      createLiveSttSession: async () => fakeStream,
+    });
+
+    const session = await service.start({ title: 'Live', translate: true });
+
+    assert.equal(session.mode, 'streaming');
+    assert.equal(session.provider, 'gemini');
+  });
+
+  it('starts a renderer Realtime client when a client secret config is available', async () => {
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => null,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: () => ({ provider: 'openai' }),
+      createRealtimeClientConfig: async () => ({
+        transport: 'webrtc',
+        endpoint: 'translation',
+        clientSecret: 'ek_test',
+      }),
+      createLiveSttSession: async () => {
+        throw new Error('server stream should not be used');
+      },
+    });
+
+    const session = await service.start({ title: 'Live', translate: true });
+
+    assert.equal(session.mode, 'streaming');
+    assert.equal(session.provider, 'openai');
+    assert.equal(session.realtimeClient?.transport, 'webrtc');
+    assert.equal(session.realtimeClient?.endpoint, 'translation');
+  });
+
+  it('falls back to Gemini when OpenAI is selected but no OpenAI API key is available', async () => {
+    let streamConfig: unknown;
+    const fakeStream: LiveSttSession = {
+      provider: 'gemini',
+      kind: 'translation',
+      sendPcm() {},
+      async close() {},
+    };
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => null,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: () => ({
+        provider: 'openai',
+        geminiApiKey: 'gemini-key',
+      }),
+      createRealtimeClientConfig: async () => null,
+      createLiveSttSession: async (config) => {
+        if (config.provider === 'openai') throw new Error('OpenAI API key is not configured.');
+        streamConfig = config;
+        return fakeStream;
+      },
+    });
+
+    const session = await service.start({ title: 'Live', translate: true });
+
+    assert.equal(session.mode, 'streaming');
+    assert.equal(session.provider, 'gemini');
+    assert.equal(session.realtimeClient, undefined);
+    assert.equal((streamConfig as { provider?: string }).provider, 'gemini');
+  });
+
+  it('records OpenAI Realtime usage when a renderer Realtime session stops', async () => {
+    let now = Date.parse('2026-06-16T02:00:00.000Z');
+    const usage: RecordInput[] = [];
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => null,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: () => ({
+        provider: 'openai',
+        openaiLiveTranslationModel: 'gpt-realtime-translate',
+      }),
+      now: () => now,
+      recordUsage: (input) => {
+        usage.push(input);
+      },
+      createRealtimeClientConfig: async () => ({
+        transport: 'webrtc',
+        endpoint: 'translation',
+        clientSecret: 'ek_test',
+      }),
+    });
+
+    const session = await service.start({ title: 'Live', translate: true });
+    now += 90_000;
+    await service.stop(session.sessionId);
+
+    assert.equal(usage.length, 1);
+    assert.equal(usage[0].modelId, 'gpt-realtime-translate');
+    assert.equal(usage[0].kind, 'realtime');
+    assert.equal(usage[0].usage.audioSeconds, 90);
+  });
+
+  it('falls back from renderer Realtime to Gemini streaming when the WebRTC call fails', async () => {
+    let streamConfig: unknown;
+    const events: LiveSessionEvent[] = [];
+    const fakeStream: LiveSttSession = {
+      provider: 'gemini',
+      kind: 'translation',
+      sendPcm() {},
+      async close() {},
+    };
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => null,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: () => ({
+        provider: 'auto',
+        geminiApiKey: 'gemini-key',
+      }),
+      emitEvent: (event) => events.push(event),
+      createRealtimeClientConfig: async () => ({
+        transport: 'webrtc',
+        endpoint: 'translation',
+        clientSecret: 'ek_test',
+      }),
+      createLiveSttSession: async (config) => {
+        streamConfig = config;
+        return fakeStream;
+      },
+    });
+
+    const session = await service.start({ title: 'Live', translate: true });
+    const fallback = await service.fallbackFromRealtime({
+      sessionId: session.sessionId,
+      error: '500 Internal Server Error',
+    });
+
+    assert.equal(fallback.mode, 'streaming');
+    assert.equal(fallback.provider, 'gemini');
+    assert.equal(fallback.realtimeClient, undefined);
+    assert.equal((streamConfig as { provider?: string }).provider, 'gemini');
+    assert.ok(events.some((event) => event.type === 'error' && /500/.test(event.error)));
+    assert.ok(
+      events.some(
+        (event) => event.type === 'status' && /using gemini live transcription/i.test(event.status),
+      ),
+    );
+  });
+
+  it('records Gemini Live usage when a streaming provider session stops', async () => {
+    let now = Date.parse('2026-06-16T03:00:00.000Z');
+    const usage: RecordInput[] = [];
+    const fakeStream: LiveSttSession = {
+      provider: 'gemini',
+      kind: 'translation',
+      sendPcm() {},
+      async close() {},
+    };
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => null,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: () => ({ provider: 'auto', geminiApiKey: 'gemini-key' }),
+      now: () => now,
+      recordUsage: (input) => {
+        usage.push(input);
+      },
+      createLiveSttSession: async () => fakeStream,
+    });
+
+    const session = await service.start({ title: 'Live', translate: true });
+    now += 60_000;
+    await service.stop(session.sessionId);
+
+    assert.equal(usage.length, 1);
+    assert.equal(usage[0].modelId, 'gemini-3.5-live-translate-preview');
+    assert.equal(usage[0].kind, 'realtime');
+    assert.equal(usage[0].usage.audioSeconds, 60);
+  });
+
+  it('falls back to Gemini in auto mode when OpenAI WebRTC setup fails', async () => {
+    let streamConfig: unknown;
+    const fakeStream: LiveSttSession = {
+      provider: 'gemini',
+      kind: 'translation',
+      sendPcm() {},
+      async close() {},
+    };
+    const events: LiveSessionEvent[] = [];
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => null,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: () => ({
+        provider: 'auto',
+        openaiApiKey: 'oa',
+        geminiApiKey: 'gemini-key',
+      }),
+      emitEvent: (event) => events.push(event),
+      createRealtimeClientConfig: async () => {
+        throw new Error('client secret failed');
+      },
+      createLiveSttSession: async (config) => {
+        streamConfig = config;
+        return fakeStream;
+      },
+    });
+
+    const session = await service.start({ title: 'Live', translate: true });
+
+    assert.equal(session.mode, 'streaming');
+    assert.equal(session.provider, 'gemini');
+    assert.equal((streamConfig as { openaiApiKey?: string }).openaiApiKey, undefined);
+    assert.ok(events.some((event) => event.type === 'error' && /client secret/.test(event.error)));
+  });
+
+  it('surfaces OpenAI WebRTC setup failure when OpenAI is explicitly selected', async () => {
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => null,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: () => ({
+        provider: 'openai',
+        openaiApiKey: 'oa',
+        geminiApiKey: 'gemini-key',
+      }),
+      createRealtimeClientConfig: async () => {
+        throw new Error('client secret failed');
+      },
+      createLiveSttSession: async () => {
+        throw new Error('server stream should not be used');
+      },
+    });
+
+    await assert.rejects(() => service.start({ title: 'Live' }), /client secret failed/);
+  });
+
+  it('stores renderer Realtime interim and final transcript events', async () => {
+    const events: LiveSessionEvent[] = [];
+    const service = new LiveSessionService({
+      getDataPath: () => workDir,
+      ensureGeminiService: () => null,
+      getAgentService: () => null,
+      formatAiCredentialsError: () => 'missing credentials',
+      getLiveSttConfig: () => ({ provider: 'openai' }),
+      emitEvent: (event) => events.push(event),
+      createRealtimeClientConfig: async () => ({
+        transport: 'webrtc',
+        endpoint: 'translation',
+        clientSecret: 'ek_test',
+      }),
+    });
+
+    const session = await service.start({ title: 'Live', translate: true });
+    service.receiveInterim({
+      sessionId: session.sessionId,
+      text: 'Speaker: Bonjour',
+      offsetMs: 500,
+    });
+    service.receiveInterim({
+      sessionId: session.sessionId,
+      text: '발화자: 안녕하세요',
+      translation: true,
+      offsetMs: 700,
+    });
+    service.receiveFinalTranscript({
+      sessionId: session.sessionId,
+      text: 'Speaker: Bonjour.',
+      translation: '발화자: 안녕하세요.',
+      offsetMs: 1_000,
+      durationMs: 0,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const snapshot = service.snapshot();
+    assert.equal(snapshot?.interimTranscript, '');
+    assert.equal(snapshot?.interimTranslation, '');
+    assert.match(snapshot?.transcript ?? '', /Bonjour/);
+    assert.match(snapshot?.translation ?? '', /안녕하세요/);
+    assert.ok(events.some((event) => event.type === 'interim' && /Bonjour/.test(event.text)));
+    assert.ok(
+      events.some((event) => event.type === 'translationInterim' && /안녕하세요/.test(event.text)),
+    );
+    assert.ok(events.some((event) => event.type === 'segment'));
+  });
+});
+
+describe('GeminiService live snippets', () => {
+  it('does not apply knownWords to live snippet prompts and drops the no-speech sentinel', async () => {
+    const service = new GeminiService({
+      provider: 'gemini',
+      apiKey: 'test-key',
+      dataPath: workDir,
+      knownWords: ['에이슬립', '이동헌'],
+      proModel: 'gemini-test-pro',
+      flashModel: 'gemini-test-flash',
+    });
+    const originalTranscribeAudio = service.transcribeAudio.bind(service);
+    let seenOptions: TranscriptionOptions | undefined;
+    service.transcribeAudio = async (
+      ...args: Parameters<GeminiService['transcribeAudio']>
+    ): Promise<TranscriptionResult> => {
+      seenOptions = args[4];
+      return {
+        transcript: '[NO_SPEECH]',
+        summary: '',
+        keyPoints: [],
+        actionItems: [],
+        emoji: '',
+      };
+    };
+
+    try {
+      const result = await service.transcribeLiveSnippet('/tmp/fake-live.webm');
+
+      assert.equal(result, '');
+      assert.equal(seenOptions?.includeGlossary, false);
+      assert.doesNotMatch(seenOptions?.transcriptionPrompt ?? '', /에이슬립|이동헌/);
+      assert.match(seenOptions?.transcriptionPrompt ?? '', /NO_SPEECH/);
+    } finally {
+      service.transcribeAudio = originalTranscribeAudio;
+    }
+  });
+});

--- a/src/liveSessionService.ts
+++ b/src/liveSessionService.ts
@@ -157,6 +157,33 @@ function resolveLiveUsageModelId(
     : DEFAULT_GEMINI_LIVE_TRANSCRIPTION_MODEL;
 }
 
+const LIVE_TRANSLATION_LANGUAGE_NAMES: Record<string, string> = {
+  ko: 'Korean',
+  en: 'English',
+  ja: 'Japanese',
+  zh: 'Chinese',
+  es: 'Spanish',
+  fr: 'French',
+  de: 'German',
+  it: 'Italian',
+  pt: 'Portuguese',
+  ru: 'Russian',
+  vi: 'Vietnamese',
+  th: 'Thai',
+  id: 'Indonesian',
+  hi: 'Hindi',
+  ar: 'Arabic',
+};
+
+// The live translation target is stored as a BCP-47 code (e.g. `ja`) but the
+// chunked-fallback translator prompt reads better with a language name. Map
+// known codes to names and pass through anything already spelled out.
+function resolveLiveTranslationTarget(language: string | undefined): string {
+  const value = language?.trim();
+  if (!value) return 'Korean';
+  return LIVE_TRANSLATION_LANGUAGE_NAMES[value.toLowerCase()] ?? value;
+}
+
 export class LiveSessionService {
   private readonly opts: LiveSessionServiceOptions;
   private session: LiveSessionState | null = null;
@@ -282,10 +309,13 @@ export class LiveSessionService {
   async stop(sessionId: string): Promise<LiveSessionSnapshot | null> {
     const session = this.session;
     if (!session || session.id !== sessionId) return null;
-    session.active = false;
-    session.abortController.abort();
+    // Close the stream while the session is still active so streaming providers
+    // (Gemini Live, OpenAI translation) can flush their final transcript via
+    // onFinal -- handleFinalTranscript drops segments once active is false.
     await session.stream?.close().catch((err) => this.handleStreamError(session, err));
     session.stream = null;
+    session.active = false;
+    session.abortController.abort();
     this.recordLiveUsage(session);
     return this.snapshot();
   }
@@ -492,7 +522,9 @@ export class LiveSessionService {
         try {
           translation = (
             await geminiService.translateText(transcript, {
-              targetLanguage: 'Korean',
+              targetLanguage: resolveLiveTranslationTarget(
+                this.opts.getLiveSttConfig().translationLanguage,
+              ),
               signal: session.abortController.signal,
             })
           ).trim();
@@ -644,7 +676,9 @@ export class LiveSessionService {
     }
     try {
       const translation = await geminiService.translateText(transcript, {
-        targetLanguage: 'Korean',
+        targetLanguage: resolveLiveTranslationTarget(
+          this.opts.getLiveSttConfig().translationLanguage,
+        ),
         signal: session.abortController.signal,
       });
       if (this.session !== session || !session.active || session.abortController.signal.aborted)

--- a/src/liveSessionService.ts
+++ b/src/liveSessionService.ts
@@ -1,0 +1,696 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { extensionForMimeType } from './audioFormats';
+import type { AgentChatMessage, AgentRunResult, AgentService } from './agentService';
+import {
+  DEFAULT_GEMINI_LIVE_TRANSCRIPTION_MODEL,
+  DEFAULT_GEMINI_LIVE_TRANSLATION_MODEL,
+  DEFAULT_OPENAI_LIVE_TRANSCRIPTION_MODEL,
+  DEFAULT_OPENAI_LIVE_TRANSLATION_MODEL,
+} from './aiProvider';
+import type { GeminiService } from './geminiService';
+import {
+  createLiveSttSession,
+  type LiveSttProviderConfig,
+  type LiveSttSession,
+  type StreamingLiveSttProvider,
+} from './liveSttProvider';
+import { recordUsage, type RecordInput } from './services/usageTracker';
+
+export interface LiveTranscriptSegment {
+  id: string;
+  offsetMs: number;
+  durationMs: number;
+  transcript: string;
+  translation?: string;
+  translationError?: string;
+  final: boolean;
+  createdAt: string;
+}
+
+export interface LiveSessionStartResult {
+  sessionId: string;
+  title: string;
+  startedAt: string;
+  translate: boolean;
+  mode: 'streaming' | 'chunked';
+  provider: StreamingLiveSttProvider | 'chunked';
+  realtimeClient?: LiveRealtimeClientConfig;
+}
+
+export interface LiveSessionSnapshot {
+  sessionId: string;
+  title: string;
+  startedAt: string;
+  active: boolean;
+  translate: boolean;
+  mode: 'streaming' | 'chunked';
+  provider: StreamingLiveSttProvider | 'chunked';
+  segments: LiveTranscriptSegment[];
+  interimTranscript: string;
+  interimTranslation: string;
+  transcript: string;
+  translation: string;
+}
+
+export type LiveSessionEvent =
+  | {
+      type: 'status';
+      sessionId: string;
+      status: string;
+      mode?: 'streaming' | 'chunked';
+      provider?: StreamingLiveSttProvider | 'chunked';
+    }
+  | { type: 'interim'; sessionId: string; text: string; offsetMs?: number }
+  | { type: 'translationInterim'; sessionId: string; text: string; offsetMs?: number }
+  | { type: 'segment'; sessionId: string; segment: LiveTranscriptSegment }
+  | { type: 'error'; sessionId: string; error: string };
+
+export interface LiveRealtimeClientConfig {
+  transport: 'webrtc';
+  endpoint: 'realtime' | 'translation';
+  clientSecret: string;
+}
+
+export interface LiveSessionServiceOptions {
+  getDataPath(): string;
+  ensureGeminiService(): GeminiService | null;
+  getAgentService(): AgentService | null;
+  formatAiCredentialsError(): string;
+  getLiveSttConfig(): LiveSttProviderConfig;
+  emitEvent?(event: LiveSessionEvent): void;
+  createLiveSttSession?(
+    config: LiveSttProviderConfig,
+    callbacks: Parameters<typeof createLiveSttSession>[1],
+  ): Promise<LiveSttSession | null>;
+  createRealtimeClientConfig?(
+    config: LiveSttProviderConfig,
+  ): Promise<LiveRealtimeClientConfig | null>;
+  recordUsage?(input: RecordInput): void;
+  now?(): number;
+}
+
+type LiveSessionState = {
+  id: string;
+  title: string;
+  startedAt: string;
+  active: boolean;
+  translate: boolean;
+  mode: 'streaming' | 'chunked';
+  provider: StreamingLiveSttProvider | 'chunked';
+  abortController: AbortController;
+  nextSegmentId: number;
+  segments: LiveTranscriptSegment[];
+  interimTranscript: string;
+  interimTranslation: string;
+  stream: LiveSttSession | null;
+  realtimeClient: LiveRealtimeClientConfig | null;
+  usageModelId: string | null;
+  usageRecorded: boolean;
+};
+
+function asBuffer(data: ArrayBuffer | Uint8Array): Buffer {
+  if (data instanceof Uint8Array) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  }
+  return Buffer.from(data);
+}
+
+function cleanTranscript(text: string): string {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join('\n\n')
+    .trim();
+}
+
+function isAbortError(error: unknown): boolean {
+  if (error && typeof error === 'object' && 'name' in error) {
+    return (error as { name?: unknown }).name === 'AbortError';
+  }
+  return false;
+}
+
+function joinSegments(
+  segments: LiveTranscriptSegment[],
+  field: 'transcript' | 'translation',
+): string {
+  return segments
+    .map((s) => s[field]?.trim() ?? '')
+    .filter((text) => text.length > 0)
+    .join('\n\n');
+}
+
+function resolveLiveUsageModelId(
+  config: LiveSttProviderConfig,
+  provider: StreamingLiveSttProvider,
+  kind: 'transcription' | 'translation',
+): string {
+  if (provider === 'openai') {
+    return kind === 'translation'
+      ? config.openaiLiveTranslationModel || DEFAULT_OPENAI_LIVE_TRANSLATION_MODEL
+      : config.openaiLiveTranscriptionModel || DEFAULT_OPENAI_LIVE_TRANSCRIPTION_MODEL;
+  }
+  return kind === 'translation'
+    ? DEFAULT_GEMINI_LIVE_TRANSLATION_MODEL
+    : DEFAULT_GEMINI_LIVE_TRANSCRIPTION_MODEL;
+}
+
+export class LiveSessionService {
+  private readonly opts: LiveSessionServiceOptions;
+  private session: LiveSessionState | null = null;
+
+  constructor(opts: LiveSessionServiceOptions) {
+    this.opts = opts;
+  }
+
+  async start(
+    input: { title?: string; translate?: boolean } = {},
+  ): Promise<LiveSessionStartResult> {
+    const previous = this.session;
+    previous?.abortController.abort();
+    await previous?.stream?.close().catch(() => {});
+    if (previous) this.recordLiveUsage(previous);
+    const startedAt = new Date(this.opts.now?.() ?? Date.now()).toISOString();
+    const session: LiveSessionState = {
+      id: `live_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+      title: input.title?.trim() || 'Live Session',
+      startedAt,
+      active: true,
+      translate: input.translate !== false,
+      mode: 'chunked',
+      provider: 'chunked',
+      abortController: new AbortController(),
+      nextSegmentId: 0,
+      segments: [],
+      interimTranscript: '',
+      interimTranslation: '',
+      stream: null,
+      realtimeClient: null,
+      usageModelId: null,
+      usageRecorded: false,
+    };
+    this.session = session;
+    let config = { ...this.opts.getLiveSttConfig(), translate: session.translate };
+    if (config.provider !== 'chunked' && this.opts.createRealtimeClientConfig) {
+      try {
+        session.realtimeClient = await this.opts.createRealtimeClientConfig(config);
+      } catch (error) {
+        if (config.provider === 'openai') throw error;
+        if (config.provider === 'auto') {
+          // Realtime client-secret/WebRTC is the supported OpenAI live path.
+          // If it fails in auto mode, continue to Gemini or chunked fallback
+          // instead of trying the lower-level OpenAI WebSocket fallback.
+          config = { ...config, openaiApiKey: undefined };
+        }
+        this.handleStreamError(session, error);
+      }
+    }
+    if (!session.realtimeClient) {
+      try {
+        await this.startStreamingProvider(session, config);
+      } catch (error) {
+        const recovered = await this.tryProviderFallbackAfterStartFailure(session, config, error);
+        if (!recovered) throw error;
+      }
+    } else {
+      this.setRealtimeProvider(session, config);
+    }
+    this.emit({
+      type: 'status',
+      sessionId: session.id,
+      status:
+        session.mode === 'streaming'
+          ? `Listening with ${session.provider} live transcription...`
+          : 'Listening with chunked fallback transcription...',
+      mode: session.mode,
+      provider: session.provider,
+    });
+    return this.startResult(session);
+  }
+
+  async fallbackFromRealtime(input: {
+    sessionId: string;
+    error?: string;
+  }): Promise<LiveSessionStartResult> {
+    const session = this.session;
+    if (!session || session.id !== input.sessionId)
+      throw new Error('Live session is no longer active.');
+    if (!session.active || session.abortController.signal.aborted)
+      throw new Error('Live session is no longer active.');
+    if (!session.realtimeClient) return this.startResult(session);
+
+    session.realtimeClient = null;
+    session.usageModelId = null;
+    if (input.error?.trim()) {
+      this.handleStreamError(session, new Error(`OpenAI Realtime WebRTC failed: ${input.error}`));
+    }
+
+    const baseConfig = { ...this.opts.getLiveSttConfig(), translate: session.translate };
+    for (const config of this.buildRealtimeFallbackConfigs(baseConfig)) {
+      try {
+        await this.startStreamingProvider(session, config);
+        if (session.stream) {
+          this.emit({
+            type: 'status',
+            sessionId: session.id,
+            status: `OpenAI Realtime unavailable; using ${session.provider} live transcription.`,
+            mode: session.mode,
+            provider: session.provider,
+          });
+          return this.startResult(session);
+        }
+      } catch (error) {
+        this.handleStreamError(session, error);
+      }
+    }
+
+    session.mode = 'chunked';
+    session.provider = 'chunked';
+    session.usageModelId = null;
+    this.emit({
+      type: 'status',
+      sessionId: session.id,
+      status: 'OpenAI Realtime unavailable; using chunked fallback transcription.',
+      mode: session.mode,
+      provider: session.provider,
+    });
+    return this.startResult(session);
+  }
+
+  async stop(sessionId: string): Promise<LiveSessionSnapshot | null> {
+    const session = this.session;
+    if (!session || session.id !== sessionId) return null;
+    session.active = false;
+    session.abortController.abort();
+    await session.stream?.close().catch((err) => this.handleStreamError(session, err));
+    session.stream = null;
+    this.recordLiveUsage(session);
+    return this.snapshot();
+  }
+
+  snapshot(): LiveSessionSnapshot | null {
+    const session = this.session;
+    if (!session) return null;
+    const segments = [...session.segments].sort((a, b) => a.offsetMs - b.offsetMs);
+    return {
+      sessionId: session.id,
+      title: session.title,
+      startedAt: session.startedAt,
+      active: session.active,
+      translate: session.translate,
+      mode: session.mode,
+      provider: session.provider,
+      segments,
+      interimTranscript: session.interimTranscript,
+      interimTranslation: session.interimTranslation,
+      transcript: joinSegments(segments, 'transcript'),
+      translation: joinSegments(segments, 'translation'),
+    };
+  }
+
+  appendPcm(input: {
+    sessionId: string;
+    audioData: ArrayBuffer | Uint8Array;
+    sampleRate: number;
+    channelCount: number;
+    offsetMs: number;
+    durationMs: number;
+    sequence: number;
+  }): void {
+    const session = this.session;
+    if (!session || session.id !== input.sessionId || !session.active || !session.stream) return;
+    session.stream.sendPcm(input);
+  }
+
+  private async startStreamingProvider(
+    session: LiveSessionState,
+    config: LiveSttProviderConfig,
+  ): Promise<void> {
+    const createSession = this.opts.createLiveSttSession ?? createLiveSttSession;
+    session.stream = await createSession(config, {
+      onStatus: (status) => this.emit({ type: 'status', sessionId: session.id, status }),
+      onInterim: (event) => this.handleInterim(session, event),
+      onTranslationInterim: (event) => this.handleTranslationInterim(session, event),
+      onFinal: (event) => {
+        void this.handleFinalTranscript(session, event);
+      },
+      onError: (error) => this.handleStreamError(session, error),
+    });
+    if (!session.stream) return;
+    session.mode = 'streaming';
+    session.provider = session.stream.provider;
+    session.usageModelId = resolveLiveUsageModelId(config, session.provider, session.stream.kind);
+  }
+
+  private setRealtimeProvider(session: LiveSessionState, config: LiveSttProviderConfig): void {
+    if (!session.realtimeClient) return;
+    session.mode = 'streaming';
+    session.provider = 'openai';
+    const kind =
+      session.realtimeClient.endpoint === 'translation' ? 'translation' : 'transcription';
+    session.usageModelId = resolveLiveUsageModelId(config, session.provider, kind);
+  }
+
+  private buildRealtimeFallbackConfigs(config: LiveSttProviderConfig): LiveSttProviderConfig[] {
+    const configs: LiveSttProviderConfig[] = [];
+    if (config.openaiApiKey?.trim()) {
+      configs.push({ ...config, provider: 'openai' });
+    }
+    if (config.geminiApiKey?.trim()) {
+      configs.push({ ...config, provider: 'gemini', openaiApiKey: undefined });
+    }
+    return configs;
+  }
+
+  private async tryProviderFallbackAfterStartFailure(
+    session: LiveSessionState,
+    config: LiveSttProviderConfig,
+    error: unknown,
+  ): Promise<boolean> {
+    const fallbackConfigs = this.buildRealtimeFallbackConfigs({
+      ...config,
+      openaiApiKey: undefined,
+    });
+    if (fallbackConfigs.length === 0) return false;
+
+    this.handleStreamError(session, error);
+    for (const fallbackConfig of fallbackConfigs) {
+      try {
+        await this.startStreamingProvider(session, fallbackConfig);
+        if (session.stream) {
+          this.emit({
+            type: 'status',
+            sessionId: session.id,
+            status: `OpenAI live provider unavailable; using ${session.provider} live transcription.`,
+            mode: session.mode,
+            provider: session.provider,
+          });
+          return true;
+        }
+      } catch (fallbackError) {
+        this.handleStreamError(session, fallbackError);
+      }
+    }
+    return false;
+  }
+
+  private startResult(session: LiveSessionState): LiveSessionStartResult {
+    return {
+      sessionId: session.id,
+      title: session.title,
+      startedAt: session.startedAt,
+      translate: session.translate,
+      mode: session.mode,
+      provider: session.provider,
+      realtimeClient: session.realtimeClient ?? undefined,
+    };
+  }
+
+  setTranslate(sessionId: string, translate: boolean): LiveSessionSnapshot | null {
+    const session = this.session;
+    if (!session || session.id !== sessionId) return null;
+    session.translate = translate;
+    return this.snapshot();
+  }
+
+  receiveInterim(input: {
+    sessionId: string;
+    text: string;
+    translation?: boolean;
+    offsetMs?: number;
+  }): void {
+    const session = this.session;
+    if (!session || session.id !== input.sessionId || !session.active) return;
+    if (input.translation) {
+      this.handleTranslationInterim(session, {
+        text: input.text,
+        offsetMs: input.offsetMs,
+      });
+      return;
+    }
+    this.handleInterim(session, {
+      text: input.text,
+      offsetMs: input.offsetMs,
+    });
+  }
+
+  receiveFinalTranscript(input: {
+    sessionId: string;
+    text: string;
+    offsetMs?: number;
+    durationMs?: number;
+    translation?: string;
+  }): void {
+    const session = this.session;
+    if (!session || session.id !== input.sessionId || !session.active) return;
+    void this.handleFinalTranscript(session, {
+      text: input.text,
+      offsetMs: input.offsetMs,
+      durationMs: input.durationMs,
+      translation: input.translation,
+    });
+  }
+
+  async processAudioChunk(input: {
+    sessionId: string;
+    audioData: ArrayBuffer | Uint8Array;
+    mimeType: string;
+    offsetMs: number;
+    durationMs: number;
+    translate?: boolean;
+  }): Promise<LiveTranscriptSegment | null> {
+    const session = this.session;
+    if (!session || session.id !== input.sessionId)
+      throw new Error('Live session is no longer active.');
+    if (!session.active || session.abortController.signal.aborted) return null;
+    const geminiService = this.opts.ensureGeminiService();
+    if (!geminiService) {
+      throw new Error(this.opts.formatAiCredentialsError());
+    }
+
+    const buffer = asBuffer(input.audioData);
+    if (buffer.byteLength < 512) return null;
+
+    const tempPath = await this.writeTempSnippet(session, input.mimeType, buffer);
+    try {
+      if (!session.active || session.abortController.signal.aborted) return null;
+      const transcript = cleanTranscript(
+        await geminiService.transcribeLiveSnippet(tempPath, {
+          signal: session.abortController.signal,
+        }),
+      );
+      if (!transcript) return null;
+      if (this.session !== session) throw new Error('Live session was replaced.');
+      if (!session.active || session.abortController.signal.aborted) return null;
+
+      let translation: string | undefined;
+      let translationError: string | undefined;
+      session.translate = input.translate !== false;
+      if (input.translate !== false) {
+        try {
+          translation = (
+            await geminiService.translateText(transcript, {
+              targetLanguage: 'Korean',
+              signal: session.abortController.signal,
+            })
+          ).trim();
+        } catch (err) {
+          if (isAbortError(err) || !session.active || session.abortController.signal.aborted) {
+            return null;
+          }
+          translationError = err instanceof Error ? err.message : String(err);
+        }
+      }
+      if (!session.active || session.abortController.signal.aborted) return null;
+
+      const segment: LiveTranscriptSegment = {
+        id: `${session.id}_${++session.nextSegmentId}`,
+        offsetMs: Math.max(0, Math.floor(input.offsetMs)),
+        durationMs: Math.max(0, Math.floor(input.durationMs)),
+        transcript,
+        translation: translation || undefined,
+        translationError,
+        final: true,
+        createdAt: new Date().toISOString(),
+      };
+      session.segments.push(segment);
+      session.segments.sort((a, b) => a.offsetMs - b.offsetMs);
+      this.emit({ type: 'segment', sessionId: session.id, segment });
+      return segment;
+    } catch (err) {
+      if (isAbortError(err) || !session.active || session.abortController.signal.aborted) {
+        return null;
+      }
+      throw err;
+    } finally {
+      await fs.promises.unlink(tempPath).catch(() => {});
+    }
+  }
+
+  async ask(input: {
+    sessionId: string;
+    question: string;
+    history?: AgentChatMessage[];
+  }): Promise<AgentRunResult> {
+    const session = this.session;
+    if (!session || session.id !== input.sessionId) {
+      throw new Error('Live session is no longer active.');
+    }
+    const question = input.question.trim();
+    if (!question) throw new Error('Empty question.');
+    const snapshot = this.snapshot();
+    const liveText = [
+      snapshot?.transcript,
+      snapshot?.interimTranscript,
+      snapshot?.translation,
+      snapshot?.interimTranslation,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+    if (!snapshot || !liveText.trim()) {
+      throw new Error('No live transcript is available yet.');
+    }
+    const agent = this.opts.getAgentService();
+    if (!agent) {
+      throw new Error(this.opts.formatAiCredentialsError());
+    }
+    return await agent.run({
+      question,
+      history: Array.isArray(input.history) ? input.history : [],
+      scope: {
+        kind: 'live',
+        title: snapshot.title,
+        transcript: snapshot.transcript || '(no finalized transcript yet)',
+        interimTranscript: snapshot.interimTranscript || undefined,
+        interimTranslation: snapshot.interimTranslation || undefined,
+        translation:
+          [snapshot.translation, snapshot.interimTranslation].filter(Boolean).join('\n\n') ||
+          undefined,
+      },
+    });
+  }
+
+  private emit(event: LiveSessionEvent): void {
+    this.opts.emitEvent?.(event);
+  }
+
+  private handleInterim(
+    session: LiveSessionState,
+    event: { text: string; itemId?: string; offsetMs?: number },
+  ): void {
+    if (this.session !== session || !session.active || !event.text.trim()) return;
+    session.interimTranscript = event.text.trim();
+    this.emit({
+      type: 'interim',
+      sessionId: session.id,
+      text: session.interimTranscript,
+      offsetMs: event.offsetMs,
+    });
+  }
+
+  private handleTranslationInterim(
+    session: LiveSessionState,
+    event: { text: string; itemId?: string; offsetMs?: number },
+  ): void {
+    if (this.session !== session || !session.active || !event.text.trim()) return;
+    session.interimTranslation = event.text.trim();
+    this.emit({
+      type: 'translationInterim',
+      sessionId: session.id,
+      text: session.interimTranslation,
+      offsetMs: event.offsetMs,
+    });
+  }
+
+  private async handleFinalTranscript(
+    session: LiveSessionState,
+    event: {
+      text: string;
+      itemId?: string;
+      offsetMs?: number;
+      durationMs?: number;
+      translation?: string;
+    },
+  ): Promise<void> {
+    const transcript = cleanTranscript(event.text);
+    if (this.session !== session || !session.active || !transcript) return;
+    session.interimTranscript = '';
+    session.interimTranslation = '';
+    const segment: LiveTranscriptSegment = {
+      id: `${session.id}_${++session.nextSegmentId}`,
+      offsetMs:
+        typeof event.offsetMs === 'number'
+          ? Math.max(0, Math.floor(event.offsetMs))
+          : Math.max(0, Date.now() - new Date(session.startedAt).getTime()),
+      durationMs:
+        typeof event.durationMs === 'number' ? Math.max(0, Math.floor(event.durationMs)) : 0,
+      transcript,
+      translation: event.translation?.trim() || undefined,
+      final: true,
+      createdAt: new Date().toISOString(),
+    };
+    session.segments.push(segment);
+    session.segments.sort((a, b) => a.offsetMs - b.offsetMs);
+    this.emit({ type: 'segment', sessionId: session.id, segment });
+
+    if (!session.active || !session.translate || segment.translation) return;
+    const geminiService = this.opts.ensureGeminiService();
+    if (!geminiService) {
+      segment.translationError = this.opts.formatAiCredentialsError();
+      this.emit({ type: 'segment', sessionId: session.id, segment });
+      return;
+    }
+    try {
+      const translation = await geminiService.translateText(transcript, {
+        targetLanguage: 'Korean',
+        signal: session.abortController.signal,
+      });
+      if (this.session !== session || !session.active || session.abortController.signal.aborted)
+        return;
+      segment.translation = translation.trim() || undefined;
+    } catch (err) {
+      if (isAbortError(err) || !session.active || session.abortController.signal.aborted) return;
+      segment.translationError = err instanceof Error ? err.message : String(err);
+    }
+    this.emit({ type: 'segment', sessionId: session.id, segment });
+  }
+
+  private handleStreamError(session: LiveSessionState, error: unknown): void {
+    if (this.session !== session || !session.active || isAbortError(error)) return;
+    const message = error instanceof Error ? error.message : String(error);
+    this.emit({ type: 'error', sessionId: session.id, error: message });
+  }
+
+  private recordLiveUsage(session: LiveSessionState): void {
+    if (session.usageRecorded) return;
+    session.usageRecorded = true;
+    if (session.mode !== 'streaming' || !session.usageModelId) return;
+    const startedAt = Date.parse(session.startedAt);
+    if (!Number.isFinite(startedAt)) return;
+    const now = this.opts.now?.() ?? Date.now();
+    const audioSeconds = Math.max(0, (now - startedAt) / 1000);
+    if (audioSeconds <= 0) return;
+    const writeUsage = this.opts.recordUsage ?? recordUsage;
+    writeUsage({
+      modelId: session.usageModelId,
+      kind: 'realtime',
+      usage: { audioSeconds },
+      timestamp: new Date(now).toISOString(),
+    });
+  }
+
+  private async writeTempSnippet(
+    session: LiveSessionState,
+    mimeType: string,
+    buffer: Buffer,
+  ): Promise<string> {
+    const dir = path.join(this.opts.getDataPath(), 'live-snippets');
+    await fs.promises.mkdir(dir, { recursive: true });
+    const ext = extensionForMimeType(mimeType || 'audio/webm');
+    const filePath = path.join(dir, `.${session.id}-${Date.now()}-${session.nextSegmentId}.${ext}`);
+    await fs.promises.writeFile(filePath, buffer);
+    return filePath;
+  }
+}

--- a/src/liveSttProvider.ts
+++ b/src/liveSttProvider.ts
@@ -309,8 +309,29 @@ class OpenAiRealtimeTranscriptionSession implements LiveSttSession {
   async close(): Promise<void> {
     this.closed = true;
     clearInterval(this.commitTimer);
+    const hadUncommitted = this.hasUncommittedAudio;
     this.commit();
-    await closeAfterDelay(this.ws, 500);
+    if (hadUncommitted) {
+      // Wait for the final committed window to transcribe (the message handler
+      // emits it via onFinal) instead of racing a fixed 500ms timer.
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, 2_000);
+        const onMessage = (data: RawData) => {
+          try {
+            const payload = JSON.parse(parseMessageData(data)) as { type?: string };
+            if (payload.type === 'conversation.item.input_audio_transcription.completed') {
+              clearTimeout(timer);
+              this.ws.off('message', onMessage);
+              resolve();
+            }
+          } catch {
+            // ignore
+          }
+        };
+        this.ws.on('message', onMessage);
+      });
+    }
+    await closeAfterDelay(this.ws, 0);
   }
 }
 

--- a/src/liveSttProvider.ts
+++ b/src/liveSttProvider.ts
@@ -1,0 +1,578 @@
+import { GoogleGenAI, Modality, type LiveServerMessage, type Session } from '@google/genai';
+import WebSocket, { type RawData } from 'ws';
+import {
+  DEFAULT_GEMINI_LIVE_TRANSCRIPTION_MODEL,
+  DEFAULT_GEMINI_LIVE_TRANSLATION_MODEL,
+  DEFAULT_OPENAI_LIVE_TRANSCRIPTION_MODEL,
+  DEFAULT_OPENAI_LIVE_TRANSLATION_MODEL,
+  DEFAULT_OPENAI_REALTIME_SESSION_MODEL,
+  type LiveSttProvider,
+} from './aiProvider';
+
+export type StreamingLiveSttProvider = 'openai' | 'gemini';
+
+export interface LiveSttProviderConfig {
+  provider: LiveSttProvider;
+  openaiApiKey?: string;
+  geminiApiKey?: string;
+  openaiLiveTranscriptionModel?: string;
+  openaiLiveTranslationModel?: string;
+  language?: string;
+  translationLanguage?: string;
+  translate?: boolean;
+}
+
+export interface LiveSttPcmFrame {
+  audioData: ArrayBuffer | Uint8Array;
+  sampleRate: number;
+  channelCount: number;
+  offsetMs: number;
+  durationMs: number;
+  sequence: number;
+}
+
+export interface LiveSttCallbacks {
+  onStatus?(status: string): void;
+  onInterim(event: { text: string; itemId?: string; offsetMs?: number }): void;
+  onTranslationInterim?(event: { text: string; itemId?: string; offsetMs?: number }): void;
+  onFinal(event: {
+    text: string;
+    itemId?: string;
+    offsetMs?: number;
+    durationMs?: number;
+    translation?: string;
+  }): void;
+  onError(error: Error): void;
+}
+
+export interface LiveSttSession {
+  readonly provider: StreamingLiveSttProvider;
+  readonly kind: 'transcription' | 'translation';
+  sendPcm(frame: LiveSttPcmFrame): void;
+  close(): Promise<void>;
+}
+
+const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime';
+const OPENAI_TRANSLATION_URL = 'wss://api.openai.com/v1/realtime/translations';
+const OPENAI_PCM_RATE = 24_000;
+const GEMINI_PCM_RATE = 16_000;
+
+export function resolveStreamingProvider(
+  config: LiveSttProviderConfig,
+): StreamingLiveSttProvider | null {
+  if (config.provider === 'chunked') return null;
+  if (config.provider === 'openai') {
+    if (!config.openaiApiKey?.trim()) throw new Error('OpenAI API key is not configured.');
+    return 'openai';
+  }
+  if (config.provider === 'gemini') {
+    if (!config.geminiApiKey?.trim()) throw new Error('Gemini API key is not configured.');
+    return 'gemini';
+  }
+  if (config.openaiApiKey?.trim()) return 'openai';
+  if (config.geminiApiKey?.trim()) return 'gemini';
+  return null;
+}
+
+function asUint8Array(data: ArrayBuffer | Uint8Array): Uint8Array {
+  if (data instanceof Uint8Array) return data;
+  return new Uint8Array(data);
+}
+
+function waitForOpen(ws: WebSocket, timeoutMs = 8_000): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('Timed out connecting to OpenAI Realtime.'));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off('open', handleOpen);
+      ws.off('error', handleError);
+      ws.off('close', handleClose);
+    };
+    const handleOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const handleError = () => {
+      cleanup();
+      reject(new Error('Could not connect to OpenAI Realtime.'));
+    };
+    const handleClose = () => {
+      cleanup();
+      reject(new Error('OpenAI Realtime closed before connecting.'));
+    };
+    ws.once('open', handleOpen);
+    ws.once('error', handleError);
+    ws.once('close', handleClose);
+  });
+}
+
+function parseMessageData(data: unknown): string {
+  if (typeof data === 'string') return data;
+  if (Array.isArray(data)) return Buffer.concat(data).toString('utf8');
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString('utf8');
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString('utf8');
+  }
+  return String(data);
+}
+
+function sendJson(ws: WebSocket, value: unknown): void {
+  if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(value));
+}
+
+function closeAfterDelay(ws: WebSocket, delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    if (ws.readyState === WebSocket.CLOSED) {
+      resolve();
+      return;
+    }
+    const timeout = setTimeout(done, 1_500);
+    const closeTimer = setTimeout(() => {
+      try {
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+          ws.close();
+        }
+      } catch {
+        done();
+      }
+    }, delayMs);
+    function done() {
+      clearTimeout(timeout);
+      clearTimeout(closeTimer);
+      ws.off('close', done);
+      ws.off('error', done);
+      resolve();
+    }
+    ws.once('close', done);
+    ws.once('error', done);
+  });
+}
+
+function downsamplePcm16(input: Uint8Array, inputRate: number, outputRate: number): Uint8Array {
+  if (inputRate === outputRate) return input;
+  if (input.byteLength < 2) return input;
+  const source = new Int16Array(input.buffer, input.byteOffset, Math.floor(input.byteLength / 2));
+  const ratio = inputRate / outputRate;
+  const outputLength = Math.max(1, Math.floor(source.length / ratio));
+  const output = new Int16Array(outputLength);
+  for (let i = 0; i < outputLength; i++) {
+    const start = Math.floor(i * ratio);
+    const end = Math.min(source.length, Math.floor((i + 1) * ratio));
+    let sum = 0;
+    let count = 0;
+    for (let j = start; j < end; j++) {
+      sum += source[j] ?? 0;
+      count++;
+    }
+    output[i] = Math.max(-32768, Math.min(32767, Math.round(sum / Math.max(1, count))));
+  }
+  return new Uint8Array(output.buffer);
+}
+
+function pcmFrameToOpenAiBase64(frame: LiveSttPcmFrame): string {
+  const pcm = downsamplePcm16(asUint8Array(frame.audioData), frame.sampleRate, OPENAI_PCM_RATE);
+  return Buffer.from(pcm.buffer, pcm.byteOffset, pcm.byteLength).toString('base64');
+}
+
+function pcmFrameToGeminiBase64(frame: LiveSttPcmFrame): string {
+  const pcm = downsamplePcm16(asUint8Array(frame.audioData), frame.sampleRate, GEMINI_PCM_RATE);
+  return Buffer.from(pcm.buffer, pcm.byteOffset, pcm.byteLength).toString('base64');
+}
+
+function openAiRealtimeWebSocket(url: string, apiKey: string): WebSocket {
+  return new WebSocket(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey.trim()}`,
+      'OpenAI-Safety-Identifier': 'listener-ai-local',
+    },
+  });
+}
+
+function mergeTranscriptText(current: string, next: string | undefined): string {
+  const text = next?.trim();
+  if (!text) return current;
+  if (!current) return text;
+  if (text.startsWith(current)) return text;
+  if (current.endsWith(text)) return current;
+  return `${current}${text.startsWith(' ') ? '' : ' '}${text}`.trim();
+}
+
+class OpenAiRealtimeTranscriptionSession implements LiveSttSession {
+  readonly provider = 'openai' as const;
+  readonly kind = 'transcription' as const;
+  private readonly ws: WebSocket;
+  private readonly commitTimer: NodeJS.Timeout;
+  private readonly itemText = new Map<string, string>();
+  private hasUncommittedAudio = false;
+  private closed = false;
+
+  private constructor(ws: WebSocket, callbacks: LiveSttCallbacks) {
+    this.ws = ws;
+    this.commitTimer = setInterval(() => this.commit(), 2_000);
+    ws.on('message', (data: RawData) => {
+      try {
+        const payload = JSON.parse(parseMessageData(data)) as {
+          type?: string;
+          item_id?: string;
+          delta?: string;
+          transcript?: string;
+          error?: { message?: string };
+        };
+        if (payload.type === 'error') {
+          callbacks.onError(
+            new Error(payload.error?.message || 'OpenAI Realtime transcription error.'),
+          );
+          return;
+        }
+        if (payload.type === 'conversation.item.input_audio_transcription.delta') {
+          const itemId = payload.item_id || 'current';
+          const text = `${this.itemText.get(itemId) ?? ''}${payload.delta ?? ''}`.trim();
+          this.itemText.set(itemId, text);
+          if (text) callbacks.onInterim({ text, itemId });
+          return;
+        }
+        if (payload.type === 'conversation.item.input_audio_transcription.completed') {
+          const itemId = payload.item_id || `item_${Date.now()}`;
+          const text = (payload.transcript || this.itemText.get(itemId) || '').trim();
+          this.itemText.delete(itemId);
+          if (text) callbacks.onFinal({ text, itemId });
+        }
+      } catch (err) {
+        callbacks.onError(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+    ws.on('close', () => {
+      if (!this.closed) callbacks.onError(new Error('OpenAI Realtime transcription disconnected.'));
+    });
+    ws.on('error', () => {
+      callbacks.onError(new Error('OpenAI Realtime transcription connection failed.'));
+    });
+  }
+
+  static async create(
+    config: LiveSttProviderConfig,
+    callbacks: LiveSttCallbacks,
+  ): Promise<OpenAiRealtimeTranscriptionSession> {
+    const transcriptionModel =
+      config.openaiLiveTranscriptionModel || DEFAULT_OPENAI_LIVE_TRANSCRIPTION_MODEL;
+    const ws = openAiRealtimeWebSocket(
+      `${OPENAI_REALTIME_URL}?model=${encodeURIComponent(DEFAULT_OPENAI_REALTIME_SESSION_MODEL)}`,
+      config.openaiApiKey ?? '',
+    );
+    await waitForOpen(ws);
+    sendJson(ws, {
+      type: 'session.update',
+      session: {
+        type: 'transcription',
+        audio: {
+          input: {
+            format: { type: 'audio/pcm', rate: OPENAI_PCM_RATE },
+            transcription: {
+              model: transcriptionModel,
+              ...(config.language?.trim() ? { language: config.language.trim() } : {}),
+              delay: 'low',
+            },
+            turn_detection: null,
+          },
+        },
+      },
+    });
+    callbacks.onStatus?.('Connected to OpenAI Realtime transcription.');
+    return new OpenAiRealtimeTranscriptionSession(ws, callbacks);
+  }
+
+  sendPcm(frame: LiveSttPcmFrame): void {
+    if (frame.channelCount !== 1) return;
+    const audio = pcmFrameToOpenAiBase64(frame);
+    if (!audio) return;
+    this.hasUncommittedAudio = true;
+    sendJson(this.ws, { type: 'input_audio_buffer.append', audio });
+  }
+
+  private commit(): void {
+    if (!this.hasUncommittedAudio) return;
+    this.hasUncommittedAudio = false;
+    sendJson(this.ws, { type: 'input_audio_buffer.commit' });
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    clearInterval(this.commitTimer);
+    this.commit();
+    await closeAfterDelay(this.ws, 500);
+  }
+}
+
+class OpenAiRealtimeTranslationSession implements LiveSttSession {
+  readonly provider = 'openai' as const;
+  readonly kind = 'translation' as const;
+  private readonly ws: WebSocket;
+  private readonly callbacks: LiveSttCallbacks;
+  private inputTranscript = '';
+  private outputTranscript = '';
+  private finalEmitted = false;
+  private closed = false;
+
+  private constructor(ws: WebSocket, callbacks: LiveSttCallbacks) {
+    this.ws = ws;
+    this.callbacks = callbacks;
+    ws.on('message', (data: RawData) => {
+      try {
+        const payload = JSON.parse(parseMessageData(data)) as {
+          type?: string;
+          delta?: string;
+          error?: { message?: string };
+        };
+        if (payload.type === 'error') {
+          callbacks.onError(
+            new Error(payload.error?.message || 'OpenAI Realtime translation error.'),
+          );
+          return;
+        }
+        if (payload.type === 'session.input_transcript.delta') {
+          this.inputTranscript = `${this.inputTranscript}${payload.delta ?? ''}`.trim();
+          if (this.inputTranscript) callbacks.onInterim({ text: this.inputTranscript });
+          return;
+        }
+        if (payload.type === 'session.output_transcript.delta') {
+          this.outputTranscript = `${this.outputTranscript}${payload.delta ?? ''}`.trim();
+          if (this.outputTranscript) {
+            callbacks.onTranslationInterim?.({ text: this.outputTranscript });
+          }
+          return;
+        }
+        if (payload.type === 'session.closed') {
+          this.emitFinal(callbacks);
+          this.closed = true;
+          this.ws.close();
+        }
+      } catch (err) {
+        callbacks.onError(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+    ws.on('close', () => {
+      if (!this.closed) callbacks.onError(new Error('OpenAI Realtime translation disconnected.'));
+    });
+    ws.on('error', () => {
+      callbacks.onError(new Error('OpenAI Realtime translation connection failed.'));
+    });
+  }
+
+  static async create(
+    config: LiveSttProviderConfig,
+    callbacks: LiveSttCallbacks,
+  ): Promise<OpenAiRealtimeTranslationSession> {
+    const model = config.openaiLiveTranslationModel || DEFAULT_OPENAI_LIVE_TRANSLATION_MODEL;
+    const ws = openAiRealtimeWebSocket(
+      `${OPENAI_TRANSLATION_URL}?model=${encodeURIComponent(model)}`,
+      config.openaiApiKey ?? '',
+    );
+    await waitForOpen(ws);
+    sendJson(ws, {
+      type: 'session.update',
+      session: {
+        audio: {
+          output: {
+            language: config.translationLanguage?.trim() || 'ko',
+          },
+        },
+      },
+    });
+    callbacks.onStatus?.('Connected to OpenAI Realtime translation.');
+    return new OpenAiRealtimeTranslationSession(ws, callbacks);
+  }
+
+  sendPcm(frame: LiveSttPcmFrame): void {
+    if (frame.channelCount !== 1) return;
+    const audio = pcmFrameToOpenAiBase64(frame);
+    if (!audio) return;
+    sendJson(this.ws, { type: 'session.input_audio_buffer.append', audio });
+  }
+
+  private emitFinal(callbacks: LiveSttCallbacks): void {
+    if (this.finalEmitted) return;
+    this.finalEmitted = true;
+    const text = this.inputTranscript.trim();
+    const translation = this.outputTranscript.trim();
+    if (text || translation) {
+      callbacks.onFinal({
+        text: text || translation,
+        translation: translation || undefined,
+      });
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    sendJson(this.ws, { type: 'session.close' });
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.emitFinal(this.callbacks);
+        this.ws.close();
+        resolve();
+      }, 2_000);
+      const done = () => {
+        clearTimeout(timer);
+        this.ws.off('close', done);
+        this.ws.off('error', done);
+        resolve();
+      };
+      this.ws.once('close', done);
+      this.ws.once('error', done);
+    });
+  }
+}
+
+class GeminiLiveSession implements LiveSttSession {
+  readonly provider = 'gemini' as const;
+  readonly kind: 'transcription' | 'translation';
+  private inputTranscript = '';
+  private outputTranscript = '';
+  private closed = false;
+
+  private constructor(
+    private readonly session: Session,
+    kind: 'transcription' | 'translation',
+    private readonly callbacks: LiveSttCallbacks,
+  ) {
+    this.kind = kind;
+  }
+
+  static async create(
+    config: LiveSttProviderConfig,
+    callbacks: LiveSttCallbacks,
+  ): Promise<GeminiLiveSession> {
+    const apiKey = config.geminiApiKey?.trim();
+    if (!apiKey) throw new Error('Gemini API key is not configured.');
+    const translate = config.translate !== false;
+    const ai = new GoogleGenAI({ apiKey });
+    const holder: { live?: GeminiLiveSession } = {};
+    const pendingMessages: LiveServerMessage[] = [];
+    const model = translate
+      ? DEFAULT_GEMINI_LIVE_TRANSLATION_MODEL
+      : DEFAULT_GEMINI_LIVE_TRANSCRIPTION_MODEL;
+    const session = await ai.live.connect({
+      model,
+      config: translate
+        ? {
+            responseModalities: [Modality.AUDIO],
+            inputAudioTranscription: {},
+            outputAudioTranscription: {},
+            translationConfig: {
+              targetLanguageCode: config.translationLanguage?.trim() || 'ko',
+              echoTargetLanguage: true,
+            },
+          }
+        : {
+            responseModalities: [Modality.AUDIO],
+            inputAudioTranscription: {},
+            systemInstruction:
+              'You are a passive live captioner. Transcribe the user audio only. Do not answer, ask questions, or generate assistant content.',
+          },
+      callbacks: {
+        onopen: () =>
+          callbacks.onStatus?.(
+            `Connected to Gemini Live ${translate ? 'translation' : 'transcription'}.`,
+          ),
+        onmessage: (message) => {
+          if (holder.live) {
+            holder.live.handleMessage(message);
+          } else {
+            pendingMessages.push(message);
+          }
+        },
+        onerror: (event) => {
+          callbacks.onError(new Error(event.message || 'Gemini Live connection failed.'));
+        },
+        onclose: () => {
+          if (!holder.live?.closed) callbacks.onError(new Error('Gemini Live disconnected.'));
+        },
+      },
+    });
+    holder.live = new GeminiLiveSession(
+      session,
+      translate ? 'translation' : 'transcription',
+      callbacks,
+    );
+    for (const message of pendingMessages) holder.live.handleMessage(message);
+    return holder.live;
+  }
+
+  sendPcm(frame: LiveSttPcmFrame): void {
+    if (frame.channelCount !== 1) return;
+    const audio = pcmFrameToGeminiBase64(frame);
+    if (!audio) return;
+    this.session.sendRealtimeInput({
+      audio: {
+        data: audio,
+        mimeType: `audio/pcm;rate=${GEMINI_PCM_RATE}`,
+      },
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.session.sendRealtimeInput({ audioStreamEnd: true });
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+    } catch {
+      // Best-effort flush before closing the websocket.
+    }
+    this.emitFinal();
+    this.session.close();
+  }
+
+  private handleMessage(message: LiveServerMessage): void {
+    const content = message.serverContent;
+    if (!content) return;
+    const inputText = content.inputTranscription?.text;
+    if (inputText) {
+      this.inputTranscript = mergeTranscriptText(this.inputTranscript, inputText);
+      this.callbacks.onInterim({ text: this.inputTranscript });
+    }
+    const outputText = this.kind === 'translation' ? content.outputTranscription?.text : undefined;
+    if (outputText) {
+      this.outputTranscript = mergeTranscriptText(this.outputTranscript, outputText);
+      this.callbacks.onTranslationInterim?.({ text: this.outputTranscript });
+    }
+    if (this.kind === 'transcription' && content.inputTranscription?.finished) {
+      this.emitFinal();
+      return;
+    }
+    if (
+      this.kind === 'translation' &&
+      (content.outputTranscription?.finished || content.turnComplete === true)
+    ) {
+      this.emitFinal();
+    }
+  }
+
+  private emitFinal(): void {
+    const text = this.inputTranscript.trim();
+    const translation = this.kind === 'translation' ? this.outputTranscript.trim() : '';
+    if (!text && !translation) return;
+    this.callbacks.onFinal({
+      text: text || translation,
+      translation: translation || undefined,
+    });
+    this.inputTranscript = '';
+    this.outputTranscript = '';
+  }
+}
+
+export async function createLiveSttSession(
+  config: LiveSttProviderConfig,
+  callbacks: LiveSttCallbacks,
+): Promise<LiveSttSession | null> {
+  const provider = resolveStreamingProvider(config);
+  if (provider === null) return null;
+  if (provider === 'gemini') return await GeminiLiveSession.create(config, callbacks);
+  if (config.translate) return await OpenAiRealtimeTranslationSession.create(config, callbacks);
+  return await OpenAiRealtimeTranscriptionSession.create(config, callbacks);
+}

--- a/src/liveSttProvider.ts
+++ b/src/liveSttProvider.ts
@@ -155,7 +155,12 @@ function closeAfterDelay(ws: WebSocket, delayMs: number): Promise<void> {
 function downsamplePcm16(input: Uint8Array, inputRate: number, outputRate: number): Uint8Array {
   if (inputRate === outputRate) return input;
   if (input.byteLength < 2) return input;
-  const source = new Int16Array(input.buffer, input.byteOffset, Math.floor(input.byteLength / 2));
+  // Int16Array views require a 2-byte-aligned offset; copy when the incoming
+  // view starts on an odd byte to avoid a RangeError.
+  const source =
+    input.byteOffset % 2 === 0
+      ? new Int16Array(input.buffer, input.byteOffset, Math.floor(input.byteLength / 2))
+      : new Int16Array(input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength));
   const ratio = inputRate / outputRate;
   const outputLength = Math.max(1, Math.floor(source.length / ratio));
   const output = new Int16Array(outputLength);
@@ -246,9 +251,11 @@ class OpenAiRealtimeTranscriptionSession implements LiveSttSession {
       }
     });
     ws.on('close', () => {
+      clearInterval(this.commitTimer);
       if (!this.closed) callbacks.onError(new Error('OpenAI Realtime transcription disconnected.'));
     });
     ws.on('error', () => {
+      clearInterval(this.commitTimer);
       callbacks.onError(new Error('OpenAI Realtime transcription connection failed.'));
     });
   }
@@ -409,22 +416,11 @@ class OpenAiRealtimeTranslationSession implements LiveSttSession {
   async close(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
-    sendJson(this.ws, { type: 'session.close' });
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        this.emitFinal(this.callbacks);
-        this.ws.close();
-        resolve();
-      }, 2_000);
-      const done = () => {
-        clearTimeout(timer);
-        this.ws.off('close', done);
-        this.ws.off('error', done);
-        resolve();
-      };
-      this.ws.once('close', done);
-      this.ws.once('error', done);
-    });
+    // OpenAI Realtime has no `session.close` client event; emit whatever
+    // translation has accumulated and close the socket directly. Sending the
+    // unsupported event only drew a server error and forced the 2s timeout.
+    this.emitFinal(this.callbacks);
+    this.ws.close();
   }
 }
 

--- a/src/liveSttProvider.ts
+++ b/src/liveSttProvider.ts
@@ -416,11 +416,26 @@ class OpenAiRealtimeTranslationSession implements LiveSttSession {
   async close(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
-    // OpenAI Realtime has no `session.close` client event; emit whatever
-    // translation has accumulated and close the socket directly. Sending the
-    // unsupported event only drew a server error and forced the 2s timeout.
-    this.emitFinal(this.callbacks);
-    this.ws.close();
+    // OpenAI Realtime translation sessions support `session.close`: it flushes
+    // pending audio, emits the remaining translated output, then replies with
+    // `session.closed`. Wait for that (or a 2s cap) before closing the socket so
+    // the final translated segment isn't dropped mid-drain.
+    sendJson(this.ws, { type: 'session.close' });
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.emitFinal(this.callbacks);
+        this.ws.close();
+        resolve();
+      }, 2_000);
+      const done = () => {
+        clearTimeout(timer);
+        this.ws.off('close', done);
+        this.ws.off('error', done);
+        resolve();
+      };
+      this.ws.once('close', done);
+      this.ws.once('error', done);
+    });
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,8 @@ import { maybeAutoSync, refreshGoogleSyncTimer } from './ipc/googleDrive';
 import { registerAllIpc } from './ipc/register';
 import { DisplayDetectorService } from './displayDetectorService';
 import { GeminiService, TranscriptionError, type TranscriptionErrorPayload } from './geminiService';
+import { LiveSessionService } from './liveSessionService';
+import type { LiveSttProviderConfig } from './liveSttProvider';
 import { MeetingDetectorService } from './meetingDetectorService';
 import { MenuBarManager } from './menuBarManager';
 import { NotionService } from './notionService';
@@ -51,9 +53,34 @@ import {
   summarizeUsage,
   type UsageSummaryResult,
 } from './services/usageTracker';
+import {
+  createOpenAiRealtimeClientConfig,
+  type OpenAiRealtimeBearer,
+} from './openAiRealtimeClient';
 import { SYSTEM_AUDIO_FORMAT, SystemAudioService } from './services/systemAudioService';
 import { SimpleAudioRecorder } from './simpleAudioRecorder';
 import { SLACK_WEBHOOK_PREFIX, SlackService, isLikelySlackWebhookUrl } from './slackService';
+
+type AppLogLevel = 'debug' | 'log' | 'info' | 'warn' | 'error';
+
+type RendererLogPayload = {
+  level?: AppLogLevel;
+  timestamp?: string;
+  url?: string;
+  args?: unknown[];
+};
+
+const APP_LOG_LEVELS = new Set<AppLogLevel>(['debug', 'log', 'info', 'warn', 'error']);
+const SENSITIVE_LOG_KEY_RE =
+  /(authorization|api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|client[-_]?secret|secret|webhook)/i;
+const originalConsole = {
+  debug: console.debug.bind(console),
+  log: console.log.bind(console),
+  info: console.info.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+} satisfies Record<AppLogLevel, (...args: unknown[]) => void>;
+let appLogDirReady = false;
 
 // Enable macOS system-audio loopback capture so getDisplayMedia({audio: 'loopback'})
 // can pull Zoom/Meet participant audio alongside the mic.
@@ -75,6 +102,100 @@ declare global {
 global.isQuitting = false;
 
 app.setPath('userData', getDataPath());
+
+function redactLogString(value: string): string {
+  return value
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/g, 'Bearer [REDACTED]')
+    .replace(/sk-[A-Za-z0-9_-]{20,}/g, 'sk-[REDACTED]');
+}
+
+function sanitizeLogValue(value: unknown, depth = 0, seen = new WeakSet<object>()): unknown {
+  if (typeof value === 'string') return redactLogString(value);
+  if (typeof value === 'number' || typeof value === 'boolean' || value == null) return value;
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'function') return `[Function ${value.name || 'anonymous'}]`;
+  if (typeof value !== 'object') return String(value);
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: redactLogString(value.message),
+      stack: value.stack ? redactLogString(value.stack) : undefined,
+    };
+  }
+
+  if (seen.has(value)) return '[Circular]';
+  if (depth >= 4) return '[MaxDepth]';
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeLogValue(item, depth + 1, seen));
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = SENSITIVE_LOG_KEY_RE.test(key)
+      ? '[REDACTED]'
+      : sanitizeLogValue(item, depth + 1, seen);
+  }
+  return out;
+}
+
+function formatLogArg(value: unknown): string {
+  const sanitized = sanitizeLogValue(value);
+  if (typeof sanitized === 'string') return sanitized;
+  try {
+    return JSON.stringify(sanitized);
+  } catch {
+    return String(sanitized);
+  }
+}
+
+function appendAppLogLine(line: string): void {
+  try {
+    const logDir = path.join(app.getPath('userData'), 'logs');
+    if (!appLogDirReady) {
+      fs.mkdirSync(logDir, { recursive: true });
+      appLogDirReady = true;
+    }
+    fs.appendFileSync(path.join(logDir, 'app.log'), `${line}\n`);
+  } catch (error) {
+    originalConsole.warn('Failed to append app log:', error);
+  }
+}
+
+function formatAppLogLine(
+  scope: 'main' | 'renderer',
+  level: AppLogLevel,
+  args: unknown[],
+  timestamp = new Date().toISOString(),
+): string {
+  return `[${timestamp}] [${scope}:${level}] ${args.map(formatLogArg).join(' ')}`;
+}
+
+function installMainConsoleLogger(): void {
+  for (const level of APP_LOG_LEVELS) {
+    console[level] = (...args: unknown[]) => {
+      originalConsole[level](...args);
+      appendAppLogLine(formatAppLogLine('main', level, args));
+    };
+  }
+}
+
+function handleRendererLog(payload: RendererLogPayload): void {
+  const level = payload.level && APP_LOG_LEVELS.has(payload.level) ? payload.level : 'log';
+  const args = Array.isArray(payload.args) ? payload.args : [];
+  const prefixArgs = payload.url ? [`url=${payload.url}`, ...args] : args;
+  const timestamp = payload.timestamp || new Date().toISOString();
+  const line = formatAppLogLine('renderer', level, prefixArgs, timestamp);
+  appendAppLogLine(line);
+  originalConsole[level](line);
+}
+
+installMainConsoleLogger();
+ipcMain.on('renderer-log', (_event, payload: RendererLogPayload) => {
+  handleRendererLog(payload);
+});
 
 let mainWindow: BrowserWindow | null = null;
 const audioRecorder = new SimpleAudioRecorder();
@@ -106,19 +227,20 @@ function formatAiCredentialsError(): string {
 function getAgentService(): AgentService | null {
   if (agentService) return agentService;
   if (!configService.hasAiAuth()) return null;
+  const codexOAuthSource = configService.getCodexOAuthSource();
   agentService = new AgentService({
     provider: configService.getAiProvider(),
     apiKey: configService.getGeminiApiKey(),
-    codexOAuth: configService.getCodexOAuth(),
-    // Only persist refreshed tokens when the credentials originated in config.json.
-    // Env-only credentials must stay ephemeral -- writing refreshed tokens to disk
-    // would leak ephemeral env creds into the persistent store.
-    onCodexOAuthUpdate: configService.hasStoredCodexOAuth()
-      ? (credentials) => {
-          configService.setCodexOAuth(credentials);
-          broadcastConfigChanged();
-        }
-      : undefined,
+    codexOAuth: codexOAuthSource?.credentials,
+    // Only persist refreshed tokens when the credentials originated in
+    // config.json. Env and Codex CLI credentials must stay external.
+    onCodexOAuthUpdate:
+      codexOAuthSource?.source === 'config'
+        ? (credentials) => {
+            configService.setCodexOAuth(credentials);
+            broadcastConfigChanged();
+          }
+        : undefined,
     codexModel: configService.getCodexModel(),
     dataPath: app.getPath('userData'),
     configService,
@@ -165,17 +287,20 @@ function trackFinalize(work: Promise<void>): void {
 
 function createGeminiService(): GeminiService | null {
   if (!configService.hasAiAuth()) return null;
+  const codexOAuthSource = configService.getCodexOAuthSource();
   return new GeminiService({
     provider: configService.getAiProvider(),
     apiKey: configService.getGeminiApiKey(),
-    codexOAuth: configService.getCodexOAuth(),
-    // See note in getAgentService(): persist refreshed tokens only for stored creds.
-    onCodexOAuthUpdate: configService.hasStoredCodexOAuth()
-      ? (credentials) => {
-          configService.setCodexOAuth(credentials);
-          broadcastConfigChanged();
-        }
-      : undefined,
+    codexOAuth: codexOAuthSource?.credentials,
+    // Persist refreshed tokens only when they came from app config. Env and
+    // Codex CLI credentials are external sources and must remain read-only here.
+    onCodexOAuthUpdate:
+      codexOAuthSource?.source === 'config'
+        ? (credentials) => {
+            configService.setCodexOAuth(credentials);
+            broadcastConfigChanged();
+          }
+        : undefined,
     knownWords: configService.getKnownWords(),
     proModel: configService.getGeminiModel(),
     flashModel: configService.getGeminiFlashModel(),
@@ -195,6 +320,43 @@ function ensureGeminiService(): GeminiService | null {
   geminiService = createGeminiService();
   return geminiService;
 }
+
+async function resolveOpenAiRealtimeBearer(
+  config: LiveSttProviderConfig,
+): Promise<OpenAiRealtimeBearer | null> {
+  if (config.provider === 'chunked' || config.provider === 'gemini') return null;
+  const openaiApiKey = config.openaiApiKey?.trim();
+  if (openaiApiKey) return { token: openaiApiKey, source: 'apiKey' };
+
+  console.warn('OpenAI Realtime requires a standard OpenAI API key; skipping Codex OAuth.');
+  return null;
+}
+
+async function createOpenAiRealtimeClientConfigForLive(config: LiveSttProviderConfig) {
+  return await createOpenAiRealtimeClientConfig(config, resolveOpenAiRealtimeBearer);
+}
+
+const liveSessionService = new LiveSessionService({
+  getDataPath: () => app.getPath('userData'),
+  ensureGeminiService,
+  getAgentService,
+  formatAiCredentialsError,
+  getLiveSttConfig: () => ({
+    provider: configService.getLiveSttProvider(),
+    openaiApiKey: configService.getOpenAiApiKey(),
+    geminiApiKey: configService.getGeminiApiKey(),
+    openaiLiveTranscriptionModel: configService.getOpenAiLiveTranscriptionModel(),
+    openaiLiveTranslationModel: configService.getOpenAiLiveTranslationModel(),
+    language: configService.getLiveSttLanguage(),
+    translationLanguage: configService.getLiveTranslationLanguage(),
+  }),
+  createRealtimeClientConfig: createOpenAiRealtimeClientConfigForLive,
+  emitEvent: (event) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('live-session-event', event);
+    }
+  },
+});
 
 function registerGlobalShortcut() {
   try {
@@ -1653,6 +1815,214 @@ ipcMain.handle('system-audio-stop', async () => {
   await systemAudioService.stop();
   return { success: true };
 });
+
+ipcMain.handle('live-session-start', async (_, opts?: { title?: string; translate?: boolean }) => {
+  try {
+    if (!configService.hasStreamingLiveSttAuth() && !configService.hasAiAuth()) {
+      return {
+        success: false,
+        error: `Live transcription auth is not configured, and fallback is unavailable: ${formatAiCredentialsError()}`,
+      };
+    }
+    const session = await liveSessionService.start({
+      title: typeof opts?.title === 'string' ? opts.title : undefined,
+      translate: opts?.translate !== false,
+    });
+    return { success: true, session };
+  } catch (error) {
+    console.error('live-session-start failed:', error);
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+});
+
+ipcMain.handle(
+  'live-session-realtime-failed',
+  async (_, opts?: { sessionId?: string; error?: string }) => {
+    try {
+      if (!opts?.sessionId) return { success: false, error: 'Missing live session id.' };
+      const session = await liveSessionService.fallbackFromRealtime({
+        sessionId: opts.sessionId,
+        error: typeof opts.error === 'string' ? opts.error : undefined,
+      });
+      return { success: true, session };
+    } catch (error) {
+      console.error('live-session-realtime-failed failed:', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+);
+
+ipcMain.handle(
+  'live-session-process-chunk',
+  async (
+    _event,
+    opts?: {
+      sessionId?: string;
+      audioData?: ArrayBuffer | Uint8Array;
+      mimeType?: string;
+      offsetMs?: number;
+      durationMs?: number;
+      translate?: boolean;
+    },
+  ) => {
+    try {
+      if (!opts?.sessionId || !opts.audioData) {
+        return { success: false, error: 'Missing live session audio payload.' };
+      }
+      const segment = await liveSessionService.processAudioChunk({
+        sessionId: opts.sessionId,
+        audioData: opts.audioData,
+        mimeType: typeof opts.mimeType === 'string' ? opts.mimeType : 'audio/webm',
+        offsetMs: Number.isFinite(opts.offsetMs) ? Number(opts.offsetMs) : 0,
+        durationMs: Number.isFinite(opts.durationMs) ? Number(opts.durationMs) : 0,
+        translate: opts.translate !== false,
+      });
+      return { success: true, segment, snapshot: liveSessionService.snapshot() };
+    } catch (error) {
+      console.error('live-session-process-chunk failed:', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+);
+
+ipcMain.on(
+  'live-session-interim',
+  (
+    _event,
+    opts?: {
+      sessionId?: string;
+      text?: string;
+      translation?: boolean;
+      offsetMs?: number;
+    },
+  ) => {
+    try {
+      if (!opts?.sessionId || typeof opts.text !== 'string') return;
+      liveSessionService.receiveInterim({
+        sessionId: opts.sessionId,
+        text: opts.text,
+        translation: opts.translation === true,
+        offsetMs: Number.isFinite(opts.offsetMs) ? Number(opts.offsetMs) : undefined,
+      });
+    } catch (error) {
+      console.error('live-session-interim failed:', error);
+    }
+  },
+);
+
+ipcMain.handle(
+  'live-session-final',
+  (
+    _event,
+    opts?: {
+      sessionId?: string;
+      text?: string;
+      offsetMs?: number;
+      durationMs?: number;
+      translation?: string;
+    },
+  ) => {
+    try {
+      if (!opts?.sessionId || typeof opts.text !== 'string') {
+        return { success: false, error: 'Missing live transcript payload.' };
+      }
+      liveSessionService.receiveFinalTranscript({
+        sessionId: opts.sessionId,
+        text: opts.text,
+        offsetMs: Number.isFinite(opts.offsetMs) ? Number(opts.offsetMs) : undefined,
+        durationMs: Number.isFinite(opts.durationMs) ? Number(opts.durationMs) : undefined,
+        translation: typeof opts.translation === 'string' ? opts.translation : undefined,
+      });
+      return { success: true };
+    } catch (error) {
+      console.error('live-session-final failed:', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+);
+
+ipcMain.on(
+  'live-session-pcm-chunk',
+  (
+    _event,
+    opts?: {
+      sessionId?: string;
+      audioData?: ArrayBuffer | Uint8Array;
+      sampleRate?: number;
+      channelCount?: number;
+      offsetMs?: number;
+      durationMs?: number;
+      sequence?: number;
+    },
+  ) => {
+    try {
+      if (!opts?.sessionId || !opts.audioData) return;
+      liveSessionService.appendPcm({
+        sessionId: opts.sessionId,
+        audioData: opts.audioData,
+        sampleRate: Number.isFinite(opts.sampleRate) ? Number(opts.sampleRate) : 48_000,
+        channelCount: Number.isFinite(opts.channelCount) ? Number(opts.channelCount) : 1,
+        offsetMs: Number.isFinite(opts.offsetMs) ? Number(opts.offsetMs) : 0,
+        durationMs: Number.isFinite(opts.durationMs) ? Number(opts.durationMs) : 0,
+        sequence: Number.isFinite(opts.sequence) ? Number(opts.sequence) : 0,
+      });
+    } catch (error) {
+      console.error('live-session-pcm-chunk failed:', error);
+    }
+  },
+);
+
+ipcMain.handle('live-session-stop', async (_, sessionId?: string) => {
+  try {
+    if (!sessionId) return { success: false, error: 'Missing live session id.' };
+    return { success: true, snapshot: await liveSessionService.stop(sessionId) };
+  } catch (error) {
+    console.error('live-session-stop failed:', error);
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+});
+
+ipcMain.handle('live-session-snapshot', async () => ({
+  success: true,
+  snapshot: liveSessionService.snapshot(),
+}));
+
+ipcMain.handle(
+  'live-session-set-translate',
+  async (_, opts?: { sessionId?: string; translate?: boolean }) => {
+    try {
+      if (!opts?.sessionId) return { success: false, error: 'Missing live session id.' };
+      return {
+        success: true,
+        snapshot: liveSessionService.setTranslate(opts.sessionId, opts.translate !== false),
+      };
+    } catch (error) {
+      console.error('live-session-set-translate failed:', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+);
+
+ipcMain.handle(
+  'live-session-ask',
+  async (
+    _event,
+    opts?: { sessionId?: string; question?: string; history?: AgentChatMessage[] },
+  ): Promise<{ success: true; result: AgentRunResult } | { success: false; error: string }> => {
+    try {
+      if (!opts?.sessionId) return { success: false, error: 'Missing live session id.' };
+      const result = await liveSessionService.ask({
+        sessionId: opts.sessionId,
+        question: opts.question ?? '',
+        history: Array.isArray(opts.history) ? opts.history : [],
+      });
+      return { success: true, result };
+    } catch (error) {
+      console.error('live-session-ask failed:', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+);
 
 // Agent chat: blocks until the agent produces a final answer. During the run the
 // main process may ask the renderer to confirm a config change via the

--- a/src/openAiRealtimeClient.test.ts
+++ b/src/openAiRealtimeClient.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  buildRealtimeClientSecretRequest,
+  createOpenAiRealtimeClientConfig,
+} from './openAiRealtimeClient';
+
+describe('openAiRealtimeClient', () => {
+  it('builds a transcription client-secret request', () => {
+    const request = buildRealtimeClientSecretRequest({
+      provider: 'openai',
+      translate: false,
+      openaiLiveTranscriptionModel: 'gpt-realtime-whisper',
+      language: 'ko',
+    });
+
+    assert.equal(request?.endpoint, 'realtime');
+    assert.equal(request?.url, 'https://api.openai.com/v1/realtime/client_secrets');
+    assert.deepEqual(request?.body, {
+      session: {
+        type: 'transcription',
+        audio: {
+          input: {
+            transcription: {
+              model: 'gpt-realtime-whisper',
+              language: 'ko',
+              delay: 'low',
+            },
+            turn_detection: null,
+          },
+        },
+      },
+    });
+  });
+
+  it('builds a translation client-secret request', () => {
+    const request = buildRealtimeClientSecretRequest({
+      provider: 'openai',
+      translate: true,
+      openaiLiveTranslationModel: 'gpt-realtime-translate',
+      translationLanguage: 'ja',
+    });
+
+    assert.equal(request?.endpoint, 'translation');
+    assert.equal(request?.url, 'https://api.openai.com/v1/realtime/translations/client_secrets');
+    assert.deepEqual(request?.body, {
+      session: {
+        model: 'gpt-realtime-translate',
+        audio: {
+          output: { language: 'ja' },
+        },
+      },
+    });
+  });
+
+  it('uses the supplied OpenAI API key to create a WebRTC client config', async () => {
+    let seenUrl = '';
+    let seenAuth = '';
+    let seenBody: unknown;
+    const result = await createOpenAiRealtimeClientConfig(
+      { provider: 'openai', translate: false },
+      async () => ({ token: 'openai-api-key', source: 'apiKey' }),
+      (async (url, init) => {
+        seenUrl = String(url);
+        const headers = new Headers(init?.headers);
+        seenAuth = headers.get('authorization') ?? '';
+        seenBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ value: 'ek_test' }), { status: 200 });
+      }) as typeof fetch,
+    );
+
+    assert.equal(seenUrl, 'https://api.openai.com/v1/realtime/client_secrets');
+    assert.equal(seenAuth, 'Bearer openai-api-key');
+    assert.equal(
+      (seenBody as { session?: { audio?: { input?: { transcription?: { model?: string } } } } })
+        .session?.audio?.input?.transcription?.model,
+      'gpt-realtime-whisper',
+    );
+    assert.deepEqual(result, {
+      transport: 'webrtc',
+      endpoint: 'realtime',
+      clientSecret: 'ek_test',
+    });
+  });
+
+  it('returns null when OpenAI live is not selected and no request should be made', async () => {
+    let called = false;
+    const result = await createOpenAiRealtimeClientConfig(
+      { provider: 'gemini', geminiApiKey: 'gemini' },
+      async () => ({ token: 'token', source: 'apiKey' }),
+      (async () => {
+        called = true;
+        return new Response('{}', { status: 200 });
+      }) as typeof fetch,
+    );
+
+    assert.equal(result, null);
+    assert.equal(called, false);
+  });
+
+  it('surfaces upstream client-secret errors', async () => {
+    await assert.rejects(
+      () =>
+        createOpenAiRealtimeClientConfig(
+          { provider: 'openai' },
+          async () => ({ token: 'token', source: 'apiKey' }),
+          (async () =>
+            new Response(JSON.stringify({ error: { message: 'quota exceeded' } }), {
+              status: 429,
+              statusText: 'Too Many Requests',
+            })) as typeof fetch,
+        ),
+      /quota exceeded/,
+    );
+  });
+});

--- a/src/openAiRealtimeClient.ts
+++ b/src/openAiRealtimeClient.ts
@@ -1,0 +1,113 @@
+import type { LiveRealtimeClientConfig } from './liveSessionService';
+import type { LiveSttProviderConfig } from './liveSttProvider';
+
+export type OpenAiRealtimeBearerSource = 'apiKey';
+
+export interface OpenAiRealtimeBearer {
+  token: string;
+  source: OpenAiRealtimeBearerSource;
+}
+
+export type OpenAiRealtimeBearerProvider = (
+  config: LiveSttProviderConfig,
+) => Promise<OpenAiRealtimeBearer | null>;
+
+type RealtimeClientSecretResponse = {
+  value?: string;
+  error?: { message?: string; code?: string };
+};
+
+export function formatRealtimeClientSecretError(
+  response: Pick<Response, 'status' | 'statusText'>,
+  payload: RealtimeClientSecretResponse | string,
+): string {
+  if (typeof payload !== 'string') {
+    const message = payload.error?.message?.trim();
+    if (message) return message;
+  }
+  if (typeof payload === 'string' && payload.trim()) return payload.trim();
+  return `${response.status} ${response.statusText}`.trim();
+}
+
+export function buildRealtimeClientSecretRequest(config: LiveSttProviderConfig): {
+  endpoint: LiveRealtimeClientConfig['endpoint'];
+  url: string;
+  body: unknown;
+} | null {
+  if (config.provider === 'chunked' || config.provider === 'gemini') return null;
+
+  const translate = config.translate !== false;
+  if (translate) {
+    return {
+      endpoint: 'translation',
+      url: 'https://api.openai.com/v1/realtime/translations/client_secrets',
+      body: {
+        session: {
+          model: config.openaiLiveTranslationModel || 'gpt-realtime-translate',
+          audio: {
+            output: { language: config.translationLanguage?.trim() || 'ko' },
+          },
+        },
+      },
+    };
+  }
+
+  return {
+    endpoint: 'realtime',
+    url: 'https://api.openai.com/v1/realtime/client_secrets',
+    body: {
+      session: {
+        type: 'transcription',
+        audio: {
+          input: {
+            transcription: {
+              model: config.openaiLiveTranscriptionModel || 'gpt-realtime-whisper',
+              ...(config.language?.trim() ? { language: config.language.trim() } : {}),
+              delay: 'low',
+            },
+            turn_detection: null,
+          },
+        },
+      },
+    },
+  };
+}
+
+export async function createOpenAiRealtimeClientConfig(
+  config: LiveSttProviderConfig,
+  getBearer: OpenAiRealtimeBearerProvider,
+  fetchImpl: typeof fetch = fetch,
+): Promise<LiveRealtimeClientConfig | null> {
+  const request = buildRealtimeClientSecretRequest(config);
+  if (!request) return null;
+
+  const bearer = await getBearer(config);
+  if (!bearer?.token.trim()) return null;
+
+  const response = await fetchImpl(request.url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${bearer.token.trim()}`,
+      'Content-Type': 'application/json',
+      'OpenAI-Safety-Identifier': 'listener-ai-local',
+    },
+    body: JSON.stringify(request.body),
+  });
+  const text = await response.text();
+  let payload: RealtimeClientSecretResponse | string = text;
+  try {
+    payload = JSON.parse(text) as RealtimeClientSecretResponse;
+  } catch {
+    // Keep raw text for the error message below.
+  }
+  if (!response.ok || typeof payload === 'string' || !payload.value) {
+    throw new Error(
+      `OpenAI Realtime client secret failed: ${formatRealtimeClientSecretError(response, payload)}`,
+    );
+  }
+  return {
+    transport: 'webrtc',
+    endpoint: request.endpoint,
+    clientSecret: payload.value,
+  };
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -4,6 +4,12 @@ import type { SyncProgressEvent } from './services/syncEngine';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   platform: process.platform,
+  logRenderer: (payload: {
+    level: 'debug' | 'log' | 'info' | 'warn' | 'error';
+    timestamp: string;
+    url: string;
+    args: unknown[];
+  }) => ipcRenderer.send('renderer-log', payload),
   startRecording: (payload: { title: string; mimeType: string }) =>
     ipcRenderer.invoke('start-recording', payload),
   sendRecordingChunk: (data: ArrayBuffer) => ipcRenderer.send('recording-chunk', data),
@@ -18,6 +24,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     geminiApiKey?: string;
     codexModel?: string;
     codexTranscriptionModel?: string;
+    liveSttProvider?: 'auto' | 'openai' | 'gemini' | 'chunked';
+    openaiApiKey?: string;
+    openaiLiveTranscriptionModel?: string;
+    openaiLiveTranslationModel?: string;
+    liveSttLanguage?: string;
+    liveTranslationLanguage?: string;
     notionApiKey?: string;
     notionDatabaseId?: string;
     autoMode?: boolean;
@@ -95,6 +107,56 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getRecordings: () => ipcRenderer.invoke('get-recordings'),
   searchTranscriptions: (opts: { query: string; fields?: string[]; limit?: number }) =>
     ipcRenderer.invoke('search-transcriptions', opts),
+  startLiveSession: (opts: { title?: string; translate?: boolean }) =>
+    ipcRenderer.invoke('live-session-start', opts),
+  handleLiveRealtimeFailure: (opts: { sessionId: string; error?: string }) =>
+    ipcRenderer.invoke('live-session-realtime-failed', opts),
+  processLiveAudioChunk: (opts: {
+    sessionId: string;
+    audioData: ArrayBuffer;
+    mimeType: string;
+    offsetMs: number;
+    durationMs: number;
+    translate?: boolean;
+  }) => ipcRenderer.invoke('live-session-process-chunk', opts),
+  sendLivePcmChunk: (opts: {
+    sessionId: string;
+    audioData: ArrayBuffer;
+    sampleRate: number;
+    channelCount: number;
+    offsetMs: number;
+    durationMs: number;
+    sequence: number;
+  }) => ipcRenderer.send('live-session-pcm-chunk', opts),
+  updateLiveSessionInterim: (opts: {
+    sessionId: string;
+    text: string;
+    translation?: boolean;
+    offsetMs?: number;
+  }) => ipcRenderer.send('live-session-interim', opts),
+  completeLiveSessionSegment: (opts: {
+    sessionId: string;
+    text: string;
+    offsetMs?: number;
+    durationMs?: number;
+    translation?: string;
+  }) => ipcRenderer.invoke('live-session-final', opts),
+  stopLiveSession: (sessionId: string) => ipcRenderer.invoke('live-session-stop', sessionId),
+  getLiveSessionSnapshot: () => ipcRenderer.invoke('live-session-snapshot'),
+  setLiveSessionTranslate: (opts: { sessionId: string; translate: boolean }) =>
+    ipcRenderer.invoke('live-session-set-translate', opts),
+  askLiveSession: (opts: {
+    sessionId: string;
+    question: string;
+    history?: Array<{
+      role: 'user' | 'model';
+      text: string;
+      piaiMessages?: unknown[];
+    }>;
+  }) => ipcRenderer.invoke('live-session-ask', opts),
+  onLiveSessionEvent: (callback: (event: unknown) => void) => {
+    ipcRenderer.on('live-session-event', (_event, payload) => callback(payload));
+  },
   agentChat: (opts: {
     question: string;
     history?: Array<{

--- a/src/services/usageTracker.test.ts
+++ b/src/services/usageTracker.test.ts
@@ -44,6 +44,15 @@ describe('computeCost', () => {
     assert.equal(roundCents(summary.usd), pricing.input!);
   });
 
+  it('prices gemini-3.5-flash when used for direct transcription', () => {
+    const pricing = MODEL_PRICING['gemini-3.5-flash'];
+    const result = computeCost('gemini-3.5-flash', 'transcription', {
+      input: 1_000_000,
+      output: 1_000_000,
+    });
+    assert.equal(roundCents(result.usd), pricing.input! + pricing.output!);
+  });
+
   it('prices gpt-4o-transcribe per audio minute, ignoring tokens', () => {
     const pricing = MODEL_PRICING['gpt-4o-transcribe'];
     // 600s = 10min; spurious `input` field must not double-bill.
@@ -52,6 +61,33 @@ describe('computeCost', () => {
       input: 1_000_000,
     });
     assert.equal(roundCents(result.usd), 10 * pricing.audioPerMinute!);
+  });
+
+  it('prices realtime models per audio minute', () => {
+    assert.equal(
+      roundCents(
+        computeCost('gpt-realtime-whisper', 'realtime', {
+          audioSeconds: 120,
+        }).usd,
+      ),
+      0.034,
+    );
+    assert.equal(
+      roundCents(
+        computeCost('gpt-realtime-translate', 'realtime', {
+          audioSeconds: 60,
+        }).usd,
+      ),
+      0.034,
+    );
+    assert.equal(
+      roundCents(
+        computeCost('gemini-3.5-live-translate-preview', 'realtime', {
+          audioSeconds: 60,
+        }).usd,
+      ),
+      0.0368,
+    );
   });
 
   it('treats thoughts tokens as output (folded by caller)', () => {

--- a/src/services/usageTracker.ts
+++ b/src/services/usageTracker.ts
@@ -28,7 +28,8 @@ import { getDataPath } from '../dataPath';
 
 /**
  * Per-model rates. Text/image/audio token rates are $ per 1M tokens.
- * `audioPerMinute` is $ per minute of audio input (STT models bill this way).
+ * `audioPerMinute` is $ per minute of audio input or realtime audio session
+ * duration for models billed by elapsed audio time.
  * `audioInput` overrides `input` when the call kind is 'transcription' and the
  * provider charges a different rate for audio tokens (gemini-2.5-flash:
  * $1.00/M for audio vs $0.30/M for text).
@@ -42,14 +43,15 @@ export interface ModelPricing {
   audioPerMinute?: number;
 }
 
-// Source: docs/model-pricing.md (verified 2026-05-13). Keep in sync.
+// Source: docs/model-pricing.md (verified 2026-06-15). Keep in sync.
 //
-// This table covers ONLY the two non-pi-ai paths. Anything reachable through
-// pi-ai's `complete()` (gemini-2.5-pro, gpt-5.x, etc.) is priced by pi-ai
-// itself -- adding it here would just create drift with the upstream table.
+// This table is consulted ONLY for non-pi-ai paths. If the same model is used
+// through pi-ai's `complete()`, the caller passes pi-ai's precomputed cost
+// instead and this table is bypassed.
 export const MODEL_PRICING: Record<string, ModelPricing> = {
-  // Gemini transcription: @google/genai SDK direct call. Audio-token rate
-  // ($1/M) overrides the text rate when kind is 'transcription'.
+  // Gemini transcription: @google/genai SDK direct call. Audio-token rates can
+  // override text rates when kind is 'transcription'.
+  'gemini-3.5-flash': { input: 1.5, output: 9.0 },
   'gemini-2.5-flash': { input: 0.3, audioInput: 1.0, output: 2.5 },
   // OpenAI STT (raw fetch to /v1/audio/transcriptions). Billed per audio
   // minute, prorated to the second.
@@ -57,9 +59,17 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   'gpt-4o-transcribe-diarize': { audioPerMinute: 0.006 },
   'gpt-4o-mini-transcribe': { audioPerMinute: 0.003 },
   'whisper-1': { audioPerMinute: 0.006 },
+  // OpenAI Realtime audio-duration pricing.
+  'gpt-realtime-whisper': { audioPerMinute: 0.017 },
+  'gpt-realtime-translate': { audioPerMinute: 0.034 },
+  // Gemini Live effective per-minute pricing from Google's audio-token rates.
+  // 3.1 Flash Live transcription uses input audio only. 3.5 Live Translate
+  // uses the documented combined input+output effective price.
+  'gemini-3.1-flash-live-preview': { audioPerMinute: 0.005 },
+  'gemini-3.5-live-translate-preview': { audioPerMinute: 0.0368 },
 };
 
-export type UsageKind = 'summary' | 'transcription' | 'agent';
+export type UsageKind = 'summary' | 'transcription' | 'agent' | 'realtime';
 
 export interface UsageTokens {
   /** Input tokens (text/image, or audio when kind=transcription). */
@@ -126,10 +136,10 @@ export function computeCost(modelId: string, kind: UsageKind, usage: UsageTokens
     return { usd: (seconds / PER_MINUTE_SECONDS) * pricing.audioPerMinute };
   }
 
-  // Token-priced model (gemini-2.5-flash today). Transcription kind uses the
-  // audio-input rate; summary/agent use the text rate. cacheRead falls back
-  // to the same input rate when no cache discount is defined (avoids silent
-  // $0 billing for cached tokens).
+  // Token-priced models. Transcription kind uses audioInput when a model has
+  // a modality-specific audio rate; summary/agent use the text rate. cacheRead
+  // falls back to the same input rate when no cache discount is defined
+  // (avoids silent $0 billing for cached tokens).
   const inputRate =
     kind === 'transcription' && typeof pricing.audioInput === 'number'
       ? pricing.audioInput


### PR DESCRIPTION
## Summary
Adds a live session panel for live captions, translated captions, and live Q&A while a meeting is being recorded. OpenAI Realtime is used only with a standard OpenAI API key; Codex OAuth stays on the Codex-backed batch/assistant path and is not treated as Realtime auth.

## Key changes
- Adds renderer live session UI for transcript, translation, provider state, warnings, and live questions.
- Taps processed recording audio as PCM for live streaming while keeping the saved MediaRecorder output path separate.
- Adds main-process live session orchestration with OpenAI Realtime client-secret/WebRTC setup, Gemini Live streaming, and 12-second chunked fallback.
- Adds settings for live provider/languages/OpenAI API key, including warning copy for Codex OAuth vs OpenAI Realtime.
- Tracks Realtime/Gemini Live usage in the monthly usage summary and adds redacted renderer/main logging.
- Reads Codex CLI OAuth credentials for Codex-backed features without persisting external tokens into app config.

## Type of change
Feature, docs, dependency update

## Testing performed
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm test` (366 tests)
- `pnpm run build`
- Manual live-session smoke was exercised locally before PR prep; final PR verification covered automated checks after simplification.

## Related issues
No issue linked.
