### PR TITLE
fix: exclude transcript quality metadata from Notion pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Listener.AI is an Electron desktop application for recording meetings and produc
 ### 4. Notion Integration (BYOK)
 - User supplies `notionApiKey` + `notionDatabaseId`; the app writes structured pages into their own database
 - Long transcripts are split to respect Notion's block-size limits
-- Page contains: title (with "by L.AI" suffix), date, summary, key points, action items, transcript, emoji icon
+- Page contains: title (with "by L.AI" suffix), date, summary, key points, action items, transcript, emoji icon; internal `transcriptQuality` metadata is excluded
 
 ### 5. Local Search
 - Full-text search over stored transcriptions (`src/searchService.ts`)

--- a/src/notionService.test.ts
+++ b/src/notionService.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { TranscriptionResult } from './geminiService';
+import { NotionService } from './notionService';
+
+describe('NotionService', () => {
+  it('keeps the full transcript but excludes internal transcript quality metadata', async () => {
+    const service = new NotionService({
+      apiKey: 'test-api-key',
+      databaseId: 'test-database-id',
+    });
+    let createInput: unknown;
+
+    (
+      service as unknown as {
+        notion: {
+          pages: {
+            create: (input: unknown) => Promise<{ id: string }>;
+          };
+        };
+      }
+    ).notion = {
+      pages: {
+        create: async (input) => {
+          createInput = input;
+          return { id: '12345678-1234-1234-1234-123456789abc' };
+        },
+      },
+    };
+
+    const result: TranscriptionResult = {
+      transcript: 'TRANSCRIPT_SENTINEL',
+      summary: 'SUMMARY_SENTINEL',
+      keyPoints: ['KEY_POINT_SENTINEL'],
+      actionItems: ['ACTION_ITEM_SENTINEL'],
+      emoji: '📝',
+      customFields: {
+        decisions: ['DECISION_SENTINEL'],
+        transcriptQuality: {
+          cleaned: true,
+          uncertainSegments: [2],
+          modelNotes: ['QUALITY_SENTINEL'],
+        },
+      },
+    };
+
+    await service.createMeetingNote('Test meeting', new Date('2026-08-10T00:00:00Z'), result);
+
+    const serializedInput = JSON.stringify(createInput);
+    assert.match(serializedInput, /SUMMARY_SENTINEL/);
+    assert.match(serializedInput, /DECISION_SENTINEL/);
+    assert.match(serializedInput, /Full Transcript/);
+    assert.match(serializedInput, /TRANSCRIPT_SENTINEL/);
+    assert.doesNotMatch(serializedInput, /Transcript Quality/);
+    assert.doesNotMatch(serializedInput, /QUALITY_SENTINEL/);
+  });
+});

--- a/src/notionService.ts
+++ b/src/notionService.ts
@@ -211,6 +211,8 @@ export class NotionService {
       // Add custom fields
       if (transcriptionResult.customFields) {
         for (const [key, value] of Object.entries(transcriptionResult.customFields)) {
+          if (key === 'transcriptQuality') continue;
+
           const label = camelToLabel(key);
 
           if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary

Prevent internal transcript quality metadata from appearing in exported Notion meeting notes while preserving the full transcript and all other custom fields.

## Key changes

- Exclude `customFields.transcriptQuality` from the Notion page payload.
- Keep the full transcript and user-facing custom fields unchanged.
- Add a regression test covering retained content and excluded quality metadata.
- Document the Notion export behavior in `CLAUDE.md`.

## Type of change

Bug fix

## Testing performed

- TypeScript compilation passed.
- Full test suite: 519 tests passed in the sandbox; the two sandbox-blocked Google OAuth cases passed in a permission-enabled rerun.
- Focused Notion regression test passed.
- `oxlint` passed on all source files.
- `oxfmt --check` passed on all source files.

## Related issues

None.